### PR TITLE
Fix: count endpoint in PublishedDataController is fixed

### DIFF
--- a/src/published-data/published-data.controller.ts
+++ b/src/published-data/published-data.controller.ts
@@ -41,7 +41,7 @@ import {
 } from "./interfaces/published-data.interface";
 import { AllowAny } from "src/auth/decorators/allow-any.decorator";
 import { RegisteredInterceptor } from "./interceptors/registered.interceptor";
-import { FilterQuery } from "mongoose";
+import { FilterQuery, QueryOptions } from "mongoose";
 import { DatasetsService } from "src/datasets/datasets.service";
 import { ProposalsService } from "src/proposals/proposals.service";
 import { AttachmentsService } from "src/attachments/attachments.service";
@@ -133,26 +133,24 @@ export class PublishedDataController {
   async count(
     @Query() filter?: { filter: string; fields: string },
   ): Promise<ICount> {
-    const jsonFilters: IPublishedDataFilters =
-      filter && filter.filter ? JSON.parse(filter.filter) : {};
-    const jsonFields: FilterQuery<PublishedDataDocument> =
-      filter && filter.fields ? JSON.parse(filter.fields) : {};
-    const whereFilters: FilterQuery<PublishedDataDocument> =
-      jsonFilters && jsonFilters.where
-        ? {
-            ...jsonFilters.where,
-            ...jsonFields,
-          }
-        : {
-            ...jsonFields,
-          };
-    const publishedDataFilters: IPublishedDataFilters = {
-      where: whereFilters,
+    const jsonFilters: IPublishedDataFilters = filter?.filter
+      ? JSON.parse(filter.filter)
+      : {};
+    const jsonFields: FilterQuery<PublishedDataDocument> = filter?.fields
+      ? JSON.parse(filter.fields)
+      : {};
+
+    const filters: FilterQuery<PublishedDataDocument> = {
+      ...jsonFilters.where,
+      ...jsonFields,
     };
-    if (jsonFilters && jsonFilters.limits) {
-      publishedDataFilters.limits = jsonFilters.limits;
-    }
-    return this.publishedDataService.count(publishedDataFilters);
+
+    const options: QueryOptions = {
+      limit: jsonFilters?.limits?.limit,
+      skip: jsonFilters?.limits?.skip,
+    };
+
+    return this.publishedDataService.countDocuments(filters, options);
   }
 
   // GET /publisheddata/formpopulate

--- a/src/published-data/published-data.service.ts
+++ b/src/published-data/published-data.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, Scope } from "@nestjs/common";
 import { REQUEST } from "@nestjs/core";
 import { Request } from "express";
 import { InjectModel } from "@nestjs/mongoose";
-import { FilterQuery, Model } from "mongoose";
+import { FilterQuery, Model, QueryOptions } from "mongoose";
 import {
   parseLimitFilters,
   addCreatedByFields,
@@ -66,8 +66,13 @@ export class PublishedDataService {
       .exec();
   }
 
-  async count(filter: FilterQuery<PublishedDataDocument>): Promise<ICount> {
-    const count = await this.publishedDataModel.count(filter).exec();
+  async countDocuments(
+    filter: FilterQuery<PublishedDataDocument>,
+    options?: QueryOptions,
+  ): Promise<ICount> {
+    const count = await this.publishedDataModel
+      .countDocuments(filter, options)
+      .exec();
     return { count };
   }
 


### PR DESCRIPTION
## Description

The previous code generated an incorrect MongoDB query for the count command, resulting in a consistently 0 result. In this update, the deprecated `count` function has been replaced with `countDocuments`. The advantage of using this function is that it includes options with `limit` and `skip` properties. Consequently, the endpoint now functions correctly based on the revised code.

## Motivation

The response for the `publishedData/count` endpoint was consistently returning 0.

## Fixes:

https://jira.esss.lu.se/browse/SWAP-3631

## Changes:

- PublishedDataController
- PublishedDataService

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
