### PR TITLE
Removed Header Filter, Retain Only Query Parameter Filter

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -118,40 +118,6 @@ export class DatasetsController {
     private logbooksService: LogbooksService,
   ) {}
 
-  getFilters(
-    headers: Record<string, string>,
-    queryFilter: { filter?: string },
-  ) {
-    // NOTE: If both headers and query filters are present return error because we don't want to support this scenario.
-    if (queryFilter?.filter && (headers?.filter || headers?.where)) {
-      throw new HttpException(
-        {
-          status: HttpStatus.BAD_REQUEST,
-          message:
-            "Using two different types(query and headers) of filters is not supported and can result with inconsistencies",
-        },
-        HttpStatus.BAD_REQUEST,
-      );
-    } else if (queryFilter?.filter) {
-      const jsonQueryFilters: IFilters<DatasetDocument, IDatasetFields> =
-        JSON.parse(queryFilter.filter);
-
-      return jsonQueryFilters;
-    } else if (headers?.filter) {
-      const jsonHeadersFilters: IFilters<DatasetDocument, IDatasetFields> =
-        JSON.parse(headers.filter);
-
-      return jsonHeadersFilters;
-    } else if (headers?.where) {
-      const jsonHeadersWhereFilters: IFilters<DatasetDocument, IDatasetFields> =
-        JSON.parse(headers.where);
-
-      return jsonHeadersWhereFilters;
-    }
-
-    return {};
-  }
-
   updateMergedFiltersForList(
     request: Request,
     mergedFilters: IFilters<DatasetDocument, IDatasetFields>,
@@ -596,11 +562,14 @@ export class DatasetsController {
     @Headers() headers: Record<string, string>,
     @Query(new FilterPipe()) queryFilter: { filter?: string },
   ): Promise<DatasetClass[] | null> {
+    const parsedQueryFilter = queryFilter.filter
+      ? JSON.parse(queryFilter.filter)
+      : {};
     const mergedFilters = replaceLikeOperator(
-      this.updateMergedFiltersForList(
-        request,
-        this.getFilters(headers, queryFilter),
-      ) as Record<string, unknown>,
+      this.updateMergedFiltersForList(request, parsedQueryFilter) as Record<
+        string,
+        unknown
+      >,
     ) as IFilters<DatasetDocument, IDatasetFields>;
 
     // this should be implemented at database level
@@ -916,13 +885,13 @@ export class DatasetsController {
     @Headers() headers: Record<string, string>,
     @Query(new FilterPipe()) queryFilter: { filter?: string },
   ): Promise<DatasetClass | null> {
-    const user: JWTUser = request.user as JWTUser;
+    const parsedQueryFilter = JSON.parse(queryFilter.filter ?? "{}");
 
     const mergedFilters = replaceLikeOperator(
-      this.updateMergedFiltersForList(
-        request,
-        this.getFilters(headers, queryFilter),
-      ) as Record<string, unknown>,
+      this.updateMergedFiltersForList(request, parsedQueryFilter) as Record<
+        string,
+        unknown
+      >,
     ) as IFilters<DatasetDocument, IDatasetFields>;
 
     const dataset = (await this.datasetsService.findOne(
@@ -988,11 +957,12 @@ export class DatasetsController {
     @Headers() headers: Record<string, string>,
     @Query(new FilterPipe()) queryFilter: { filter?: string },
   ): Promise<{ count: number }> {
+    const parsedQueryFilter = JSON.parse(queryFilter.filter ?? "{}");
     const mergedFilters = replaceLikeOperator(
-      this.updateMergedFiltersForList(
-        request,
-        this.getFilters(headers, queryFilter),
-      ) as Record<string, unknown>,
+      this.updateMergedFiltersForList(request, parsedQueryFilter) as Record<
+        string,
+        unknown
+      >,
     ) as IFilters<DatasetDocument, IDatasetFields>;
 
     return this.datasetsService.count(mergedFilters);

--- a/src/elastic-search/configuration/datasetFieldMapping.ts
+++ b/src/elastic-search/configuration/datasetFieldMapping.ts
@@ -25,6 +25,7 @@ export const datasetMappings: MappingObject = {
   },
   pid: {
     type: "keyword",
+    ignore_above: 256,
   },
   creationTime: {
     type: "date",
@@ -39,29 +40,37 @@ export const datasetMappings: MappingObject = {
   },
   proposalId: {
     type: "keyword",
+    ignore_above: 256,
   },
   sourceFolder: {
     type: "keyword",
+    ignore_above: 256,
   },
   isPublished: {
     type: "boolean",
   },
   type: {
     type: "keyword",
+    ignore_above: 256,
   },
   keywords: {
     type: "keyword",
+    ignore_above: 256,
   },
   creationLocation: {
     type: "keyword",
+    ignore_above: 256,
   },
   ownerGroup: {
     type: "keyword",
+    ignore_above: 256,
   },
   accessGroups: {
     type: "keyword",
+    ignore_above: 256,
   },
   sharedWith: {
     type: "keyword",
+    ignore_above: 256,
   },
 };

--- a/src/users/user-identities.controller.ts
+++ b/src/users/user-identities.controller.ts
@@ -2,7 +2,6 @@ import {
   Controller,
   ForbiddenException,
   Get,
-  Headers,
   NotFoundException,
   Query,
   Req,
@@ -39,18 +38,12 @@ export class UserIdentitiesController {
     // NOTE: This now supports both headers filter and query filter.
     // There is a loopback config file where we have this as a setting on the frontend.
     // In the future if we fully migrate to the new backend we can only support query filters.
-    @Headers() headers: Record<string, string>,
     @Req() request: Request,
     @Query("filter") queryFilters?: string,
   ): Promise<UserIdentity | null> {
     const parsedQueryFilters = JSON.parse(queryFilters ?? "{}");
     let filter = {};
-    if (headers.filter) {
-      const parsedFilter = JSON.parse(headers.filter);
-      if (parsedFilter.where) {
-        filter = parsedFilter.where;
-      }
-    } else if (parsedQueryFilters.where) {
+    if (parsedQueryFilters.where) {
       filter = parsedQueryFilters.where;
     }
 
@@ -93,17 +86,11 @@ export class UserIdentitiesController {
     // NOTE: This now supports both headers filter and query filter.
     // There is a loopback config file where we have this as a setting on the frontend.
     // In the future if we fully migrate to the new backend we can only support query filters.
-    @Headers() headers: Record<string, string>,
     @Query("filter") queryFilters?: string,
   ): Promise<boolean | null> {
     const parsedQueryFilters = JSON.parse(queryFilters ?? "{}");
     let filter = {};
-    if (headers.filter) {
-      const parsedFilter = JSON.parse(headers.filter);
-      if (parsedFilter.where) {
-        filter = parsedFilter.where;
-      }
-    } else if (parsedQueryFilters.where) {
+    if (parsedQueryFilters.where) {
       filter = parsedQueryFilters.where;
     }
 


### PR DESCRIPTION
## Description

Removed header-based filters from three endpoints: datasets, policies, and user-identities controller in the received request.

## Motivation

Passing business logic through header filter increases complexity and security invulnerability 

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
