### PR TITLE
Job Status Update: Implement RabbitMQ Action

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -7,6 +7,7 @@ import {
 import { LogJobAction } from "../jobs/actions/logaction";
 import { EmailJobAction } from "../jobs/actions/emailaction";
 import { URLAction } from "src/jobs/actions/urlaction";
+import { RabbitMQJobAction } from "src/jobs/actions/rabbitmqaction";
 import * as fs from "fs";
 import { merge } from "lodash";
 import localconfiguration from "./localconfiguration";
@@ -240,6 +241,7 @@ export function registerDefaultActions() {
   // Status Update
   registerStatusUpdateAction(LogJobAction);
   registerStatusUpdateAction(EmailJobAction);
+  registerStatusUpdateAction(RabbitMQJobAction);
 }
 
 export type OidcConfig = ReturnType<typeof configuration>["oidc"];

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -238,6 +238,7 @@ export function registerDefaultActions() {
   registerCreateAction(LogJobAction);
   registerCreateAction(EmailJobAction);
   registerCreateAction(URLAction);
+  registerCreateAction(RabbitMQJobAction);
   // Status Update
   registerStatusUpdateAction(LogJobAction);
   registerStatusUpdateAction(EmailJobAction);

--- a/src/jobs/actions/logaction.ts
+++ b/src/jobs/actions/logaction.ts
@@ -15,11 +15,11 @@ export class LogJobAction<T> implements JobAction<T> {
   }
 
   async validate(dto: T) {
-    Logger.log("Validating CREATE job: " + JSON.stringify(dto), "LogJobAction");
+    Logger.log("Validating job: " + JSON.stringify(dto), "LogJobAction");
   }
 
   async performJob(job: JobClass) {
-    Logger.log("Performing CREATE job: " + JSON.stringify(job), "LogJobAction");
+    Logger.log("Performing job: " + JSON.stringify(job), "LogJobAction");
   }
 
   constructor(data: Record<string, any>) {

--- a/src/jobs/actions/rabbitmqaction.ts
+++ b/src/jobs/actions/rabbitmqaction.ts
@@ -1,0 +1,85 @@
+import { Logger, NotFoundException } from "@nestjs/common";
+import amqp, { Connection } from "amqplib/callback_api";
+import { JobAction } from "../config/jobconfig";
+import { JobClass } from "../schemas/job.schema";
+
+
+/**
+ * Publish a message following a job status update
+ */
+export class RabbitMQJobAction<T> implements JobAction<T> {
+  public static readonly actionType = "rabbitmq";
+  private connectionDetails;
+  private queueName;
+
+  constructor(data: Record<string, any>) {
+    Logger.log(
+      "Initializing RabbitMQJobAction. Params: " + JSON.stringify(data),
+      "RabbitMQJobAction",
+    );
+
+    this.connectionDetails = {
+      protocol: "amqp",
+      hostname: data.hostname,
+      port: data.port,
+      username: data.username,
+      password: data.password,
+    };
+    this.queueName = data.queue;
+  }
+
+  getActionType(): string {
+    return RabbitMQJobAction.actionType;
+  }
+
+  async validate(dto: T) {
+    Logger.log(
+      "Validating RabbitMQJobAction: " + JSON.stringify(dto),
+      "RabbitMQJobAction",
+    );
+
+    if ([undefined, ""].some(el => Object.values(this.connectionDetails).includes(el))) {
+      throw new NotFoundException("Configuration is missing connection details.");
+    }
+    if (this.queueName == undefined || this.queueName == "") {
+      throw new NotFoundException("Queue name is not defined.");
+    }
+  }
+
+  async performJob(job: JobClass) {
+    Logger.log(
+      "Performing RabbitMQJobAction: " + JSON.stringify(job),
+      "RabbitMQJobAction",
+    );
+
+    amqp.connect(this.connectionDetails, (connectionError: Error, connection: Connection) => {
+      if (connectionError) {
+        console.log(connectionError);
+        Logger.log(
+          "Connection error in RabbitMQJobAction: " + JSON.stringify(connectionError.message),
+          "RabbitMQJobAction",
+        );
+        return;
+      }
+
+      connection.createChannel((channelError: Error, channel) => {
+        if (channelError) {
+          Logger.log(
+            "Channel error in RabbitMQJobAction: " + JSON.stringify(channelError.message),
+            "RabbitMQJobAction",
+          );
+          return;
+        }
+        channel.assertQueue(this.queueName);
+
+        const msg = `StatusUpdate Job ${job.id}`;
+        channel.sendToQueue(this.queueName, Buffer.from(msg));
+        Logger.log(
+          "Published message: " + msg,
+          "RabbitMQJobAction",
+        );
+        connection.close();
+      });
+    });
+  }
+}

--- a/src/jobs/actions/rabbitmqaction.ts
+++ b/src/jobs/actions/rabbitmqaction.ts
@@ -70,7 +70,10 @@ export class RabbitMQJobAction<T> implements JobAction<T> {
           );
           return;
         }
-        channel.assertQueue(this.queueName);
+
+        channel.assertQueue(this.queueName, {
+          durable: true
+        });
 
         const msg = `StatusUpdate Job ${job.id}`;
         channel.sendToQueue(this.queueName, Buffer.from(msg));
@@ -78,7 +81,10 @@ export class RabbitMQJobAction<T> implements JobAction<T> {
           "Published message: " + msg,
           "RabbitMQJobAction",
         );
-        connection.close();
+
+        channel.close(() => {
+          connection.close();
+        });
       });
     });
   }

--- a/src/jobs/config/jobConfig.example.json
+++ b/src/jobs/config/jobConfig.example.json
@@ -27,7 +27,7 @@
             "post": 5672,
             "username": "guest",
             "password": "guest",
-            "queue": "client.jobs.write"
+            "queue": "jobs.statusUpdate"
           }
         ]
       }

--- a/src/jobs/config/jobConfig.example.json
+++ b/src/jobs/config/jobConfig.example.json
@@ -22,7 +22,9 @@
             "port": 5672,
             "username": "guest",
             "password": "guest",
-            "queue": "jobqueue"
+            "exchange": "jobs.write",
+            "queue": "client.jobs.write",
+            "key": "jobqueue"
           }
         ]
       },
@@ -35,7 +37,9 @@
             "port": 5672,
             "username": "guest",
             "password": "guest",
-            "queue": "jobqueue"
+            "exchange": "jobs.write",
+            "queue": "client.jobs.write",
+            "key": "jobqueue"
           }
         ]
       }

--- a/src/jobs/config/jobConfig.example.json
+++ b/src/jobs/config/jobConfig.example.json
@@ -19,7 +19,17 @@
         ]
       },
       "statusUpdate": {
-        "auth": "archivemanager"
+        "auth": "archivemanager",
+        "actions": [
+          {
+            "actionType": "rabbitmq",
+            "hostname": "rabbitmq",
+            "post": 5672,
+            "username": "guest",
+            "password": "guest",
+            "queue": "client.jobs.write"
+          }
+        ]
       }
     },
     {

--- a/src/jobs/config/jobConfig.example.json
+++ b/src/jobs/config/jobConfig.example.json
@@ -15,6 +15,14 @@
             "headers": {
               "accept": "application/json"
             }
+          },
+          {
+            "actionType": "rabbitmq",
+            "hostname": "rabbitmq",
+            "port": 5672,
+            "username": "guest",
+            "password": "guest",
+            "queue": "jobqueue"
           }
         ]
       },
@@ -24,10 +32,10 @@
           {
             "actionType": "rabbitmq",
             "hostname": "rabbitmq",
-            "post": 5672,
+            "port": 5672,
             "username": "guest",
             "password": "guest",
-            "queue": "jobs.statusUpdate"
+            "queue": "jobqueue"
           }
         ]
       }

--- a/src/jobs/config/jobconfig.ts
+++ b/src/jobs/config/jobconfig.ts
@@ -79,12 +79,10 @@ export class JobConfig {
 export class JobOperation<DtoType> {
   auth: JobsAuth | undefined;
   actions: JobAction<DtoType>[];
-  configuration: Object;
 
-  constructor(auth: JobsAuth | undefined, actions: JobAction<DtoType>[] = [], configuration: Object) {
-    this.auth = auth;
+  constructor(actions: JobAction<DtoType>[] = [], auth: JobsAuth | undefined) {
     this.actions = actions;
-    this.configuration = configuration;
+    this.auth = auth;
   }
 
   static parse<DtoType>(
@@ -101,7 +99,7 @@ export class JobOperation<DtoType> {
     const actions = actionsData.map((json) =>
       parseAction<DtoType>(actionList, json),
     );
-    return new JobOperation<DtoType>(auth, actions, actionsData);
+    return new JobOperation<DtoType>(actions, auth);
   }
 }
 

--- a/src/jobs/interceptors/job-create.interceptor.ts
+++ b/src/jobs/interceptors/job-create.interceptor.ts
@@ -78,6 +78,28 @@ export class JobCreateInterceptor implements NestInterceptor {
         });
       }),
     );
-    return jc;
+
+    return this.mergeActionsConfigurationFields(jc as any);
+  }
+
+  /**
+   * Store only the job's configuration object in the database
+   * and not the action instances
+   */
+  mergeActionsConfigurationFields(jobConfig: any): JobConfig {
+    const { create, statusUpdate, ...rest } = jobConfig;
+    const newCreate = { ...create };
+    const newStatusUpdate = { ...statusUpdate };
+  
+    newCreate.actions = newCreate.configuration;
+    newStatusUpdate.actions = newStatusUpdate.configuration;
+    delete newCreate.configuration;
+    delete newStatusUpdate.configuration;
+  
+    return {
+      ...rest,
+      create: newCreate,
+      statusUpdate: newStatusUpdate,
+    };
   }
 }

--- a/src/jobs/interceptors/job-create.interceptor.ts
+++ b/src/jobs/interceptors/job-create.interceptor.ts
@@ -79,7 +79,7 @@ export class JobCreateInterceptor implements NestInterceptor {
       }),
     );
 
-    return this.mergeActionsConfigurationFields(jc as any);
+    return this.mergeActionsConfigurationFields(jc as JobConfig);
   }
 
   /**

--- a/src/jobs/interceptors/job-create.interceptor.ts
+++ b/src/jobs/interceptors/job-create.interceptor.ts
@@ -79,27 +79,6 @@ export class JobCreateInterceptor implements NestInterceptor {
       }),
     );
 
-    return this.mergeActionsConfigurationFields(jc as JobConfig);
-  }
-
-  /**
-   * Store only the job's configuration object in the database
-   * and not the action instances
-   */
-  mergeActionsConfigurationFields(jobConfig: any): JobConfig {
-    const { create, statusUpdate, ...rest } = jobConfig;
-    const newCreate = { ...create };
-    const newStatusUpdate = { ...statusUpdate };
-  
-    newCreate.actions = newCreate.configuration;
-    newStatusUpdate.actions = newStatusUpdate.configuration;
-    delete newCreate.configuration;
-    delete newStatusUpdate.configuration;
-  
-    return {
-      ...rest,
-      create: newCreate,
-      statusUpdate: newStatusUpdate,
-    };
+    return jc;
   }
 }

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -600,7 +600,7 @@ export class JobsController {
     );
     // Update job in database
     const updatedJob = await this.jobsService.statusUpdate(id, statusUpdateJobDto);
-    // Perform the action that is specified in the create portion of the job configuration
+    // Perform the action that is specified in the update portion of the job configuration
     if (updatedJob !== null) {
       await this.performJobStatusUpdateAction(updatedJob);
     }

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -46,6 +46,7 @@ import {
   filterExampleSimplified,
 } from "src/common/utils";
 import { JobCreateInterceptor } from "./interceptors/job-create.interceptor";
+import { JobAction } from "./config/jobconfig";
 
 @ApiBearerAuth()
 @ApiTags("jobs")
@@ -447,25 +448,45 @@ export class JobsController {
   /**
    * Send off to external service, update job in database if needed
    */
+  async performJobAction(jobInstance: JobClass, action: JobAction<CreateJobDto> | JobAction<StatusUpdateJobDto>): Promise<void> {
+    await action.performJob(jobInstance).catch((err: Error) => {
+      if (err instanceof HttpException) {
+        throw err;
+      }
+      throw new HttpException(
+        {
+          status: HttpStatus.BAD_REQUEST,
+          message: `Invalid job input. Action ${action.getActionType()} unable to validate ${
+            jobInstance.type
+          } job due to ${err}`,
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    });
+  }
+
   async performJobCreateAction(jobInstance: JobClass): Promise<void> {
-    for (const action of jobInstance.configuration.create.actions) {
-      await action.performJob(jobInstance).catch((err: Error) => {
-        if (err instanceof HttpException) {
-          throw err;
-        }
-        throw new HttpException(
-          {
-            status: HttpStatus.BAD_REQUEST,
-            message: `Invalid job input. Action ${action.getActionType()} unable to validate ${
-              jobInstance.type
-            } job due to ${err}`,
-          },
-          HttpStatus.BAD_REQUEST,
-        );
-      });
+    const jobConfigs = configuration().jobConfiguration;
+    const matchingConfig = jobConfigs.filter(
+      (j) => j.jobType == jobInstance.type,
+    );
+    for (const action of matchingConfig[0].create.actions) {
+      await this.performJobAction(jobInstance, action);
     }
     return;
   }
+
+  async performJobStatusUpdateAction(jobInstance: JobClass): Promise<void> {
+    const jobConfigs = configuration().jobConfiguration;
+    const matchingConfig = jobConfigs.filter(
+      (j) => j.jobType == jobInstance.type,
+    );
+    for (const action of matchingConfig[0].statusUpdate.actions) {
+      await this.performJobAction(jobInstance, action);
+    }
+    return;
+  }
+
 
   /**
    * Create job
@@ -579,6 +600,10 @@ export class JobsController {
     );
     // Update job in database
     const updatedJob = await this.jobsService.statusUpdate(id, statusUpdateJobDto);
+    // Perform the action that is specified in the create portion of the job configuration
+    if (updatedJob !== null) {
+      await this.performJobStatusUpdateAction(updatedJob);
+    }
 
     // Emit update event
     // MN: not needed

--- a/src/jobs/types/jobs-config-schema.enum.ts
+++ b/src/jobs/types/jobs-config-schema.enum.ts
@@ -1,5 +1,6 @@
 export enum JobsConfigSchema {
   // Valid Job Config schema fields
+  Jobs = "jobs",
   JobType = "jobType",
   ConfigVersion = "configVersion",
   Auth = "auth",


### PR DESCRIPTION
## Description

Fixes #1121 

## Motivation

The RabbitMQ action is a requirement for PSI

## Fixes:

The changes made in `JobOperation class` in `jobconfig.ts` and in  `job-create.interceptor.ts` fix the way we are storing the configuration in each job created in the database. Previously, the part of configuration file for actions was replaced by the action instance information, which in some cases makes the result we see in the database incomprehensible. We now store the action information exactly as it comes from the json file. This fix provides readability and reproducibility. 

## Changes:

- `jobConfig.example.json`: added configuration for the rabbitMQ action
- `jobs.controller`: added function to call the relevant actions on job update
- `rabbitmqaction.ts`: makes a RabbitMQ connection, creates a channel and sends a message in the queue  

**Important:** In order to spin up RabbitMQ, one needs to update the `.env` and `docker-compose.yaml` files in `scicat-ci`. These changes have been made in `despadam/scicat-ci:dev-docs` fork and should be merged as well.

## Tests:

To test whether the message has been published, one can login to the RabbitMQ management page on `localhost:15672` with the default credentials and inspect the queue.

## Notes:

The discussion about whether we should store the full configuration in each job should remain open. Storing configuration per job means that each job can run with different configuration. However, even if this has been implemented in the job schema (see also the fix mentioned above), we tend to not utilize it. More specifically, authorization in `casl-factory` and action initialization are still using the SciCat running instance configuration, instead of the job specific one, which is contradictory.