### PR TITLE
Improve URLAction templating

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -30,6 +30,9 @@ import {
   formatCamelCase,
   unwrapJSON,
   jsonify,
+  job_v3,
+  urlencode,
+  base64enc,
 } from "./common/handlebars-helpers";
 import { CommonModule } from "./common/common.module";
 import { EventEmitterModule } from "@nestjs/event-emitter";
@@ -75,6 +78,9 @@ import { LoggerModule } from "./loggers/logger.module";
               keyToWord: formatCamelCase,
               eq: (a, b) => a === b,
               jsonify: jsonify,
+              job_v3: job_v3,
+              urlencode: urlencode,
+              base64enc: base64enc,
             }),
             options: {
               strict: true,

--- a/src/common/handlebars-helpers.ts
+++ b/src/common/handlebars-helpers.ts
@@ -1,3 +1,22 @@
+/**
+ * Handlebar helper functions.
+ *
+ * Helpers should be registered in app.module.ts
+ */
+import { JobClass } from "src/jobs/schemas/job.schema";
+import { JobsConfigSchema } from "src/jobs/types/jobs-config-schema.enum";
+
+/**
+ * Convert json objects to HTML
+ *
+ * Supports:
+ * - boolean, numbers, and strings without modification
+ * - Arrays as <ul>
+ * - Objects as key: value pairs separated by <br/>
+ * - null as "Not specified"
+ * @param json
+ * @returns
+ */
 export const unwrapJSON = (json: unknown): string | number => {
   if (json === null) {
     return "Not specified";
@@ -40,6 +59,82 @@ export const formatCamelCase = (camelCase: string): string => {
   return words;
 };
 
-export const jsonify = (context: any): string => {
+/**
+ * Convert a handlebars context to a json string
+ *
+ * Useful for debugging, eg "{{{jsonify this}}}". Results contain newlines.
+ * @param context Handlebars variable
+ * @returns string
+ */
+export const jsonify = (context: unknown): string => {
   return JSON.stringify(context, null, 3);
 };
+
+
+type DatasetIdV3 = {
+  pid: string;
+  files: string[];
+};
+interface JobV3 {
+  id: string;
+  emailJobInitiator: string;
+  type: string;
+  creationTime: Date;
+  executionTime?: Date;
+  jobParams: Record<string, unknown>;
+  jobStatusMessage: string;
+  datasetList: DatasetIdV3[];
+  jobResultObject?: unknown;
+}
+
+/**
+ * Convert a current job to follow the old v3 schema.
+ *
+ * Useful as a shim for backwards compatibility with old archive systems.
+ *
+ * Example: '{{{ jsonify (job_v3 this) }}}'
+ * @param context
+ */
+export const job_v3 = (job: JobClass): JobV3 => {
+  let datasetList: DatasetIdV3[];
+  if(JobsConfigSchema.DatasetIds in job.jobParams) {
+    const datasetIds = job.jobParams[JobsConfigSchema.DatasetIds] as string[];
+    datasetList = datasetIds.map(pid => ({
+      pid: pid,
+      files: [],
+    }));
+  } else {
+    datasetList = [];
+  }
+  return {
+    "id": job.id,
+    "emailJobInitiator": job.contactEmail,
+    "type": job.type,
+    "creationTime": job.createdAt,
+    "jobParams": {
+      ...job.jobParams,
+      "username": job.createdBy
+    },
+    //v3 statusMessages were generally concise, so use the statusCode
+    "jobStatusMessage": job.statusCode,
+    "datasetList": datasetList,
+  };
+};
+
+/**
+ * URL encode input
+ * @param context Handlebars variable
+ * @returns URL-encoded string
+ */
+export const urlencode = (context: string): string => {
+  return encodeURIComponent(context);
+}
+
+/**
+ * Base64 encode input
+ * @param context Handlebars variable
+ * @returns URL-encoded string
+ */
+export const base64enc = (context: string): string => {
+  return btoa(context);
+}

--- a/src/common/handlebars-helpers.ts
+++ b/src/common/handlebars-helpers.ts
@@ -70,7 +70,6 @@ export const jsonify = (context: unknown): string => {
   return JSON.stringify(context, null, 3);
 };
 
-
 type DatasetIdV3 = {
   pid: string;
   files: string[];
@@ -97,9 +96,9 @@ interface JobV3 {
  */
 export const job_v3 = (job: JobClass): JobV3 => {
   let datasetList: DatasetIdV3[];
-  if(JobsConfigSchema.DatasetIds in job.jobParams) {
+  if (JobsConfigSchema.DatasetIds in job.jobParams) {
     const datasetIds = job.jobParams[JobsConfigSchema.DatasetIds] as string[];
-    datasetList = datasetIds.map(pid => ({
+    datasetList = datasetIds.map((pid) => ({
       pid: pid,
       files: [],
     }));
@@ -107,17 +106,17 @@ export const job_v3 = (job: JobClass): JobV3 => {
     datasetList = [];
   }
   return {
-    "id": job.id,
-    "emailJobInitiator": job.contactEmail,
-    "type": job.type,
-    "creationTime": job.createdAt,
-    "jobParams": {
+    id: job.id,
+    emailJobInitiator: job.contactEmail,
+    type: job.type,
+    creationTime: job.createdAt,
+    jobParams: {
       ...job.jobParams,
-      "username": job.createdBy
+      username: job.createdBy
     },
     //v3 statusMessages were generally concise, so use the statusCode
-    "jobStatusMessage": job.statusCode,
-    "datasetList": datasetList,
+    jobStatusMessage: job.statusCode,
+    datasetList: datasetList,
   };
 };
 
@@ -128,7 +127,7 @@ export const job_v3 = (job: JobClass): JobV3 => {
  */
 export const urlencode = (context: string): string => {
   return encodeURIComponent(context);
-}
+};
 
 /**
  * Base64 encode input
@@ -137,4 +136,4 @@ export const urlencode = (context: string): string => {
  */
 export const base64enc = (context: string): string => {
   return btoa(context);
-}
+};

--- a/src/common/handlebars-helpers.ts
+++ b/src/common/handlebars-helpers.ts
@@ -112,7 +112,7 @@ export const job_v3 = (job: JobClass): JobV3 => {
     creationTime: job.createdAt,
     jobParams: {
       ...job.jobParams,
-      username: job.createdBy
+      username: job.createdBy,
     },
     //v3 statusMessages were generally concise, so use the statusCode
     jobStatusMessage: job.statusCode,

--- a/src/jobs/actions/urlaction.ts
+++ b/src/jobs/actions/urlaction.ts
@@ -63,11 +63,11 @@ export class URLAction<T> implements JobAction<T> {
       method: this.method,
       headers: this.headerTemplates
         ? Object.fromEntries(
-          Object.entries(this.headerTemplates).map(([key, template]) => [
-            key,
-            template(job, jobTemplateOptions),
-          ]),
-        )
+            Object.entries(this.headerTemplates).map(([key, template]) => [
+              key,
+              template(job, jobTemplateOptions),
+            ]),
+          )
         : undefined,
       body: this.bodyTemplate
         ? this.bodyTemplate(job, jobTemplateOptions)

--- a/src/jobs/actions/urlaction.ts
+++ b/src/jobs/actions/urlaction.ts
@@ -42,7 +42,10 @@ export class URLAction<T> implements JobAction<T> {
 
   private urlTemplate: Handlebars.TemplateDelegate<JobClass>;
   private method = "GET";
-  private headerTemplates?: Record<string, Handlebars.TemplateDelegate<JobClass>> = {};
+  private headerTemplates?: Record<
+    string,
+    Handlebars.TemplateDelegate<JobClass>
+  > = {};
   private bodyTemplate?: Handlebars.TemplateDelegate<JobClass>;
 
   getActionType(): string {
@@ -59,13 +62,16 @@ export class URLAction<T> implements JobAction<T> {
     const response = await fetch(url, {
       method: this.method,
       headers: this.headerTemplates
-               ? Object.fromEntries(
-                 Object.entries(this.headerTemplates).map(([key, template]) => [
-                  key,
-                  template(job, jobTemplateOptions),
-                ])
-               ) : undefined,
-      body: this.bodyTemplate ? this.bodyTemplate(job, jobTemplateOptions) : undefined,
+        ? Object.fromEntries(
+          Object.entries(this.headerTemplates).map(([key, template]) => [
+            key,
+            template(job, jobTemplateOptions),
+          ]),
+        )
+        : undefined,
+      body: this.bodyTemplate
+        ? this.bodyTemplate(job, jobTemplateOptions)
+        : undefined,
     });
 
     Logger.log(`Request for ${url} returned ${response.status}`, "URLAction");
@@ -103,8 +109,10 @@ export class URLAction<T> implements JobAction<T> {
       this.method = data.method;
     }
     if (data["headers"]) {
-      if(!isStringRecord(data.headers)) {
-        throw new NotFoundException("Param 'headers' should map strings to strings");
+      if (!isStringRecord(data.headers)) {
+        throw new NotFoundException(
+          "Param 'headers' should map strings to strings",
+        );
       }
       this.headerTemplates = Object.fromEntries(
         Object.entries(data.headers).map(([key, value]) => [

--- a/src/jobs/actions/urlaction.ts
+++ b/src/jobs/actions/urlaction.ts
@@ -25,11 +25,11 @@ const jobTemplateOptions = {
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isStringRecord(obj: any): obj is Record<string, string> {
-  return ( 
+  return (
     typeof obj === "object" &&
     obj !== null &&
     Object.keys(obj).every(
-      (key) => typeof key === "string" && typeof obj[key] === "string"
+      (key) => typeof key === "string" && typeof obj[key] === "string",
     )
   );
 }
@@ -58,12 +58,13 @@ export class URLAction<T> implements JobAction<T> {
 
     const response = await fetch(url, {
       method: this.method,
-      headers: this.headerTemplates ? 
-                Object.fromEntries(
-                  Object.entries(this.headerTemplates).map(
-                    ([key, template]) => [key, template(job, jobTemplateOptions)]
-                  )
-                ) : undefined,
+      headers: this.headerTemplates
+               ? Object.fromEntries(
+                 Object.entries(this.headerTemplates).map(([key, template]) => [
+                  key,
+                  template(job, jobTemplateOptions),
+                ])
+               ) : undefined,
       body: this.bodyTemplate ? this.bodyTemplate(job, jobTemplateOptions) : undefined,
     });
 
@@ -106,9 +107,10 @@ export class URLAction<T> implements JobAction<T> {
         throw new NotFoundException("Param 'headers' should map strings to strings");
       }
       this.headerTemplates = Object.fromEntries(
-        Object.entries(data.headers).map(
-          ([key, value]) => [key, Handlebars.compile(value)]
-        )
+        Object.entries(data.headers).map(([key, value]) => [
+          key,
+          Handlebars.compile(value),
+        ]),
       );
     }
     if (data["body"]) {

--- a/src/jobs/actions/urlaction.ts
+++ b/src/jobs/actions/urlaction.ts
@@ -23,9 +23,15 @@ const jobTemplateOptions = {
  * @param obj
  * @returns
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function isStringRecord(obj: any): obj is Record<string, string> {
-  return typeof obj === 'object' && obj !== null &&
-         Object.keys(obj).every(key => typeof key === 'string' && typeof obj[key] === 'string');
+  return ( 
+    typeof obj === "object" &&
+    obj !== null &&
+    Object.keys(obj).every(
+      (key) => typeof key === "string" && typeof obj[key] === "string"
+    )
+  );
 }
 
 /**
@@ -52,7 +58,12 @@ export class URLAction<T> implements JobAction<T> {
 
     const response = await fetch(url, {
       method: this.method,
-      headers: this.headerTemplates ? Object.fromEntries(Object.entries(this.headerTemplates).map(([key, template]) => [key, template(job, jobTemplateOptions)])): undefined,
+      headers: this.headerTemplates ? 
+                Object.fromEntries(
+                  Object.entries(this.headerTemplates).map(
+                    ([key, template]) => [key, template(job, jobTemplateOptions)]
+                  )
+                ) : undefined,
       body: this.bodyTemplate ? this.bodyTemplate(job, jobTemplateOptions) : undefined,
     });
 
@@ -94,7 +105,11 @@ export class URLAction<T> implements JobAction<T> {
       if(!isStringRecord(data.headers)) {
         throw new NotFoundException("Param 'headers' should map strings to strings");
       }
-      this.headerTemplates = Object.fromEntries(Object.entries(data.headers).map(([key, value]) => [key, Handlebars.compile(value)]));
+      this.headerTemplates = Object.fromEntries(
+        Object.entries(data.headers).map(
+          ([key, value]) => [key, Handlebars.compile(value)]
+        )
+      );
     }
     if (data["body"]) {
       this.bodyTemplate = Handlebars.compile(data["body"]);


### PR DESCRIPTION
Allow templates in URLAction body and headers.

Also adds a few useful handlebar templates, particularly `job_v3` which is a compatibility splint to massage v4 jobs into the old v3 schema when needed.