### PR TITLE
fix: 400 error on the datasets page when changing the number of items per page

### DIFF
--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -31,10 +31,7 @@ import { Request } from "express";
 import { JWTUser } from "../auth/interfaces/jwt-user.interface";
 import { UserSettings } from "./schemas/user-settings.schema";
 import { CreateUserSettingsDto } from "./dto/create-user-settings.dto";
-import {
-  PartialUpdateUserSettingsDto,
-  UpdateUserSettingsDto,
-} from "./dto/update-user-settings.dto";
+import { PartialUpdateUserSettingsDto } from "./dto/update-user-settings.dto";
 import { User } from "./schemas/user.schema";
 import { CreateUserSettingsInterceptor } from "./interceptors/create-user-settings.interceptor";
 import { AuthService } from "src/auth/auth.service";
@@ -255,7 +252,7 @@ export class UsersController {
   async updateSettings(
     @Req() request: Request,
     @Param("id") id: string,
-    @Body() updateUserSettingsDto: UpdateUserSettingsDto,
+    @Body() updateUserSettingsDto: PartialUpdateUserSettingsDto,
   ): Promise<UserSettings | null> {
     await this.checkUserAuthorization(
       request,

--- a/test/Users.js
+++ b/test/Users.js
@@ -1,8 +1,14 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
-const { TestData } = require("./TestData");
+"use strict";
 
-describe("Users: Login with functional accounts", () => {
-  it("Admin ingestor login fails with incorrect credentials", async () => {
+const { TestData } = require("./TestData");
+const utils = require("./LoginUtils");
+
+let userIdUser1 = null,
+  accessTokenUser1 = null;
+
+describe("2350: Users: Login with functional accounts", () => {
+  it("0010: Admin ingestor login fails with incorrect credentials", async () => {
     return request(appUrl)
       .post("/api/v3/Users/Login?include=user")
       .send({
@@ -15,7 +21,7 @@ describe("Users: Login with functional accounts", () => {
       });
   });
 
-  it("Login should succeed with correct credentials", async () => {
+  it("0020: Login should succeed with correct credentials", async () => {
     return request(appUrl)
       .post("/api/v3/Users/Login?include=user")
       .send({
@@ -27,6 +33,37 @@ describe("Users: Login with functional accounts", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have.property("user").and.be.instanceof(Object);
+      });
+  });
+});
+
+describe("2360: Users settings", () => {
+  beforeEach((done) => {
+    utils.getIdAndToken(
+      appUrl,
+      {
+        username: "user1",
+        password: TestData.Accounts["user1"]["password"],
+      },
+      (idVal, tokenVal) => {
+        accessTokenUser1 = tokenVal;
+        userIdUser1 = idVal;
+        done();
+      },
+    );
+  });
+
+  it("0010: Update users settings with valid value should sucess ", async () => {
+    return request(appUrl)
+      .put(`/api/v3/Users/${userIdUser1}/settings`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.SuccessfulPatchStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("userId", userIdUser1);
+        res.body.should.have.property("datasetCount");
+        res.body.should.have.property("jobCount");
       });
   });
 });


### PR DESCRIPTION
## Description
Changing the items-per-page value on the Datasets page throws a 400 Bad Request error.


## Fixes:
replace misused DTO with the correct one for updateSettings API in users controller. 


## Changes:
Added API test for the fix


## Tests included/Docs Updated?

- [x] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
