### PR TITLE
Include repository in docker image

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,6 +1,6 @@
 services:
   mongodb:
-    image: bitnami/mongodb:4.2
+    image: docker.io/bitnami/mongodb:4.2
     volumes:
       - mongodb_data:/bitnami
   backend:


### PR DESCRIPTION
Motivation:

The docker-compose image does not work under Debian systems because such systems disable automatically resolving.  This is done because it is unsafe: you might download the "wrong" image.

Modification:

Update the reference so that it includes the registry (dockerhub.io) explicitly.

Result:

Docker compose now works under Debian

## Description

Short description of the pull request

## Motivation

Background on use case, changes needed

## Fixes:

* Items added

## Changes:

* changes made

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
