### PR TITLE
Remove unused fields from job schema

### DIFF
--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -916,7 +916,7 @@ export class CaslAbilityFactory {
             ["configuration.create.auth" as string]: {
               $in: jobCreateDatasetAuthorizationValues,
             },
-            datasetValidation: true,
+            datasetsValidation: true,
           });
         }
 

--- a/src/jobs/schemas/job.schema.ts
+++ b/src/jobs/schemas/job.schema.ts
@@ -82,19 +82,6 @@ export class JobClass extends OwnableClass {
   })
   statusMessage: string;
 
-  // messages
-  @ApiProperty({
-    type: Object,
-    required: false,
-    description:
-      "This is the equivalent object of the message sent to external service.",
-  })
-  @Prop({
-    type: Object,
-    required: false,
-  })
-  messageSent: Record<string, unknown>;
-
   // parameters (instance)
   @ApiProperty({
     type: Object,
@@ -144,9 +131,6 @@ export class JobClass extends OwnableClass {
     required: true,
   })
   configuration: JobConfig;
-
-  @Prop({ type: Boolean, required: false, default: false })
-  datasetValidation?: boolean;
 }
 export const JobSchema = SchemaFactory.createForClass(JobClass);
 


### PR DESCRIPTION
## Description
The current `job.schema` contains:
- A property `messageSent` which is never used. The details/content about the messages sent (RabbitMQ messages, emails, etc.) should be provided via the configuration file.
- Properties `datasetValidation` and `datasetsValidation`. We should only use the second one (`datasetsValidation`).

## Motivation
Fix #621 

## Changes:
- Removing the unused properties from `job.schema`.
- Fix `casl-ability` to  use only `datasetsValidation`.