### PR TITLE
Make `emailVerified` and `realm` optional in ReturnedUserDto #998

### DIFF
--- a/src/users/dto/returned-user.dto.ts
+++ b/src/users/dto/returned-user.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { IsOptional } from "class-validator";
 
 export class ReturnedUserDto {
   @ApiProperty({
@@ -18,13 +19,17 @@ export class ReturnedUserDto {
 
   @ApiProperty({
     description: "Email has been verified",
+    required: false,
   })
-  readonly emailVerified: boolean;
+  @IsOptional()
+  readonly emailVerified?: boolean;
 
   @ApiProperty({
     description: "Where the info of this user are stored",
+    required: false,
   })
-  readonly realm: string;
+  @IsOptional()
+  readonly realm?: string;
 
   @ApiProperty({
     description: "Strategy used to authenticate this user",


### PR DESCRIPTION
## Description

See Issue #998 

## Motivation

OpenAPI does not quite reflect server behaviour.

## Fixes:

* Auto-generated clients throwing errors when trying to log in because `emailVerified` and `realm` were not included in the server response

## Changes:

* Made `emailVerified` and `realm` optional in the OpenAPI description
