### PR TITLE
fix: update datasets fullquery to use pid instead of _id

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -845,7 +845,7 @@ export const datasetsFullQueryDescriptionFields =
   "metadataKey": "metadata", <optional>\n \
   "_id": "item id", <optional>\n \
   "userGroups": ["group1", ...], <optional>\n \
-  "sharedWith": "email", <optional>\n \
+  "sharedWith": ["email", ...], <optional>\n \
 }\n \
   </pre>';
 

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -126,7 +126,7 @@ export class DatasetsService {
       );
 
       datasets = await this.datasetModel
-        .find({ _id: { $in: esResult.data } })
+        .find({ pid: { $in: esResult.data } })
         .sort(modifiers.sort)
         .exec();
     }


### PR DESCRIPTION
## Description

The _id and pid for datasets can be different when created manually. This change will use pid as the source of truth for the dataset's fullquery.

```
    "_id" : "20.500.12269/34e117ea-9502-404f-8db1-0c1cd5f6d9d9",
    "updatedBy" : "admin",
    "createdAt" : ISODate("2023-09-05T09:51:49.954+0000"),
    "updatedAt" : ISODate("2023-09-05T09:51:49.954+0000"),
    "ownerGroup" : "262651",
    "accessGroups" : [
        "swap"
    ],
    "pid" : "20.500.12269/b140f8fd-660d-4429-af72-77b499153b16",
```

## Motivation

Background on use case, changes needed

## Fixes:

* Items added

## Changes:

* changes made

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
