### PR TITLE
fix: behavior of Elasticsearch query differs from mongoDB query

### DIFF
--- a/src/elastic-search/configuration/datasetFieldMapping.ts
+++ b/src/elastic-search/configuration/datasetFieldMapping.ts
@@ -25,9 +25,11 @@ export const datasetMappings: MappingObject = {
   },
   pid: {
     type: "keyword",
+    ignore_above: 256,
   },
   creationTime: {
     type: "date",
+    ignore_above: 256,
   },
   scientificMetadata: {
     type: "nested",
@@ -45,38 +47,49 @@ export const datasetMappings: MappingObject = {
   history: {
     type: "nested",
     dynamic: false,
+    ignore_above: 256,
   },
   proposalId: {
     type: "keyword",
+    ignore_above: 256,
   },
   sampleId: {
     type: "keyword",
+    ignore_above: 256,
   },
   sourceFolder: {
     type: "keyword",
+    ignore_above: 256,
   },
   isPublished: {
     type: "boolean",
   },
   type: {
     type: "keyword",
+    ignore_above: 256,
   },
   keywords: {
     type: "keyword",
+    ignore_above: 256,
   },
   creationLocation: {
     type: "keyword",
+    ignore_above: 256,
   },
   ownerGroup: {
     type: "keyword",
+    ignore_above: 256,
   },
   accessGroups: {
     type: "keyword",
+    ignore_above: 256,
   },
   sharedWith: {
     type: "keyword",
+    ignore_above: 256,
   },
   ownerEmail: {
     type: "keyword",
+    ignore_above: 256,
   },
 };

--- a/src/elastic-search/configuration/datasetFieldMapping.ts
+++ b/src/elastic-search/configuration/datasetFieldMapping.ts
@@ -49,6 +49,9 @@ export const datasetMappings: MappingObject = {
   proposalId: {
     type: "keyword",
   },
+  sampleId: {
+    type: "keyword",
+  },
   sourceFolder: {
     type: "keyword",
   },
@@ -71,6 +74,9 @@ export const datasetMappings: MappingObject = {
     type: "keyword",
   },
   sharedWith: {
+    type: "keyword",
+  },
+  ownerEmail: {
     type: "keyword",
   },
 };

--- a/src/elastic-search/configuration/datasetFieldMapping.ts
+++ b/src/elastic-search/configuration/datasetFieldMapping.ts
@@ -29,7 +29,6 @@ export const datasetMappings: MappingObject = {
   },
   creationTime: {
     type: "date",
-    ignore_above: 256,
   },
   scientificMetadata: {
     type: "nested",

--- a/src/elastic-search/configuration/datasetFieldMapping.ts
+++ b/src/elastic-search/configuration/datasetFieldMapping.ts
@@ -46,7 +46,6 @@ export const datasetMappings: MappingObject = {
   history: {
     type: "nested",
     dynamic: false,
-    ignore_above: 256,
   },
   proposalId: {
     type: "keyword",

--- a/src/elastic-search/elastic-search.service.ts
+++ b/src/elastic-search/elastic-search.service.ts
@@ -428,7 +428,7 @@ export class ElasticSearchService implements OnModuleInit {
         ];
       },
       onDrop(doc) {
-        console.debug(`${doc.document._id}`, doc.error?.reason);
+        console.debug(`${doc.document.pid}`, doc.error?.reason);
       },
     });
   }

--- a/src/elastic-search/providers/fields.enum.ts
+++ b/src/elastic-search/providers/fields.enum.ts
@@ -12,14 +12,6 @@ export enum FilterFields {
   Mode = "mode",
 }
 
-export enum FacetFields {
-  Type = "type",
-  CreationLocation = "creationLocation",
-  OwnerGroup = "ownerGroup",
-  AccessGroups = "accessGroups",
-  Keywords = "keywords",
-}
-
 export enum QueryFields {
   DatasetName = "datasetName",
   Description = "description",
@@ -28,6 +20,14 @@ export enum QueryFields {
 export enum ShouldFields {
   SharedWith = "sharedWith",
   UserGroups = "userGroups",
+}
+
+export enum FacetFields {
+  Type = "type",
+  CreationLocation = "creationLocation",
+  OwnerGroup = "ownerGroup",
+  AccessGroups = "accessGroups",
+  Keywords = "keywords",
 }
 
 export enum SortFields {

--- a/src/elastic-search/providers/fields.enum.ts
+++ b/src/elastic-search/providers/fields.enum.ts
@@ -12,7 +12,7 @@ export enum FilterFields {
   Mode = "mode",
 }
 
-export enum QueryFields {
+export enum MustFields {
   DatasetName = "datasetName",
   Description = "description",
 }

--- a/src/elastic-search/providers/query-builder.service.ts
+++ b/src/elastic-search/providers/query-builder.service.ts
@@ -44,15 +44,14 @@ export class SearchQueryService {
   private buildFilterFields(fields: Partial<IDatasetFields>): IFilter[] {
     const filter: IFilter[] = [];
 
-    for (const fieldName of this.filterFields) {
-      if (fields[fieldName]) {
-        const filterQueries = this.buildTermsFilter(
-          fieldName,
-          fields[fieldName],
-        );
-        filter.push(...filterQueries);
+    Object.entries(fields).forEach(([key, value]) => {
+      if (this.shouldFields.includes(key as ShouldFields) || key === "text") {
+        return;
       }
-    }
+
+      const filterQueries = this.buildTermsFilter(key, value);
+      filter.push(...filterQueries);
+    });
 
     return filter;
   }
@@ -173,7 +172,7 @@ export class SearchQueryService {
         if (typeof values === "string") {
           filterArray.push({
             match: {
-              [`${fieldName}.keyword`]: values as string,
+              [fieldName]: values as string,
             },
           });
         }


### PR DESCRIPTION
## Description

This PR refines the Elasticsearch integration by updating the dataset field mappings, improving the query-building service, and ensuring that the logic is more intuitive and maintainable. The changes are aimed at enhancing the search functionality, ensuring better performance, and providing more accurate search results.

## Motivation

The purpose of this PR is to enhance the Elasticsearch configuration and query-building logic to improve the flexibility and accuracy of search queries. This includes updating field mappings, refining the query-building service, and ensuring better alignment with the new requirements for data filtering and querying.

## Fixes:

* Items added

## Changes:

Field Mapping Updates (datasetFieldMapping.ts):

- Added ignore_above attribute to several keyword fields to ensure Elasticsearch handles large field values correctly.
- Added new field ownerEmail to the mapping.

Elasticsearch Service (elastic-search.service.ts):

- Corrected logging statement in onDrop method to use doc.document.pid instead of doc.document._id for better clarity and debugging.

Enums Update (fields.enum.ts):

- Renamed QueryFields to MustFields for clarity.

Query Builder Service (query-builder.service.ts):
-  Refactored buildFilterFields & buildTermsFilter to support fields that are not included in the FilterFields enum.

## Tests included/Docs Updated?

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 
- [ ] Docs updated?
- [ ] New packages used/requires npm install? 
- [ ] Toggle added for new features?
