### PR TITLE
Add a security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Only the latest version is supported.
 
 ## Reporting a Vulnerability
 
-If you believe you have found a security vulnerability in Scitacean, please
+If you believe you have found a security vulnerability in SciCat, please
 - ✅ report it to us by creating a [security advisory](https://github.com/SciCatProject/scicat-backend-next/security/advisories/new).
 - ❌ do not report security vulnerabilities through public GitHub issues, discussions, or pull requests, etc.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest version is supported.
+
+## Reporting a Vulnerability
+
+If you believe you have found a security vulnerability in SciCat, please report it to us through coordinated disclosure.
+
+**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+
+Instead, please email <ADDRESS>
+
+Please include as much information as you can to help us better understand and resolve the issue.
+
+## Disclosure
+
+We use GitHub [security advisories](https://github.com/SciCatProject/scitacean/security/advisories) to disclose fixed vulnerabilities.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,13 +6,12 @@ Only the latest version is supported.
 
 ## Reporting a Vulnerability
 
-If you believe you have found a security vulnerability in SciCat, please report it to us through coordinated disclosure.
-
-**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
-
-Instead, please email <ADDRESS>
+If you believe you have found a security vulnerability in Scitacean, please
+- ✅ report it to us by creating a [security advisory](https://github.com/SciCatProject/scicat-backend-next/security/advisories/new).
+- ❌ do not report security vulnerabilities through public GitHub issues, discussions, or pull requests, etc.
 
 Please include as much information as you can to help us better understand and resolve the issue.
+We work on fixing the issues [privately](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/collaborating-in-a-temporary-private-fork-to-resolve-a-repository-security-vulnerability).
 
 ## Disclosure
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,4 +16,4 @@ Please include as much information as you can to help us better understand and r
 
 ## Disclosure
 
-We use GitHub [security advisories](https://github.com/SciCatProject/scitacean/security/advisories) to disclose fixed vulnerabilities.
+We use GitHub [security advisories](https://github.com/SciCatProject/scicat-backend-next/security/advisories) to disclose fixed vulnerabilities.


### PR DESCRIPTION
This is good practice so that users know what to do when they find a problem.

I basically copied this from Scitacean. So it may not be exactly what you want here. In particular, please 
- Let me know what email address I can insert.
- Check if the supported versions info is correct.