### PR TITLE
latest official mongo

### DIFF
--- a/CI/ESS/docker-compose.api.yaml
+++ b/CI/ESS/docker-compose.api.yaml
@@ -1,6 +1,6 @@
 services:
   mongodb:
-    image: bitnami/mongodb:4.2
+    image: mongo:latest
     volumes:
       - mongodb_data:/bitnami
     ports:

--- a/CI/ESS/docker-compose.gitlab.yaml
+++ b/CI/ESS/docker-compose.gitlab.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
     mongodb:
-        image: "bitnami/mongodb:4.0"
+        image: mongo:latest
     scicat-backend:
         build:
             context: .

--- a/CI/ESS/docker-compose.yaml
+++ b/CI/ESS/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   mongodb:
-    image: 'bitnami/mongodb:latest'
+    image: mongo:latest
     labels:
       kompose.service.type: nodeport
     ports:


### PR DESCRIPTION
## Description
This PR changes the docker compose file used in the API tests to use the latest official mongodb version

## Motivation
As indicated in issue #1019, current api tests use bitnami mongodb v4.2. This is an old version of mongo, it is not the official one and it does not run on the latest apple chips.

## Changes:
* CI/ESS/docker-compose.api.yml
