### PR TITLE
build(deps): bump mongoose version to 8.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "luxon": "^3.2.1",
         "mathjs": "^12.0.0",
         "migrate-mongo": "^11.0.0",
-        "mongoose": "^8.0.4",
+        "mongoose": "^8.3.1",
         "node-fetch": "^3.3.0",
         "nodemailer": "^6.7.8",
         "openid-client": "^5.1.8",
@@ -2008,9 +2008,9 @@
       "integrity": "sha512-9b8mPpKrfeGRuhFH5iO1iwCLeIIsV6+H1sRfxbkoGXIyQE2BTsPd9zqSqQJ+pv5sJ/hT5M1zvOFL02MnEezFug=="
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
-      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
+      "integrity": "sha512-XLNOMH66KhJzUJNwT/qlMnS4WsNDWD5ASdyaSH3EtK+F4r/CFGa3jT4GNi4mfOitGvWXtdLgQJkQjxSVrio+jA==",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -4514,9 +4514,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-6.2.0.tgz",
-      "integrity": "sha512-ID1cI+7bazPDyL9wYy9GaQ8gEEohWvcUl/Yf0dIdutJxnmInEEyCsb4awy/OiBfall7zBA179Pahi3vCdFze3Q==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.6.0.tgz",
+      "integrity": "sha512-BVINv2SgcMjL4oYbBuCQTpE3/VKOSxrOA8Cj/wQP7izSzlBGVomdm+TcUd0Pzy0ytLSSDweCKQ6X3f5veM5LQA==",
       "engines": {
         "node": ">=16.20.1"
       }
@@ -9270,9 +9270,9 @@
       }
     },
     "node_modules/kareem": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
-      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -10476,12 +10476,12 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.3.0.tgz",
-      "integrity": "sha512-tt0KuGjGtLUhLoU263+xvQmPHEGTw5LbcNC73EoFRYgSHwZt5tsoJC110hDyO1kjQzpgNrpdcSza9PknWN4LrA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.5.0.tgz",
+      "integrity": "sha512-Fozq68InT+JKABGLqctgtb8P56pRrJFkbhW0ux+x1mdHeyinor8oNzJqwLjV/t5X5nJGfTlluxfyMnOXNggIUA==",
       "dependencies": {
-        "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^6.2.0",
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.4.0",
         "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
@@ -10561,13 +10561,13 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.2.2.tgz",
-      "integrity": "sha512-6sMxe1d3k/dBjiOX4ExNTNOP0g1x0iq8eXyg+ttgIXM3HLnQ0IUyXRwVVAPFFY6O4/8uYN5dB0Ec72FrexbPpw==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.3.1.tgz",
+      "integrity": "sha512-D78C+s7QI4+pJQhs3XbOxzrHFEti4x+BDhaH94QrdV1/cmMA7fHc50LgLSXjzA/5q89TBK8DAXyf3VwDZbQJlA==",
       "dependencies": {
-        "bson": "^6.2.0",
-        "kareem": "2.5.1",
-        "mongodb": "6.3.0",
+        "bson": "^6.5.0",
+        "kareem": "2.6.3",
+        "mongodb": "6.5.0",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "luxon": "^3.2.1",
     "mathjs": "^12.0.0",
     "migrate-mongo": "^11.0.0",
-    "mongoose": "^8.0.4",
+    "mongoose": "^8.3.1",
     "node-fetch": "^3.3.0",
     "nodemailer": "^6.7.8",
     "openid-client": "^5.1.8",

--- a/src/auth/strategies/ldap.strategy.ts
+++ b/src/auth/strategies/ldap.strategy.ts
@@ -30,7 +30,7 @@ export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
     const userFilter: FilterQuery<UserDocument> = {
       $or: [
         { username: `ldap.${payload.displayName}` },
-        { username: payload.displayName },
+        { username: payload.displayName as string },
         { email: payload.mail as string },
       ],
     };

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -467,22 +467,42 @@ export const createFullqueryFilter = <T>(
       };
     } else if (key === "userGroups") {
       filterQuery["$or"]?.push({
-        ownerGroup: searchExpression<T>(model, "ownerGroup", fields[key]),
+        ownerGroup: searchExpression<T>(
+          model,
+          "ownerGroup",
+          fields[key],
+        ) as object,
       });
       filterQuery["$or"]?.push({
-        accessGroups: searchExpression<T>(model, "accessGroups", fields[key]),
+        accessGroups: searchExpression<T>(
+          model,
+          "accessGroups",
+          fields[key],
+        ) as object,
       });
     } else if (key === "ownerGroup") {
       filterQuery["$or"]?.push({
-        ownerGroup: searchExpression<T>(model, "ownerGroup", fields[key]),
+        ownerGroup: searchExpression<T>(
+          model,
+          "ownerGroup",
+          fields[key],
+        ) as object,
       });
     } else if (key === "accessGroups") {
       filterQuery["$or"]?.push({
-        accessGroups: searchExpression<T>(model, "accessGroups", fields[key]),
+        accessGroups: searchExpression<T>(
+          model,
+          "accessGroups",
+          fields[key],
+        ) as object,
       });
     } else if (key === "sharedWith") {
       filterQuery["$or"]?.push({
-        sharedWith: searchExpression<T>(model, "sharedWith", fields[key]),
+        sharedWith: searchExpression<T>(
+          model,
+          "sharedWith",
+          fields[key],
+        ) as object,
       });
     } else {
       filterQuery[key as keyof FilterQuery<T>] = searchExpression<T>(
@@ -890,7 +910,7 @@ export const replaceLikeOperator = <T>(filter: IFilters<T>): IFilters<T> => {
   if (filter.where) {
     filter.where = replaceLikeOperatorRecursive(
       filter.where as Record<string, unknown>,
-    );
+    ) as object;
   }
   return filter;
 };

--- a/src/origdatablocks/origdatablocks.controller.ts
+++ b/src/origdatablocks/origdatablocks.controller.ts
@@ -319,7 +319,15 @@ export class OrigDatablocksController {
         parsedFilters.where.userGroups = parsedFilters.where.userGroups ?? [];
         parsedFilters.where.userGroups.push(...user.currentGroups);
       } else if (canViewOwner) {
-        parsedFilters.where.ownerGroup = parsedFilters.where.ownerGroup ?? [];
+        if (!parsedFilters.where.ownerGroup) {
+          parsedFilters.where.ownerGroup = [];
+        }
+
+        parsedFilters.where.ownerGroup = Array.isArray(
+          parsedFilters.where.ownerGroup,
+        )
+          ? parsedFilters.where.ownerGroup
+          : [parsedFilters.where.ownerGroup as string];
         parsedFilters.where.ownerGroup.push(...user.currentGroups);
       }
     }


### PR DESCRIPTION
## Description
Closes the issue: https://github.com/SciCatProject/scicat-backend-next/issues/1162
Updated Mongoose from 8.0.4 to 8.3.1. Fixed type issues caused by new mongoose version bump.


## Motivation

- Keep dependencies updated for security and performance.
- Enhance type safety to prevent runtime errors.

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
