### PR TITLE
policy e2e test fail fix

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -253,11 +253,11 @@ export const parseLimitFilters = (
   sort?: { [key: string]: "asc" | "desc" } | string;
 } => {
   if (!limits) {
-    return { limit: 100, skip: 0 };
+    return { limit: 100, skip: 0, sort: {} };
   }
   const limit = limits.limit ? limits.limit : 100;
   const skip = limits.skip ? limits.skip : 0;
-  let sort;
+  let sort = {};
   if (limits.order) {
     const [field, direction] = limits.order.split(":");
     if (direction === "asc" || direction === "desc") {

--- a/src/elastic-search/elastic-search.service.ts
+++ b/src/elastic-search/elastic-search.service.ts
@@ -266,8 +266,8 @@ export class ElasticSearchService implements OnModuleInit {
     const defaultMinScore = searchParam.text ? 1 : 0;
 
     try {
+      const isSortEmpty = !sort || JSON.stringify(sort) === "{}";
       const searchQuery = this.searchService.buildSearchQuery(searchParam);
-
       const searchOptions = {
         track_scores: true,
         sort: [{ _score: { order: "desc" } }],
@@ -279,7 +279,7 @@ export class ElasticSearchService implements OnModuleInit {
         _source: [""],
       } as SearchRequest;
 
-      if (sort) {
+      if (!isSortEmpty) {
         const sortField = Object.keys(sort)[0];
         const sortDirection = Object.values(sort)[0];
 

--- a/src/policies/policies.service.ts
+++ b/src/policies/policies.service.ts
@@ -17,7 +17,11 @@ import { Request } from "express";
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
 import { UsersService } from "src/users/users.service";
 import { IPolicyFilter } from "./interfaces/policy-filters.interface";
-import { addCreatedByFields, addUpdatedByField } from "src/common/utils";
+import {
+  addCreatedByFields,
+  addUpdatedByField,
+  parseLimitFilters,
+} from "src/common/utils";
 import { REQUEST } from "@nestjs/core";
 
 @Injectable()
@@ -100,19 +104,14 @@ export class PoliciesService implements OnModuleInit {
 
   async findAll(filter: IPolicyFilter): Promise<Policy[]> {
     const whereFilter: FilterQuery<PolicyDocument> = filter.where ?? {};
-    let limit = 100;
-    let skip = 0;
-    let sort = {};
-    if (filter.limit) {
-      limit = filter.limit;
-    }
-    if (filter.skip) {
-      skip = filter.skip;
-    }
-    if (filter.order) {
-      const [field, direction] = filter.order.split(":");
-      sort = { [field]: direction };
-    }
+
+    const limits = {
+      limit: filter.limit as number,
+      skip: filter.skip as number,
+      order: filter.order as string,
+    };
+    const { limit, skip, sort } = parseLimitFilters(limits);
+
     return this.policyModel
       .find(whereFilter)
       .limit(limit)


### PR DESCRIPTION
## Description

- Refactored policies findAll endpoint filter transformation to adapt parseLimitFilters utility function.
- skip sort in elasticsearch query if the sort object is empty

## Motivation

deficient sort filter logic causing e2e and API test fail.

## Fixes:

* Items added

## Changes:

* changes made

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
