### PR TITLE
Updated swagger description of createdAt and updateAt fields

### DIFF
--- a/src/common/schemas/queryable.schema.ts
+++ b/src/common/schemas/queryable.schema.ts
@@ -32,7 +32,7 @@ export class QueryableClass {
   @ApiProperty({
     type: Date,
     description:
-      "Date and time when this record was created. This property is added and maintained by mongoose.",
+      "Date and time when this record was created. This field is managed by mongoose with through the timestamp settings. The field should be a string containing a date in ISO 8601 format (2024-02-27T12:26:57.313Z)",
   })
   @Prop({
     type: Date,
@@ -42,7 +42,7 @@ export class QueryableClass {
   @ApiProperty({
     type: Date,
     description:
-      "Date and time when this record was updated last. This property is added and maintained by mongoose.",
+      "Date and time when this record was updated last. This field is managed by mongoose with through the timestamp settings. The field should be a string containing a date in ISO 8601 format (2024-02-27T12:26:57.313Z)",
   })
   @Prop({
     type: Date,

--- a/src/datasets/schemas/history.schema.ts
+++ b/src/datasets/schemas/history.schema.ts
@@ -44,7 +44,8 @@ export class HistoryClass {
     type: Date,
     required: true,
     default: Date.now(),
-    description: "Time when the update was performed. This field is managed by mongoose with through the timestamp settings. The field should be a string containing a date in ISO 8601 format (2024-02-27T12:26:57.313Z)",
+    description:
+      "Time when the update was performed. This field is managed by mongoose with through the timestamp settings. The field should be a string containing a date in ISO 8601 format (2024-02-27T12:26:57.313Z)",
   })
   @Prop({
     type: Date,

--- a/src/datasets/schemas/history.schema.ts
+++ b/src/datasets/schemas/history.schema.ts
@@ -44,7 +44,7 @@ export class HistoryClass {
     type: Date,
     required: true,
     default: Date.now(),
-    description: "Time when the update was performed.",
+    description: "Time when the update was performed. This field is managed by mongoose with through the timestamp settings. The field should be a string containing a date in ISO 8601 format (2024-02-27T12:26:57.313Z)",
   })
   @Prop({
     type: Date,


### PR DESCRIPTION
This PR updates the documentation regarding the fields _createdAt_ and _updatedAt_.
In swagger, the description associated with the fields states clearly that this fields are managed by Mongoose and which is the expected format.

This should solve #1055 