### PR TITLE
Don't fail if es is not enabled and config is missing

### DIFF
--- a/src/elastic-search/elastic-search.service.ts
+++ b/src/elastic-search/elastic-search.service.ts
@@ -65,7 +65,10 @@ export class ElasticSearchService implements OnModuleInit {
     this.defaultIndex =
       this.configService.get<string>("elasticSearch.defaultIndex") || "";
 
-    if (!this.host || !this.username || !this.password || !this.defaultIndex) {
+    if (
+      this.esEnabled &&
+      (!this.host || !this.username || !this.password || !this.defaultIndex)
+    ) {
       Logger.error(
         "Missing ENVIRONMENT variables for elastic search connection",
       );


### PR DESCRIPTION
If es is not enabled, startup fails  or logs an error as values for the related vars are still required.

