### PR TITLE
Fixed OpenAPI Schema of HistoryClass and Dataset

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -91,6 +91,7 @@ import {
   fullQueryExampleLimits,
   replaceLikeOperator,
 } from "src/common/utils";
+import { HistoryClass } from "./schemas/history.schema";
 import { TechniqueClass } from "./schemas/technique.schema";
 import { RelationshipClass } from "./schemas/relationship.schema";
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
@@ -103,6 +104,7 @@ import configuration from "src/config/configuration";
   CreateAttachmentDto,
   CreateDerivedDatasetDto,
   CreateRawDatasetDto,
+  HistoryClass,
   TechniqueClass,
   RelationshipClass,
 )

--- a/src/datasets/schemas/dataset.schema.ts
+++ b/src/datasets/schemas/dataset.schema.ts
@@ -287,11 +287,13 @@ export class DatasetClass extends OwnableClass {
   version?: string;
 
   @ApiProperty({
-    type: HistoryClass,
+    type: "array",
+    items: { $ref: getSchemaPath(HistoryClass) },
     required: false,
+    default: [],
     description: "List of objects containing old and new values.",
   })
-  @Prop({ type: [HistorySchema], required: false })
+  @Prop({ type: [HistorySchema], required: false, default: [] })
   history?: HistoryClass[];
 
   @ApiProperty({

--- a/src/datasets/schemas/history.schema.ts
+++ b/src/datasets/schemas/history.schema.ts
@@ -14,6 +14,7 @@ export type HistoryDocument = HistoryClass & Document;
 })
 export class HistoryClass {
   @ApiProperty({
+    name: "id",
     type: String,
     required: true,
     default: uuidv4(),
@@ -26,13 +27,6 @@ export class HistoryClass {
     required: true,
     default: uuidv4(),
   })
-  /*
-  id: string;
-
-  @Prop({
-    type: String,
-  })
-  */
   _id: string;
 
   /*
@@ -60,9 +54,8 @@ export class HistoryClass {
   updatedAt: Date;
 
   @ApiProperty({
-    type: Date,
+    type: String,
     required: true,
-    default: Date.now(),
     description: "Username of the user that performed the update.",
   })
   @Prop({


### PR DESCRIPTION
## Description

Fixed OpenAPI representation of Datasets HistoryClass

## Motivation

OpenAPI schema of the Datasets HistoryClass was not mirroring its interal use.

## Fixes:

* OpenAPI schema for Dataset and HistoryClass

## Changes:

* Added HistoryClass to OpenAPI schema
* Set schema name of HistoryClass._id to id
* Changed type and default of HistoryClass.updatedBy to match actual usage
* Made Dataset.history an array of HistoryClass`s

## Tests included/Docs Updated?

This PR only includes API schema changes, no code changes.
