### PR TITLE
fixed errors caused by mongoose version update to 8.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "luxon": "^3.2.1",
         "mathjs": "^12.0.0",
         "migrate-mongo": "^11.0.0",
-        "mongoose": "^7.4.3",
+        "mongoose": "^8.0.3",
         "node-fetch": "^3.3.0",
         "nodemailer": "^6.7.8",
         "openid-client": "^5.1.8",
@@ -1867,7 +1867,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
       "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
-      "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -4352,11 +4351,11 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.5.0.tgz",
-      "integrity": "sha512-B+QB4YmDx9RStKv8LLSl/aVIEV3nYJc3cJNNTK2Cd1TL+7P+cNpw9mAPeCgc5K+j01Dv6sxUzcITXDx7ZU3F0w==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.2.0.tgz",
+      "integrity": "sha512-ID1cI+7bazPDyL9wYy9GaQ8gEEohWvcUl/Yf0dIdutJxnmInEEyCsb4awy/OiBfall7zBA179Pahi3vCdFze3Q==",
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer": {
@@ -7627,7 +7626,9 @@
     "node_modules/ip": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
+      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ip-regex": {
       "version": "2.1.0",
@@ -9521,8 +9522,7 @@
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
     },
     "node_modules/mensch": {
       "version": "0.3.4",
@@ -10384,32 +10384,34 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.0.tgz",
-      "integrity": "sha512-g+GCMHN1CoRUA+wb1Agv0TI4YTSiWr42B5ulkiAfLLHitGK1R+PkSAf3Lr5rPZwi/3F04LiaZEW0Kxro9Fi2TA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.2.0.tgz",
+      "integrity": "sha512-d7OSuGjGWDZ5usZPqfvb36laQ9CPhnWkAGHT61x5P95p/8nMVeH8asloMwW6GcYFeB0Vj4CB/1wOTDG2RA9BFA==",
       "dependencies": {
-        "bson": "^5.5.0",
-        "mongodb-connection-string-url": "^2.6.0",
-        "socks": "^2.7.1"
+        "@mongodb-js/saslprep": "^1.1.0",
+        "bson": "^6.2.0",
+        "mongodb-connection-string-url": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.20.1"
-      },
-      "optionalDependencies": {
-        "@mongodb-js/saslprep": "^1.1.0"
+        "node": ">=16.20.1"
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.0.0",
-        "kerberos": "^1.0.0 || ^2.0.0",
-        "mongodb-client-encryption": ">=2.3.0 <3",
-        "snappy": "^7.2.2"
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
           "optional": true
         },
         "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
           "optional": true
         },
         "kerberos": {
@@ -10419,6 +10421,9 @@
           "optional": true
         },
         "snappy": {
+          "optional": true
+        },
+        "socks": {
           "optional": true
         }
       }
@@ -10464,20 +10469,20 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.6.3.tgz",
-      "integrity": "sha512-moYP2qWCOdWRDeBxqB/zYwQmQnTBsF5DoolX5uPyI218BkiA1ujGY27P0NTd4oWIX+LLkZPw0LDzlc/7oh1plg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.0.3.tgz",
+      "integrity": "sha512-LJRT0yP4TW14HT4r2RkxqyvoTylMSzWpl5QOeVHTnRggCLQSpkoBdgbUtORFq/mSL2o9cLCPJz+6uzFj25qbHw==",
       "dependencies": {
-        "bson": "^5.5.0",
+        "bson": "^6.2.0",
         "kareem": "2.5.1",
-        "mongodb": "5.9.0",
+        "mongodb": "6.2.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
         "sift": "16.0.1"
       },
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=16.20.1"
       },
       "funding": {
         "type": "opencollective",
@@ -12441,6 +12446,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -12450,6 +12457,8 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
       "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -12491,7 +12500,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "luxon": "^3.2.1",
     "mathjs": "^12.0.0",
     "migrate-mongo": "^11.0.0",
-    "mongoose": "^7.4.3",
+    "mongoose": "^8.0.3",
     "node-fetch": "^3.3.0",
     "nodemailer": "^6.7.8",
     "openid-client": "^5.1.8",
@@ -71,9 +71,9 @@
     "uuid": "^9.0.0"
   },
   "overrides": {
-   "pac-resolver": {
+    "pac-resolver": {
       "degenerator": "~5"
-   }	   
+    }
   },
   "devDependencies": {
     "@faker-js/faker": "^8.0.1",

--- a/src/attachments/attachments.service.ts
+++ b/src/attachments/attachments.service.ts
@@ -51,9 +51,9 @@ export class AttachmentsService {
       .exec();
   }
 
-  async findOneAndRemove(
+  async findOneAndDelete(
     filter: FilterQuery<AttachmentDocument>,
   ): Promise<unknown> {
-    return this.attachmentModel.findOneAndRemove(filter).exec();
+    return this.attachmentModel.findOneAndDelete(filter).exec();
   }
 }

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -250,14 +250,14 @@ export const parseLimitFilters = (
 ): {
   limit: number;
   skip: number;
-  sort: { [key: string]: "asc" | "desc" } | string;
+  sort?: { [key: string]: "asc" | "desc" } | string;
 } => {
   if (!limits) {
-    return { limit: 100, skip: 0, sort: "" };
+    return { limit: 100, skip: 0 };
   }
   const limit = limits.limit ? limits.limit : 100;
   const skip = limits.skip ? limits.skip : 0;
-  let sort: { [key: string]: "asc" | "desc" } | string = "";
+  let sort;
   if (limits.order) {
     const [field, direction] = limits.order.split(":");
     if (direction === "asc" || direction === "desc") {
@@ -275,7 +275,7 @@ export const parseLimitFiltersForPipeline = (
   if (!limits) {
     pipelineStages.push({ $skip: 0 }, { $limit: 100 });
   } else {
-    const { limit = 100, skip = 0, order } = limits;
+    const { limit = 100, skip = 0, order = null } = limits;
 
     pipelineStages.push({ $skip: skip }, { $limit: limit });
 
@@ -356,12 +356,7 @@ export const createNewFacetPipelineStage = (
 };
 
 export const schemaTypeOf = <T>(
-  model: Model<
-    T,
-    Record<string, never>,
-    Record<string, never>,
-    Record<string, never>
-  >,
+  model: Model<T>,
   key: string,
   value: unknown = null,
 ): string => {
@@ -388,12 +383,7 @@ export const schemaTypeOf = <T>(
 };
 
 export const searchExpression = <T>(
-  model: Model<
-    T,
-    Record<string, never>,
-    Record<string, never>,
-    Record<string, never>
-  >,
+  model: Model<T>,
   fieldName: string,
   value: unknown,
 ): unknown => {
@@ -434,12 +424,7 @@ export const searchExpression = <T>(
 };
 
 export const createFullqueryFilter = <T>(
-  model: Model<
-    T,
-    Record<string, never>,
-    Record<string, never>,
-    Record<string, never>
-  >,
+  model: Model<T>,
   idField: keyof T,
   fields: FilterQuery<T> = {},
 ): FilterQuery<T> => {

--- a/src/datablocks/datablocks.service.ts
+++ b/src/datablocks/datablocks.service.ts
@@ -52,6 +52,6 @@ export class DatablocksService {
   }
 
   async remove(filter: FilterQuery<DatablockDocument>): Promise<unknown> {
-    return this.datablockModel.findOneAndRemove(filter).exec();
+    return this.datablockModel.findOneAndDelete(filter).exec();
   }
 }

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -1534,7 +1534,7 @@ export class DatasetsController {
       Action.DatasetAttachmentDelete,
     );
 
-    return this.attachmentsService.findOneAndRemove({
+    return this.attachmentsService.findOneAndDelete({
       _id: aid,
       pid,
     });

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -125,8 +125,6 @@ export class DatasetsService {
         modifiers.sort,
       );
 
-      console.log("es-filter", whereClause);
-
       datasets = await this.datasetModel
         .find({ _id: { $in: esResult.data } })
         .sort(modifiers.sort)

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -125,6 +125,8 @@ export class DatasetsService {
         modifiers.sort,
       );
 
+      console.log("es-filter", whereClause);
+
       datasets = await this.datasetModel
         .find({ _id: { $in: esResult.data } })
         .sort(modifiers.sort)
@@ -199,7 +201,7 @@ export class DatasetsService {
       );
       count = totalCount;
     } else {
-      count = await this.datasetModel.count(whereFilter).exec();
+      count = await this.datasetModel.countDocuments(whereFilter).exec();
     }
 
     return { count };
@@ -300,7 +302,7 @@ export class DatasetsService {
     if (this.ESClient) {
       await this.ESClient.deleteDocument(id);
     }
-    return await this.datasetModel.findOneAndRemove({ pid: id });
+    return await this.datasetModel.findOneAndDelete({ pid: id });
   }
   // GET datasets without _id which is used for elastic search data synchronization
   async getDatasetsWithoutId() {

--- a/src/instruments/instruments.service.ts
+++ b/src/instruments/instruments.service.ts
@@ -56,6 +56,6 @@ export class InstrumentsService {
   }
 
   async remove(filter: FilterQuery<InstrumentDocument>): Promise<unknown> {
-    return this.instrumentModel.findOneAndRemove(filter).exec();
+    return this.instrumentModel.findOneAndDelete(filter).exec();
   }
 }

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -94,7 +94,7 @@ export class JobsService {
   }
 
   async remove(filter: FilterQuery<JobDocument>): Promise<unknown> {
-    return this.jobModel.findOneAndRemove(filter).exec();
+    return this.jobModel.findOneAndDelete(filter).exec();
   }
 
   @OnEvent("jobCreated")

--- a/src/origdatablocks/origdatablocks.service.ts
+++ b/src/origdatablocks/origdatablocks.service.ts
@@ -160,6 +160,6 @@ export class OrigDatablocksService {
   }
 
   async remove(filter: FilterQuery<OrigDatablockDocument>): Promise<unknown> {
-    return this.origDatablockModel.findOneAndRemove(filter).exec();
+    return this.origDatablockModel.findOneAndDelete(filter).exec();
   }
 }

--- a/src/policies/policies.service.ts
+++ b/src/policies/policies.service.ts
@@ -122,7 +122,7 @@ export class PoliciesService implements OnModuleInit {
   }
 
   async count(where: FilterQuery<PolicyDocument>): Promise<{ count: number }> {
-    const count = await this.policyModel.count(where).exec();
+    const count = await this.policyModel.countDocuments(where).exec();
     return { count };
   }
 
@@ -143,7 +143,7 @@ export class PoliciesService implements OnModuleInit {
   }
 
   async remove(filter: FilterQuery<PolicyDocument>): Promise<unknown> {
-    return this.policyModel.findOneAndRemove(filter).exec();
+    return this.policyModel.findOneAndDelete(filter).exec();
   }
 
   async updateWhere(ownerGroupList: string, data: UpdatePolicyDto) {

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -794,7 +794,7 @@ export class ProposalsController {
       proposalId,
       Action.ProposalsAttachmentDelete,
     );
-    return this.attachmentsService.findOneAndRemove({
+    return this.attachmentsService.findOneAndDelete({
       _id: attachmentId,
       proposalId: proposalId,
     });

--- a/src/proposals/proposals.service.ts
+++ b/src/proposals/proposals.service.ts
@@ -109,6 +109,6 @@ export class ProposalsService {
   }
 
   async remove(filter: FilterQuery<ProposalDocument>): Promise<unknown> {
-    return this.proposalModel.findOneAndRemove(filter).exec();
+    return this.proposalModel.findOneAndDelete(filter).exec();
   }
 }

--- a/src/published-data/published-data.service.ts
+++ b/src/published-data/published-data.service.ts
@@ -99,6 +99,6 @@ export class PublishedDataService {
   }
 
   async remove(filter: FilterQuery<PublishedDataDocument>): Promise<unknown> {
-    return this.publishedDataModel.findOneAndRemove(filter).exec();
+    return this.publishedDataModel.findOneAndDelete(filter).exec();
   }
 }

--- a/src/samples/samples.controller.ts
+++ b/src/samples/samples.controller.ts
@@ -783,7 +783,7 @@ export class SamplesController {
       sampleId,
       Action.SamplesAttachmentDelete,
     );
-    return this.attachmentsService.findOneAndRemove({
+    return this.attachmentsService.findOneAndDelete({
       _id: attachmentId,
       sampleId: sampleId,
     });

--- a/src/samples/samples.service.ts
+++ b/src/samples/samples.service.ts
@@ -133,6 +133,6 @@ export class SamplesService {
   }
 
   async remove(filter: FilterQuery<SampleDocument>): Promise<unknown> {
-    return this.sampleModel.findOneAndRemove(filter).exec();
+    return this.sampleModel.findOneAndDelete(filter).exec();
   }
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -239,7 +239,7 @@ export class UsersController {
       [Action.UserUpdateAny, Action.UserUpdateOwn],
       id,
     );
-    return this.usersService.findOneAndRemoveUserSettings(id);
+    return this.usersService.findOneAndDeleteUserSettings(id);
   }
 
   @UseGuards(AuthenticatedPoliciesGuard)

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -272,8 +272,8 @@ export class UsersService implements OnModuleInit {
       .exec();
   }
 
-  async findOneAndRemoveUserSettings(userId: string): Promise<unknown> {
-    return this.userSettingsModel.findOneAndRemove({ userId }).exec();
+  async findOneAndDeleteUserSettings(userId: string): Promise<unknown> {
+    return this.userSettingsModel.findOneAndDelete({ userId }).exec();
   }
 
   async createUserJWT(


### PR DESCRIPTION
## Description

With newer mongoose update, couple of methods are deprecated. This commit aims to replace the depcreated methods.  


## Motivation

Adapted our application for the latest Mongoose update by replacing deprecated methods and fixing test failures.

## Changes
- Replaced `findOneAndRemove` with `findOneAndDelete` 
- Replaced `count` with `countDocument`
- Replaced generic types model from `model: Model<T, Record<string,never>,Record<string,never>,Record<string,never>>`to `model: Model<T>`

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
