### PR TITLE
Update mongoose to 8.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "luxon": "^3.2.1",
         "mathjs": "^12.0.0",
         "migrate-mongo": "^11.0.0",
-        "mongoose": "^8.0.3",
+        "mongoose": "^8.0.4",
         "node-fetch": "^3.3.0",
         "nodemailer": "^6.7.8",
         "openid-client": "^5.1.8",
@@ -3054,16 +3054,15 @@
       "integrity": "sha512-c/hzNDBh7eRF+KbCf+OoZxKbnkpaK/cKp9iLQWqB7muXtM+MtL9SUUH8vCFcLn6dH1Qm05jiexK0ofWY7TfOhQ=="
     },
     "node_modules/@types/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="
     },
     "node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.4.tgz",
+      "integrity": "sha512-lXCmTWSHJvf0TRSO58nm978b8HJ/EdsSsEKLd3ODHFjo+3VGAyyTp4v50nWvwtzBxSMQrVOK7tcuN0zGPLICMw==",
       "dependencies": {
-        "@types/node": "*",
         "@types/webidl-conversions": "*"
       }
     },
@@ -4734,9 +4733,9 @@
       ]
     },
     "node_modules/chai": {
-      "version": "4.3.10",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-      "integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+      "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
@@ -7237,19 +7236,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -9559,12 +9545,12 @@
       }
     },
     "node_modules/loupe": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
       "dev": true,
       "dependencies": {
-        "get-func-name": "^2.0.0"
+        "get-func-name": "^2.0.1"
       }
     },
     "node_modules/lower-case": {
@@ -10612,13 +10598,13 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.2.0.tgz",
-      "integrity": "sha512-d7OSuGjGWDZ5usZPqfvb36laQ9CPhnWkAGHT61x5P95p/8nMVeH8asloMwW6GcYFeB0Vj4CB/1wOTDG2RA9BFA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.3.0.tgz",
+      "integrity": "sha512-tt0KuGjGtLUhLoU263+xvQmPHEGTw5LbcNC73EoFRYgSHwZt5tsoJC110hDyO1kjQzpgNrpdcSza9PknWN4LrA==",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.0",
         "bson": "^6.2.0",
-        "mongodb-connection-string-url": "^2.6.0"
+        "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
         "node": ">=16.20.1"
@@ -10657,23 +10643,23 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.0.tgz",
+      "integrity": "sha512-t1Vf+m1I5hC2M5RJx/7AtxgABy1cZmIPQRMXw+gEIPn/cZNF3Oiy+l0UIypUwVB5trcWHq3crg2g3uAR9aAwsQ==",
       "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
       }
     },
     "node_modules/mongodb-connection-string-url/node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
       "dependencies": {
-        "punycode": "^2.1.1"
+        "punycode": "^2.3.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/mongodb-connection-string-url/node_modules/webidl-conversions": {
@@ -10685,25 +10671,25 @@
       }
     },
     "node_modules/mongodb-connection-string-url/node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
       "dependencies": {
-        "tr46": "^3.0.0",
+        "tr46": "^4.1.1",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       }
     },
     "node_modules/mongoose": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.0.3.tgz",
-      "integrity": "sha512-LJRT0yP4TW14HT4r2RkxqyvoTylMSzWpl5QOeVHTnRggCLQSpkoBdgbUtORFq/mSL2o9cLCPJz+6uzFj25qbHw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.1.0.tgz",
+      "integrity": "sha512-kOA4Xnq2goqNpN9EmYElGNWfxA9H80fxcr7UdJKWi3UMflza0R7wpTihCpM67dE/0MNFljoa0sjQtlXVkkySAQ==",
       "dependencies": {
         "bson": "^6.2.0",
         "kareem": "2.5.1",
-        "mongodb": "6.2.0",
+        "mongodb": "6.3.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "luxon": "^3.2.1",
     "mathjs": "^12.0.0",
     "migrate-mongo": "^11.0.0",
-    "mongoose": "^8.0.3",
+    "mongoose": "^8.0.4",
     "node-fetch": "^3.3.0",
     "nodemailer": "^6.7.8",
     "openid-client": "^5.1.8",

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -171,9 +171,7 @@ export class DatasetsService {
     filter: FilterQuery<DatasetDocument>,
     updateDatasetDto: Record<string, unknown>,
   ): Promise<unknown> {
-    return this.datasetModel
-      .updateMany(filter, updateDatasetDto, { new: true })
-      .exec();
+    return this.datasetModel.updateMany(filter, updateDatasetDto, {}).exec();
   }
 
   async findOne(

--- a/src/policies/policies.service.ts
+++ b/src/policies/policies.service.ts
@@ -183,7 +183,7 @@ export class PoliciesService implements OnModuleInit {
           try {
             // allow all functional users
             return await this.policyModel
-              .updateOne({ ownerGroup }, data, { new: true })
+              .updateOne({ ownerGroup }, data, {})
               .exec();
           } catch (error) {
             throw new InternalServerErrorException();
@@ -202,7 +202,7 @@ export class PoliciesService implements OnModuleInit {
 
           try {
             return await this.policyModel
-              .updateOne({ ownerGroup }, data, { new: true })
+              .updateOne({ ownerGroup }, data, {})
               .exec();
           } catch (error) {
             throw new InternalServerErrorException();

--- a/src/published-data/published-data.service.ts
+++ b/src/published-data/published-data.service.ts
@@ -68,7 +68,7 @@ export class PublishedDataService {
 
   async countDocuments(
     filter: FilterQuery<PublishedDataDocument>,
-    options?: QueryOptions,
+    options?: object,
   ): Promise<ICount> {
     const count = await this.publishedDataModel
       .countDocuments(filter, options)


### PR DESCRIPTION
Upgrade mongoose to 8.0.4 and fix  resulting problems

 - Model.updateOne/Many does not have a new option  (this option is only available on findAndReplace)
 - CountOptions is not available as a type  and not compatible with QueryOptions ( may be an upstream error)