### PR TITLE
Add MongoDB index to dataset property in attachments

### DIFF
--- a/src/attachments/schemas/attachment.schema.ts
+++ b/src/attachments/schemas/attachment.schema.ts
@@ -43,7 +43,7 @@ export class Attachment extends OwnableClass {
   caption: string;
 
   @ApiProperty({ type: String, required: false })
-  @Prop({ type: String, ref: "Dataset", required: false })
+  @Prop({ type: String, ref: "Dataset", index: true, required: false })
   datasetId: string;
 
   @ApiProperty({ type: String, required: false })


### PR DESCRIPTION
## Description

Add a new index to MongoDB for the dataset property in attachments.

## Motivation

Performance for loading attachments on the dataset view page becomes very slow as the number of datasets increases. New datasets are very slow to look-up the attachments, spiking CPU use. This just adds an index to the attachments table for datasets, which fixes the slow performance. For Diamond, with 10,000 datasets, this takes the time to find the attachment from 10s of seconds to a 10s of milliseconds.

## Fixes:
Please provide a list of the fixes implemented by this PR

* N/A

## Changes:
Please provide a list of the changes implemented by this PR

* Add index to dataset property in attachements

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included


