### PR TITLE
updated issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -4,16 +4,22 @@ about: Describe this issue purpose here.
 
 ---
 
-## Issue Name
+## Issue Name (title)
+Please enter the title for this github issue
 
 ### Summary
+Description of the issue
 
 ### Steps to Reproduce
+Describe how to reproduce the issue
 
 ### Current Behaviour
+Describe the current behavior if it is relevant
 
 ### Expected Behaviour
+Describe the expected behavior if it is relevant
 
-### Extra Details
+### Details
+Provide all the details related to this issue. Also include screenshots, wireframes or mockups if they help.
 
-Here you should include details about the system (if it is unique) and possible information about a fix (feel free to link to code where relevant). Screenshots/GIFs are also fine here.
+__PS__: make sure to add the proper tags to the issue

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,17 +7,25 @@ Short description of the pull request
 Background on use case, changes needed
 
 ## Fixes:
+Please provide a list of the fixes implemented by this PR
 
 * Items added
 
 ## Changes:
+Please provide a list of the changes implemented by this PR
 
 * changes made
 
-## Tests included/Docs Updated?
+## Tests included
 
 - [ ] Included for each change/fix?
 - [ ] Passing? (Merge will not be approved unless this is checked) 
-- [ ] Docs updated?
-- [ ] New packages used/requires npm install? 
-- [ ] Toggle added for new features?
+
+## Documentation
+- [ ] swagger documentation updated \[required\]
+- [ ] official documentation updated \[nice-to-have]
+
+### official documentation info
+If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included
+
+


### PR DESCRIPTION
Updated issue and pr templates according to latest requests from developer meeting. 
See https://docs.google.com/document/d/1OGNvLOZpXa9Gfp8WA8KmXZRguMhkvczYsT8kxXiA1Uw

## Description
Updated PR template to separate and clarify tests and changes information.

## Motivation
In the developer meeting, it has been decided that swagger documentation is required in a PR, while official documentation is a nice-to-have. The PR templates has been updated accordingly.

There were two templates for issue. They were exactly the same. I removed one and updated the remaining one.

## Fixes:
* PR template file
* issue template file 

## Changes:
* removed duplicated issue template file
