### PR TITLE
fix: updated mathJS package version && improved number check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "handlebars": "^4.7.7",
         "lodash": "^4.17.21",
         "luxon": "^3.2.1",
-        "mathjs": "^11.4.0",
+        "mathjs": "^11.11.2",
         "migrate-mongo": "^11.0.0",
         "mongoose": "^7.4.3",
         "node-fetch": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "handlebars": "^4.7.7",
     "lodash": "^4.17.21",
     "luxon": "^3.2.1",
-    "mathjs": "^11.4.0",
+    "mathjs": "^11.11.2",
     "migrate-mongo": "^11.0.0",
     "mongoose": "^7.4.3",
     "node-fetch": "^3.3.0",
@@ -124,8 +124,7 @@
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
-    "transformIgnorePatterns": [
-    ],
+    "transformIgnorePatterns": [],
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],

--- a/src/elastic-search/helpers/utils.ts
+++ b/src/elastic-search/helpers/utils.ts
@@ -10,9 +10,8 @@ export const transformKeysInObject = (obj: Record<string, unknown>) => {
   for (const [key, value] of Object.entries(obj)) {
     const newKey = transformKey(key);
 
-    const isNumberValueType = Number.isInteger(
-      (value as Record<string, unknown>)?.value,
-    );
+    const isNumberValueType =
+      typeof (value as Record<string, unknown>)?.value === "number";
     if (isNumberValueType) {
       (value as Record<string, unknown>)["value_type"] = "number";
     } else {


### PR DESCRIPTION
## Description

- Replaced `Number.isInteger `function with `typeof`
- Updated mathJS package

## Motivation

Number.isInteger does not identify number with floating points as type number



## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
