### PR TITLE
chore: allow backend image to support multi-platforms

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Deploy
 
 on:
   push:
-    branches: 
-    - master
+    branches:
+      - master
 
 jobs:
   deploy:
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -22,7 +22,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Create image tags
         id: meta
         uses: docker/metadata-action@v5
@@ -30,14 +30,15 @@ jobs:
           images: ghcr.io/scicatproject/backend-next
           flavor: latest=true # adds :latest tag to outputs.tags
           tags: type=sha,format=long,prefix= # adds :<sha> tag to outputs.tags
-        
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64/v8
           push: true
           tags: ${{ steps.meta.outputs.tags }}
-            
+
       - name: Trigger ESS pipeline
         uses: swapActions/trigger-swap-deployment@v1
         with:


### PR DESCRIPTION
## Description

Added supports for both AMD and ARM64 on Github action build time

## Motivation

Current backend image does not run on Mac machine with arm64 chip



## Fixes:
Specifies platforms for Docker build (linux/amd64, linux/arm64/v8).



## Tests included

- [x] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included


