### PR TITLE
Remove configVersion, fix statusUpdate fields, update GET/jobs

### DIFF
--- a/src/casl/authop.enum.ts
+++ b/src/casl/authop.enum.ts
@@ -6,6 +6,7 @@ export enum AuthOp {
   ReadOwn = "readown",
   ReadAll = "readall",
   Update = "update",
+  StatusUpdate = "statusUpdate",
   Delete = "delete",
   ListOwn = "listown",
   ListAll = "listall",

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -800,7 +800,7 @@ export class CaslAbilityFactory {
       cannot(AuthOp.JobRead, JobClass);
       if (
         configuration().jobConfiguration.some(
-          (j) => j.update.auth == UpdateJobAuth.All,
+          (j) => j.statusUpdate.auth == UpdateJobAuth.All,
         )
       ) {
         can(AuthOp.JobStatusUpdate, JobClass);
@@ -953,7 +953,7 @@ export class CaslAbilityFactory {
           // endpoint authorization
           if (
             configuration().jobConfiguration.some(
-              (j) => j.update.auth! in jobUpdateEndPointAuthorizationValues,
+              (j) => j.statusUpdate.auth! in jobUpdateEndPointAuthorizationValues,
             )
           ) {
             can(AuthOp.JobStatusUpdate, JobClass);
@@ -962,16 +962,16 @@ export class CaslAbilityFactory {
           // -------------------------------------
           // data instance authorization
           can(AuthOp.JobStatusUpdateConfiguration, JobClass, {
-            ["configuration.update.auth" as string]: {
+            ["configuration.statusUpdate.auth" as string]: {
               $in: jobUpdateInstanceAuthorizationValues,
             },
           });
           can(AuthOp.JobStatusUpdateConfiguration, JobClass, {
-            ["configuration.update.auth" as string]: "#jobOwnerUser",
+            ["configuration.statusUpdate.auth" as string]: "#jobOwnerUser",
             ownerUser: user.username,
           });
           can(AuthOp.JobStatusUpdateConfiguration, JobClass, {
-            ["configuration.update.auth" as string]: "#jobOwnerGroup",
+            ["configuration.statusUpdate.auth" as string]: "#jobOwnerGroup",
             ownerGroup: { $in: user.currentGroups },
           });
         }

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -25,7 +25,7 @@ import { UserSettings } from "src/users/schemas/user-settings.schema";
 import { User } from "src/users/schemas/user.schema";
 import { AuthOp } from "./authop.enum";
 import configuration from "src/config/configuration";
-import { CreateJobAuth, UpdateJobAuth } from "src/jobs/types/jobs-auth.enum";
+import { CreateJobAuth, StatusUpdateJobAuth } from "src/jobs/types/jobs-auth.enum";
 
 type Subjects =
   | string
@@ -800,7 +800,7 @@ export class CaslAbilityFactory {
       cannot(AuthOp.JobRead, JobClass);
       if (
         configuration().jobConfiguration.some(
-          (j) => j.statusUpdate.auth == UpdateJobAuth.All,
+          (j) => j.statusUpdate.auth == StatusUpdateJobAuth.All,
         )
       ) {
         can(AuthOp.JobStatusUpdate, JobClass);
@@ -922,7 +922,7 @@ export class CaslAbilityFactory {
 
         if (
           user.currentGroups.some((g) =>
-            configuration().updateJobGroups.includes(g),
+            configuration().statusUpdateJobGroups.includes(g),
           )
         ) {
           // -------------------------------------
@@ -939,11 +939,11 @@ export class CaslAbilityFactory {
           });
         } else {
           const jobUpdateEndPointAuthorizationValues = [
-            ...Object.values(UpdateJobAuth),
+            ...Object.values(StatusUpdateJobAuth),
             ...jobUserAuthorizationValues,
           ];
           const jobUpdateInstanceAuthorizationValues = [
-            ...Object.values(UpdateJobAuth).filter(
+            ...Object.values(StatusUpdateJobAuth).filter(
               (v) => ~String(v).includes("#job"),
             ),
             ...jobUserAuthorizationValues,

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -759,18 +759,6 @@ export const addCreatedByFields = <T>(
   };
 };
 
-export const addConfigVersionField = <T>(
-  obj: T,
-  version: string,
-): T & {
-  configVersion: string;
-} => {
-  return {
-    ...obj,
-    configVersion: version,
-  };
-};
-
 export const addUpdatedByField = <T>(
   obj: T,
   username: string,

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -1,9 +1,8 @@
 import { Logger } from "@nestjs/common";
 import {
-  JobConfig,
   loadJobConfig,
   registerCreateAction,
-  registerUpdateAction,
+  registerStatusUpdateAction,
 } from "../jobs/config/jobconfig";
 import { LogJobAction } from "../jobs/actions/logaction";
 import { EmailJobAction } from "../jobs/actions/emailaction";
@@ -238,9 +237,9 @@ export function registerDefaultActions() {
   registerCreateAction(LogJobAction);
   registerCreateAction(EmailJobAction);
   registerCreateAction(URLAction);
-  // Update
-  registerUpdateAction(LogJobAction);
-  registerUpdateAction(EmailJobAction);
+  // Status Update
+  registerStatusUpdateAction(LogJobAction);
+  registerStatusUpdateAction(EmailJobAction);
 }
 
 export type OidcConfig = ReturnType<typeof configuration>["oidc"];

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -29,7 +29,7 @@ const configuration = () => {
     process.env.DATASET_CREATION_VALIDATION_REGEX || ("" as string);
 
   const createJobGroups = process.env.CREATE_JOB_GROUPS || ("" as string);
-  const updateJobGroups = process.env.UPDATE_JOB_GROUPS || ("" as string);
+  const statusUpdateJobGroups = process.env.UPDATE_JOB_GROUPS || ("" as string);
 
   const proposalGroups = process.env.PROPOSAL_GROUPS || ("" as string);
   const sampleGroups = process.env.SAMPLE_GROUPS || ("#all" as string);
@@ -81,7 +81,7 @@ const configuration = () => {
   //   "- Create dataset privileged groups : " + createDatasetPrivilegedGroups,
   // );
   // Logger.log("- Create job groups : " + createJobGroups);
-  // Logger.log("- Update job groups : " + updateJobGroups);
+  // Logger.log("- Update job groups : " + statusUpdateJobGroups);
 
   // Register built-in job actions
   registerDefaultActions();
@@ -107,7 +107,7 @@ const configuration = () => {
     datasetCreationValidationEnabled: datasetCreationValidationEnabled,
     datasetCreationValidationRegex: datasetCreationValidationRegex,
     createJobGroups: createJobGroups,
-    updateJobGroups: updateJobGroups,
+    statusUpdateJobGroups: statusUpdateJobGroups,
     logoutURL: process.env.LOGOUT_URL ?? "", // Example: http://localhost:3000/
     accessGroupsGraphQlConfig: {
       enabled: boolean(process.env?.ACCESS_GROUPS_GRAPHQL_ENABLED || false),

--- a/src/jobs/config/jobConfig.example.json
+++ b/src/jobs/config/jobConfig.example.json
@@ -1,34 +1,35 @@
-[
-  {
-    "jobType": "archive",
-    "configVersion": "v1.0 2024-03-01 6f3f38",
-    "create": {
-      "auth": "#all",
-      "actions": [
-        {
-          "actionType": "log"
-        },
-        {
-          "actionType": "url",
-          "url": "http://localhost:3000/api/v3/health?jobid={{id}}",
-          "headers": {
-            "accept": "application/json"
+{
+  "configVersion": "v1.0 2024-03-01 6f3f38",
+  "jobs": [
+    {
+      "jobType": "archive",
+      "create": {
+        "auth": "#all",
+        "actions": [
+          {
+            "actionType": "log"
+          },
+          {
+            "actionType": "url",
+            "url": "http://localhost:3000/api/v3/health?jobid={{id}}",
+            "headers": {
+              "accept": "application/json"
+            }
           }
-        }
-      ]
+        ]
+      },
+      "statusUpdate": {
+        "auth": "archivemanager"
+      }
     },
-    "statusUpdate": {
-      "auth": "archivemanager"
+    {
+      "jobType": "public",
+      "create": {
+        "auth": "#all"
+      },
+      "statusUpdate": {
+        "auth": "#all"
+      }
     }
-  },
-  {
-    "jobType": "public",
-    "configVersion": "v1.0 2024-03-01 6f3f31",
-    "create": {
-      "auth": "#all"
-    },
-    "statusUpdate": {
-      "auth": "#all"
-    }
-  }
-]
+  ]
+}

--- a/src/jobs/config/jobConfig.example.json
+++ b/src/jobs/config/jobConfig.example.json
@@ -17,7 +17,7 @@
         }
       ]
     },
-    "update": {
+    "statusUpdate": {
       "auth": "archivemanager"
     }
   },
@@ -27,7 +27,7 @@
     "create": {
       "auth": "#all"
     },
-    "update": {
+    "statusUpdate": {
       "auth": "#all"
     }
   }

--- a/src/jobs/config/jobConfig.schema.ts
+++ b/src/jobs/config/jobConfig.schema.ts
@@ -1,6 +1,5 @@
-import { CreateJobAuth, UpdateJobAuth } from "../types/jobs-auth.enum";
-
 // We use this to validate the Json schema of the provided configuration
+
 export const JobConfigSchema = {
   type: "array",
   items: {
@@ -26,7 +25,7 @@ export const JobConfigSchema = {
         },
         additionalProperties: true,
       },
-      update: {
+      statusUpdate: {
         type: "object",
         properties: {
           auth: { type: "string" },

--- a/src/jobs/config/jobConfig.schema.ts
+++ b/src/jobs/config/jobConfig.schema.ts
@@ -1,50 +1,57 @@
 // We use this to validate the Json schema of the provided configuration
 
 export const JobConfigSchema = {
-  type: "array",
-  items: {
-    type: "object",
-    properties: {
-      jobType: { type: "string" },
-      configVersion: { type: "string" },
-      create: {
+  type: "object",
+  properties: {
+    configVersion: { type: "string" },
+    jobs: {
+      type: "array",
+      items: {
         type: "object",
         properties: {
-          auth: { type: "string" },
-          actions: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                actionType: { type: "string" },
+          jobType: { type: "string" },
+          create: {
+            type: "object",
+            properties: {
+              auth: { type: "string" },
+              actions: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    actionType: { type: "string" },
+                  },
+                  required: ["actionType"],
+                  additionalProperties: true,
+                },
               },
-              required: ["actionType"],
-              additionalProperties: true,
             },
+            additionalProperties: true,
+          },
+          statusUpdate: {
+            type: "object",
+            properties: {
+              auth: { type: "string" },
+              actions: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    actionType: { type: "string" },
+                  },
+                  required: ["actionType"],
+                  additionalProperties: true,
+                },
+              },
+            },
+            additionalProperties: true,
           },
         },
-        additionalProperties: true,
-      },
-      statusUpdate: {
-        type: "object",
-        properties: {
-          auth: { type: "string" },
-          actions: {
-            type: "array",
-            items: {
-              type: "object",
-              properties: {
-                actionType: { type: "string" },
-              },
-              required: ["actionType"],
-              additionalProperties: true,
-            },
-          },
-        },
+        required: ["jobType"],
         additionalProperties: true,
       },
     },
-    required: ["jobType", "configVersion"],
-    additionalProperties: true,
   },
+  required: ["configVersion", "jobs"],
+  additionalProperties: true,
 };

--- a/src/jobs/config/jobconfig.ts
+++ b/src/jobs/config/jobconfig.ts
@@ -53,9 +53,11 @@ export class JobConfig {
    * @param data JSON
    * @returns
    */
-  static parse(data: Record<string, any>) {
+  static parse(
+    data: Record<string, any>,
+    configVersion: string
+  ): JobConfig {
     const type = data[JobsConfigSchema.JobType];
-    const configVersion = data[JobsConfigSchema.ConfigVersion];
     const create = JobOperation.parse<CreateJobDto>(
       createActions,
       data[AuthOp.Create],
@@ -220,10 +222,6 @@ export function loadJobConfig(filePath: string): JobConfig[] {
     console.log("Invalid Schema", JSON.stringify(validate.errors, null, 2));
   }
 
-  if (!Array.isArray(data)) {
-    data = [data];
-  }
-
-  jobConfig = data.map(JobConfig.parse);
+  jobConfig = data.jobs.map((jobData: Record<string, any>) => JobConfig.parse(jobData, data.configVersion));
   return jobConfig as JobConfig[];
 }

--- a/src/jobs/config/jobconfig.ts
+++ b/src/jobs/config/jobconfig.ts
@@ -17,7 +17,7 @@
 import * as fs from "fs";
 import { JobClass } from "../schemas/job.schema";
 import { CreateJobDto } from "../dto/create-job.dto";
-import { UpdateStatusJobDto } from "../dto/status-update-job.dto";
+import { StatusUpdateJobDto } from "../dto/status-update-job.dto";
 import { JobsConfigSchema } from "../types/jobs-config-schema.enum";
 import { AuthOp } from "src/casl/authop.enum";
 import { CreateJobAuth, JobsAuth } from "../types/jobs-auth.enum";
@@ -32,20 +32,20 @@ export class JobConfig {
   configVersion: string;
   create: JobOperation<CreateJobDto>;
   // read: JobReadAction[];
-  update: JobOperation<UpdateStatusJobDto>;
+  statusUpdate: JobOperation<StatusUpdateJobDto>;
 
   constructor(
     jobType: string,
     configVersion: string,
     create: JobOperation<CreateJobDto>,
     read = undefined,
-    update: JobOperation<UpdateStatusJobDto>,
+    statusUpdate: JobOperation<StatusUpdateJobDto>,
   ) {
     this.jobType = jobType;
     this.configVersion = configVersion;
     this.create = create;
     // this.read = read;
-    this.update = update;
+    this.statusUpdate = statusUpdate;
   }
 
   /**
@@ -60,12 +60,12 @@ export class JobConfig {
       createActions,
       data[AuthOp.Create],
     );
-    const read = undefined; //"read" in data ? oneOrMore(data["read"]).map((json) => parseReadAction(json["action"])) : [];
-    const update = JobOperation.parse<UpdateStatusJobDto>(
-      updateActions,
-      data[AuthOp.Update],
+    const read = undefined;  // "read" in data ? oneOrMore(data["read"]).map((json) => parseReadAction(json["action"])) : [];
+    const statusUpdate = JobOperation.parse<StatusUpdateJobDto>(
+      statusUpdateActions,
+      data[AuthOp.StatusUpdate],
     );
-    return new JobConfig(type, configVersion, create, read, update);
+    return new JobConfig(type, configVersion, create, read, statusUpdate);
   }
 }
 
@@ -151,7 +151,7 @@ export interface JobActionClass<DtoType> {
 
 export type JobCreateAction = JobAction<CreateJobDto>;
 // export type JobReadAction = JobAction<ReadJobDto>;
-export type JobUpdateAction = JobAction<UpdateStatusJobDto>;
+export type JobStatusUpdateAction = JobAction<StatusUpdateJobDto>;
 
 /// Action registration
 
@@ -159,7 +159,7 @@ export type JobUpdateAction = JobAction<UpdateStatusJobDto>;
 
 const createActions: Record<string, JobActionClass<CreateJobDto>> = {};
 // const readActions: Record<string, JobActionCtor<ReadJobDto>> = {};
-const updateActions: Record<string, JobActionClass<UpdateStatusJobDto>> = {};
+const statusUpdateActions: Record<string, JobActionClass<StatusUpdateJobDto>> = {};
 
 /**
  * Registers an action to handle jobs of a particular type
@@ -180,17 +180,17 @@ export function getRegisteredCreateActions(): string[] {
  * Registers an action to handle jobs of a particular type
  * @param action
  */
-export function registerUpdateAction(
-  action: JobActionClass<UpdateStatusJobDto>,
+export function registerStatusUpdateAction(
+  action: JobActionClass<StatusUpdateJobDto>,
 ) {
-  updateActions[action.actionType] = action;
+  statusUpdateActions[action.actionType] = action;
 }
 /**
  * List of action types with a registered action
  * @returns
  */
-export function getRegisteredUpdateActions(): string[] {
-  return Object.keys(updateActions);
+export function getRegisteredStatusUpdateActions(): string[] {
+  return Object.keys(statusUpdateActions);
 }
 
 /// Parsing

--- a/src/jobs/dto/status-update-job.dto.ts
+++ b/src/jobs/dto/status-update-job.dto.ts
@@ -2,7 +2,7 @@ import { ApiProperty, ApiTags } from "@nestjs/swagger";
 import { IsOptional, IsString } from "class-validator";
 
 @ApiTags("jobs")
-export class UpdateStatusJobDto {
+export class StatusUpdateJobDto {
   @ApiProperty({
     type: String,
     required: true,
@@ -11,7 +11,6 @@ export class UpdateStatusJobDto {
   @IsString()
   readonly statusCode: string;
 
-  // TBD are 'message' and 'token' needed?
   @ApiProperty({
     type: String,
     required: false,

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -653,7 +653,7 @@ export class JobsController {
       if (!this.isFilterValid(Object.keys(parsedFilter))) {
         throw { message: "Invalid filter syntax." };
       }
-      return this.jobsService.findAll(parsedFilter, request.user as JWTUser);
+      return this.jobsService.findAll(parsedFilter);
     }
     catch (e) {
       throw new HttpException(

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -45,18 +45,10 @@ export class JobsService {
   }
 
   async findAll(
-    filter: IFilters<JobDocument, FilterQuery<JobDocument>>,
-    user: JWTUser
+    filter: IFilters<JobDocument, FilterQuery<JobDocument>>
   ): Promise<JobClass[]> {
     var whereFilters: FilterQuery<JobDocument> = filter.where ?? {};
     const { limit, skip, sort } = parseLimitFilters(filter.limits);
-
-    if (user.username !== "admin") {
-      whereFilters = {
-        ...whereFilters,
-        ...{ "ownerUser": user.username }
-      }
-    }
 
     return this.jobModel
       .find(whereFilters)

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -14,14 +14,13 @@ import { IFacets, IFilters } from "src/common/interfaces/common.interface";
 import {
   addStatusFields,
   addCreatedByFields,
-  addConfigVersionField,
   addUpdatedByField,
   createFullfacetPipeline,
   createFullqueryFilter,
   parseLimitFilters,
 } from "src/common/utils";
 import { CreateJobDto } from "./dto/create-job.dto";
-import { UpdateStatusJobDto } from "./dto/status-update-job.dto";
+import { StatusUpdateJobDto } from "./dto/status-update-job.dto";
 import { JobClass, JobDocument } from "./schemas/job.schema";
 
 @Injectable({ scope: Scope.REQUEST })
@@ -33,15 +32,11 @@ export class JobsService {
 
   async create(
     createJobDto: CreateJobDto,
-    configVersion: string,
   ): Promise<JobDocument> {
     const username = (this.request.user as JWTUser).username;
     const createdJob = new this.jobModel(
       addStatusFields(
-        addConfigVersionField(
-          addCreatedByFields(createJobDto, username),
-          configVersion,
-        ),
+        addCreatedByFields(createJobDto, username),
         "Job has been created.",
         "jobCreated",
       ),
@@ -51,9 +46,17 @@ export class JobsService {
 
   async findAll(
     filter: IFilters<JobDocument, FilterQuery<JobDocument>>,
+    user: JWTUser
   ): Promise<JobClass[]> {
-    const whereFilters: FilterQuery<JobDocument> = filter.where ?? {};
+    var whereFilters: FilterQuery<JobDocument> = filter.where ?? {};
     const { limit, skip, sort } = parseLimitFilters(filter.limits);
+
+    if (user.username !== "admin") {
+      whereFilters = {
+        ...whereFilters,
+        ...{ "ownerUser": user.username }
+      }
+    }
 
     return this.jobModel
       .find(whereFilters)
@@ -93,7 +96,7 @@ export class JobsService {
 
   async statusUpdate(
     id: string,
-    updateJobDto: UpdateStatusJobDto,
+    statusUpdateJobDto: StatusUpdateJobDto,
   ): Promise<JobClass | null> {
     const existingJob = await this.jobModel.findOne({ id: id }).exec();
     if (!existingJob) {
@@ -105,9 +108,9 @@ export class JobsService {
       .findOneAndUpdate(
         { id: id },
         addStatusFields(
-          addUpdatedByField(updateJobDto as UpdateQuery<JobDocument>, username),
-          updateJobDto.statusCode,
-          updateJobDto.statusMessage!,
+          addUpdatedByField(statusUpdateJobDto as UpdateQuery<JobDocument>, username),
+          statusUpdateJobDto.statusCode,
+          statusUpdateJobDto.statusMessage!,
         ),
         { new: true },
       )

--- a/src/jobs/schemas/job.schema.ts
+++ b/src/jobs/schemas/job.schema.ts
@@ -3,7 +3,6 @@ import { ApiProperty } from "@nestjs/swagger";
 import { Document } from "mongoose";
 import { v4 as uuidv4 } from "uuid";
 import { OwnableClass } from "src/common/schemas/ownable.schema";
-import { CreateJobAuth } from "../types/jobs-auth.enum";
 import { JobConfig } from "../config/jobconfig";
 
 export type JobDocument = JobClass & Document;
@@ -83,18 +82,6 @@ export class JobClass extends OwnableClass {
   })
   statusMessage: string;
 
-  // configuration version
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Stores the job's latest configuration version.",
-  })
-  @Prop({
-    type: String,
-    required: false,
-  })
-  configVersion: string;
-
   // messages
   @ApiProperty({
     type: Object,
@@ -160,9 +147,6 @@ export class JobClass extends OwnableClass {
 
   @Prop({ type: Boolean, required: false, default: false })
   datasetValidation?: boolean;
-
-  // TODO email address for owner from scicat? see create example for job.recipients
-  // in case email is needed it goes into params, and other values too
 }
 export const JobSchema = SchemaFactory.createForClass(JobClass);
 

--- a/src/jobs/types/jobs-auth.enum.ts
+++ b/src/jobs/types/jobs-auth.enum.ts
@@ -13,7 +13,7 @@ export enum CreateJobAuth {
   DatasetOwner = "#datasetOwner",
 }
 
-export enum UpdateJobAuth {
+export enum StatusUpdateJobAuth {
   // any user can update, no checks are performed
   // to be used carefully, mainly for testing
   All = "#all",
@@ -25,4 +25,4 @@ export enum UpdateJobAuth {
   JobOwnerGroup = "#jobOwnerGroup",
 }
 
-export type JobsAuth = CreateJobAuth | UpdateJobAuth;
+export type JobsAuth = CreateJobAuth | StatusUpdateJobAuth;


### PR DESCRIPTION
Fixes #1265.

Details:
- In the config file, `update` has been replaced with `statusUpdate` for consistency reasons and to avoid confusion in case we would like to introduce a general update function in the future.
- As a result, `casl-ability` has been updated and a `statusUpdate` authentication option has been added in the `casl/AuthOp`.
- `UpdateActions` have been renamed to `StatusUpdateActions`.
- `UpdateStatusJobDto` has been renamed to `StatusUpdateJobDto`.
- `configVersion` has been removed from the Job Schema.
- As a result, the util function `addConfigVesrionField` has also been removed, since it is no longer used in the `jobs.service`.
- In `jobs.service` we also introduce an additional filter in the `findAll` function which is used for `GET/jobs`: Only an admin can see all jobs, so if the user is not an admin then he can see only the jobs that he owns.
- In `jobs.controller` the `GET/jobs` function has been updated in order to user a `try-catch` that checks that the filters provided by the user are a valid Json and contain only valid fields.
- `checkJobConfiguration` and `checkConfigurationVersion` have been removed from `jobs.controller` as they are no longer being used.