### PR TITLE
Allow `PROPOSAL_GROUPS` members to update proposal

### DIFF
--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -10,6 +10,7 @@ import { Injectable } from "@nestjs/common";
 import { Attachment } from "src/attachments/schemas/attachment.schema";
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
 // import { Role } from "src/auth/role.enum";
+import configuration from "src/config/configuration";
 import { Datablock } from "src/datablocks/schemas/datablock.schema";
 import { DatasetClass } from "src/datasets/schemas/dataset.schema";
 import { ElasticSearchActions } from "src/elastic-search/dto";
@@ -25,7 +26,6 @@ import { UserIdentity } from "src/users/schemas/user-identity.schema";
 import { UserSettings } from "src/users/schemas/user-settings.schema";
 import { User } from "src/users/schemas/user.schema";
 import { Action } from "./action.enum";
-import configuration from "src/config/configuration";
 
 type Subjects =
   | string
@@ -981,6 +981,7 @@ export class CaslAbilityFactory {
       // -------------------------------------
       // data instance authorization
       can(Action.ProposalsCreateAny, ProposalClass);
+      can(Action.ProposalsUpdateAny, ProposalClass);
       can(Action.ProposalsReadManyAccess, ProposalClass);
       can(Action.ProposalsReadOneAccess, ProposalClass, {
         ownerGroup: { $in: user.currentGroups },


### PR DESCRIPTION
## Description

Allow `PROPOSAL_GROUPS` members to update proposal.

## Motivation

In the proposal ingestion workflow, we first ingest the proposal and each time a measurement period is scheduled/removed, it's updated in SciCat.

I'll update the corresponding documentation before merging if the patch is accepted.

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?