### PR TITLE
Use package version for OpenAPI

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ async function bootstrap() {
   const config = new DocumentBuilder()
     .setTitle("SciCat backend API")
     .setDescription("This is the API for the SciCat Backend")
-    .setVersion("4.0.0")
+    .setVersion("" + process.env.npm_package_version)
     .addBearerAuth()
     .build();
   const document = SwaggerModule.createDocument(app, config);


### PR DESCRIPTION
## Description

Uses environment variable set by node for the OpenAPI version number.

## Motivation

Keeps both version numbers in sync

## Changes:

* changed from hard coded string to environment variable