### PR TITLE
chore: auto-merge dependabot patch versions

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yaml
+++ b/.github/workflows/auto-merge-dependabot.yaml
@@ -1,17 +1,50 @@
-name: Auto merge dependabot
+name: Dependabot auto-merge
 
-on:
-  pull_request:
-    branches:
-      - master
+on: pull_request_target
+
+permissions:
+  pull-requests: write
+  contents: write
+  packages: read
 
 jobs:
-  auto-merge-dependabot:
+  dependabot:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     steps:
-      - uses: actions/checkout@v4
-        ## https://github.com/ahmadnassri/action-dependabot-auto-merge
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      ## Extract information about the dependencies being updated by a Dependabot-generated PR
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.6.0
         with:
-          target: patch
-          github-token: ${{ secrets.DEPENDABOT_TOKEN  }}
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      ## Git glone repository
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      ## NOTE: This step is only required if the repository has been configured to Require approval
+      ## Checks if update-type is patch or minor, then approve if the PR status is not approved yet.
+      ## Token with PR approval permission is required
+      - name: Approve patch and minor updates
+        if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'}}
+        run: |
+          gh pr checkout "$PR_URL"
+            if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
+          then
+            gh pr review --approve "$PR_URL"
+          else
+            echo "PR already approved.";
+          fi
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.PR_APPROVE_TOKEN}}
+
+      ## NOTE: Requirements for merge has to be configured in the Branch protection rule page.
+      ## To do so, go to repository > Settings > Branches > Edit
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{ contains(github.event.pull_request.title, 'bump')}}
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/auto-merge-dependabot.yaml
+++ b/.github/workflows/auto-merge-dependabot.yaml
@@ -14,4 +14,4 @@ jobs:
       - uses: ahmadnassri/action-dependabot-auto-merge@v2
         with:
           target: patch
-          github-token: ${{ secrets.GITHUB_TOKEN  }}
+          github-token: ${{ secrets.DEPENDABOT_TOKEN  }}

--- a/.github/workflows/auto-merge-dependabot.yaml
+++ b/.github/workflows/auto-merge-dependabot.yaml
@@ -1,0 +1,17 @@
+name: Auto merge dependabot
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  auto-merge-dependabot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        ## https://github.com/ahmadnassri/action-dependabot-auto-merge
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: patch
+          github-token: ${{ secrets.GITHUB_TOKEN  }}

--- a/.github/workflows/auto-merge-dependabot.yaml
+++ b/.github/workflows/auto-merge-dependabot.yaml
@@ -19,10 +19,6 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      ## Git glone repository
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
       ## NOTE: This step is only required if the repository has been configured to Require approval
       ## Checks if update-type is patch or minor, then approve if the PR status is not approved yet.
       ## Token with PR approval permission is required

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -198,12 +198,3 @@ jobs:
         with:
           name: cypress-videos
           path: frontend/cypress/videos/
-
-  auto-merge:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
-        with:
-          target: patch
-          github-token: ${{ secrets.GITHUB_TOKEN  }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-
       - name: Restore node_modules
         id: cached-node-modules
         uses: actions/cache@v3
@@ -199,3 +198,12 @@ jobs:
         with:
           name: cypress-videos
           path: frontend/cypress/videos/
+
+  auto-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+        with:
+          target: patch
+          github-token: ${{ secrets.GITHUB_TOKEN  }}


### PR DESCRIPTION
## Description
Added new workflow to auto merge dependabot package version bump PR when all checks pass.
Solves https://github.com/SciCatProject/scicat-backend-next/issues/762

The logic of `Dependabot auto-merge` workflow are:
1. checks if **pull request user** is _**dependabot**_
2. approve the pull request made by dependabot, if the bump is either **_minor or patch level_**. ( TOKEN with PR approval permission is required )
3. enabling auto merge, so the PR is **_only get merged after all checks passes_** (auto-merge prerequisite can be configured)

auto-merge prerequisite configuration can be done in **Settings > Branches > Edit or Add rule**

![image](https://github.com/SciCatProject/scicat-backend-next/assets/78078898/9f4c7650-b263-4cd0-9c02-3c0876bff375)







## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
