### PR TITLE
Jobs should only use the SciCat instance configuration

### DIFF
--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -362,7 +362,6 @@ export class JobsController {
     // If other fields are needed can be added later.
     const jobInstance = new JobClass();
     const jobConfiguration = this.getJobMatchingConfiguration(jobCreateDto);
-    console.log(jobConfiguration);
 
     jobInstance._id = "";
     jobInstance.ownerUser = "";

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -323,6 +323,35 @@ export class JobsController {
   };
 
   /**
+   * Check job type matching configuration
+   */
+  getJobMatchingConfiguration = (createJobDto: CreateJobDtoWithConfig) => {
+    const jobConfigs = configuration().jobConfiguration;
+    const matchingConfig = jobConfigs.filter(
+      (j) => j.jobType == createJobDto.type,
+    );
+
+    if (matchingConfig.length != 1) {
+      if (matchingConfig.length > 1) {
+        Logger.error(
+          "More than one job configurations matching type " + createJobDto.type,
+        );
+      } else {
+        Logger.error("No job configuration matching type " + createJobDto.type);
+      }
+      // return error that job type does not exists
+      throw new HttpException(
+        {
+          status: HttpStatus.BAD_REQUEST,
+          message: "Invalid job type: " + createJobDto.type,
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    return matchingConfig[0];
+  };
+
+  /**
    * Checking if user is allowed to create job according to auth field of job configuration
    */
   async instanceAuthorizationJobCreate(
@@ -332,7 +361,9 @@ export class JobsController {
     // NOTE: We need JobClass instance because casl module works only on that.
     // If other fields are needed can be added later.
     const jobInstance = new JobClass();
-    const jobConfiguration = jobCreateDto.configuration;
+    const jobConfiguration = this.getJobMatchingConfiguration(jobCreateDto);
+    console.log(jobConfiguration);
+
     jobInstance._id = "";
     jobInstance.ownerUser = "";
     jobInstance.ownerGroup = "";
@@ -448,7 +479,8 @@ export class JobsController {
    * Send off to external service, update job in database if needed
    */
   async performJobCreateAction(jobInstance: JobClass): Promise<void> {
-    for (const action of jobInstance.configuration.create.actions) {
+    const jobConfig = this.getJobMatchingConfiguration(jobInstance);
+    for (const action of jobConfig.create.actions) {
       await action.performJob(jobInstance).catch((err: Error) => {
         if (err instanceof HttpException) {
           throw err;


### PR DESCRIPTION
## Description

Based on the last comment under topic https://github.com/SciCatProject/scicat-backend-next/issues/1294.

> For the MVP we will enforce the use of instance-specific configuration instead of job-specific. This will allow us to fix and merge the current PRs and finish the testing.

## Changes:

In `jobs.controller`: `instanceAuthorizationJobCreate` and `performJobCreateAction` have been updated to extract the necessary information for the job configuration per job type, from the global configuration variable that is created when the SciCat instance starts running. Previously they were using the job-specific configuration that is being stored within each job instance.

## Notes:

- The full job type specific configuration is still being stored in the db when a new job instance is created. We keep it like this for now, so that we don't apply changes to the job schema, as it has been finalized. After the MVP implementation we will decide whether this should change too.