### PR TITLE
changed casl to allow user to be able to admin and delete instrument

### DIFF
--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -1302,37 +1302,38 @@ export class CaslAbilityFactory {
       cannot(Action.InstrumentCreate, Instrument);
       cannot(Action.InstrumentUpdate, Instrument);
       cannot(Action.InstrumentDelete, Instrument);
-    } else if (
-      user.currentGroups.some((g) => configuration().deleteGroups.includes(g))
-    ) {
-      /*
-        / user that belongs to any of the group listed in DELETE_GROUPS
+    } else {
+      if (
+        user.currentGroups.some((g) => configuration().deleteGroups.includes(g))
+      ) {
+        /*
+         * user that belongs to any of the group listed in DELETE_GROUPS
+         */
+
+        // -------------------------------------
+        // endpoint authorization
+        can(Action.InstrumentDelete, Instrument);
+      } else {
+        cannot(Action.InstrumentDelete, Instrument);
+      }
+
+      if (
+        user.currentGroups.some((g) => configuration().adminGroups.includes(g))
+      ) {
+        /**
+        * authenticated users belonging to any of the group listed in ADMIN_GROUPS
         */
 
-      // -------------------------------------
-      // instrument
-      // -------------------------------------
-      // endpoint authorization
-      can(Action.InstrumentDelete, Instrument);
-    } else if (
-      user.currentGroups.some((g) => configuration().adminGroups.includes(g))
-    ) {
-      /**
-       * authenticated users belonging to any of the group listed in ADMIN_GROUPS
-       */
-      // -------------------------------------
-      // instrument
-      // -------------------------------------
-      // endpoint authorization
-      can(Action.InstrumentRead, Instrument);
-      can(Action.InstrumentCreate, Instrument);
-      can(Action.InstrumentUpdate, Instrument);
-      cannot(Action.InstrumentDelete, Instrument);
-    } else if (user) {
-      can(Action.InstrumentRead, Instrument);
-      cannot(Action.InstrumentCreate, Instrument);
-      cannot(Action.InstrumentUpdate, Instrument);
-      cannot(Action.InstrumentDelete, Instrument);
+        // -------------------------------------
+        // endpoint authorization
+        can(Action.InstrumentRead, Instrument);
+        can(Action.InstrumentCreate, Instrument);
+        can(Action.InstrumentUpdate, Instrument);
+      } else {
+        can(Action.InstrumentRead, Instrument);
+        cannot(Action.InstrumentCreate, Instrument);
+        cannot(Action.InstrumentUpdate, Instrument);
+      }
     }
 
     // Instrument permissions

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -1321,8 +1321,8 @@ export class CaslAbilityFactory {
         user.currentGroups.some((g) => configuration().adminGroups.includes(g))
       ) {
         /**
-        * authenticated users belonging to any of the group listed in ADMIN_GROUPS
-        */
+         * authenticated users belonging to any of the group listed in ADMIN_GROUPS
+         */
 
         // -------------------------------------
         // endpoint authorization


### PR DESCRIPTION
## Description
This PR should fix bug reported in issue #1172. Now a user can be both in the admin group and delete group and have full control over instruments.

## Motivation
We advice to restrict who can delete items, but some facilities request that admin can also delete entries.

## Changes:
* casl factory

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
