### PR TITLE
build: updated configuration for new FE datafiles actions

### DIFF
--- a/src/config/frontend.config.json
+++ b/src/config/frontend.config.json
@@ -2,21 +2,21 @@
   "accessTokenPrefix": "Bearer ",
   "addDatasetEnabled": false,
   "archiveWorkflowEnabled": false,
+  "datasetReduceEnabled": false,
   "datasetJsonScientificMetadata": true,
-  "datasetReduceEnabled": true,
   "editDatasetSampleEnabled": true,
   "editMetadataEnabled": true,
   "editPublishedData": false,
   "addSampleEnabled": false,
   "externalAuthEndpoint": "/api/v3/auth/msad",
-  "facility": "ESS",
-  "loginFacilityLabel": "ESS",
+  "facility": "SciCat Vanilla",
+  "siteIcon": "site-header-logo.png",
+  "loginFacilityLabel": "SciCat Vanilla",
   "loginLdapLabel": "Ldap",
   "loginLocalLabel": "Local",
   "loginFacilityEnabled": true,
   "loginLdapEnabled": true,
   "loginLocalEnabled": true,
-  "facilityLoginLabel": "ESS",
   "localLoginLabel": "Local",
   "fileColorEnabled": true,
   "fileDownloadEnabled": true,
@@ -24,9 +24,9 @@
   "ingestManual": null,
   "jobsEnabled": true,
   "jsonMetadataEnabled": true,
-  "jupyterHubUrl": "https://jupyterhub.esss.lu.se/",
+  "jupyterHubUrl": "",
   "landingPage": "doi.ess.eu/detail/",
-  "lbBaseURL": "",
+  "lbBaseURL": "http://127.0.0.1:3000",
   "localColumns": [
     {
       "name": "select",
@@ -112,7 +112,7 @@
   "maxDirectDownloadSize": 5000000000,
   "metadataPreviewEnabled": true,
   "metadataStructure": "",
-  "multipleDownloadAction": "https://scicatfileserver.esss.dk/zip",
+  "multipleDownloadAction": "http:/127.0.0.1:3012/zip",
   "multipleDownloadEnabled": true,
   "oAuth2Endpoints": [
     {
@@ -134,5 +134,51 @@
   "tableSciDataEnabled": true,
   "datasetDetailsShowMissingProposalId": false,
   "notificationInterceptorEnabled": true,
-  "metadataEditingUnitListDisabled": true
+  "metadataEditingUnitListDisabled": true,
+  "datafilesActionsEnabled" : true,
+  "datafilesActions" : [
+    {
+      "id" : "eed8efec-4354-11ef-a3b5-d75573a5d37f",
+      "order" : 4,
+      "label" : "Download All",
+      "files" : "all",
+      "mat_icon" : "download",
+      "url" : "",
+      "target" : "_blank",
+      "enabled" : "#SizeLimit",
+      "authorization" : ["#datasetAccess", "#datasetPublic" ]
+    },
+    {
+      "id" : "3072fafc-4363-11ef-b9f9-ebf568222d26",
+      "order" : 3,
+      "label" : "Download Selected",
+      "files" : "selected",
+      "mat_icon" : "download",
+      "url" : "",
+      "target" : "_blank",
+      "enabled" : "#Selected && #SizeLimit",
+      "authorization" : ["#datasetAccess", "#datasetPublic" ]
+    },
+    {
+      "id" : "4f974f0e-4364-11ef-9c63-03d19f813f4e",
+      "order" : 2,
+      "label" : "Notebook All",
+      "files" : "all",
+      "icon" : "/assets/icons/jupyter_logo.png",
+      "url" : "",
+      "target" : "_blank",
+      "authorization" : ["#datasetAccess", "#datasetPublic" ]
+    },
+    {
+      "id" : "fa3ce6ee-482d-11ef-95e9-ff2c80dd50bd",
+      "order" : 1,
+      "label" : "Notebook Selected",
+      "files" : "selected",
+      "icon" : "/assets/icons/jupyter_logo.png",
+      "url" : "",
+      "target" : "_blank",
+      "enabled" : "#Selected",
+      "authorization" : ["#datasetAccess", "#datasetPublic" ]
+    }
+  ]
 }


### PR DESCRIPTION
## Description

This PR updates the example files containing the FE configuration with the new keys needed for new FE datafiles actions.

## Motivation

In order to make the FE more flexible, [FE PR #1528](https://github.com/SciCatProject/frontend/pull/1528) adds configurable datafiles actions. I norder to be compatible with the new FE, the BE needs to have an updated FE configuration which contains such new keys

## Changes:
* src/config/frontend.config.json

## Tests included

- [ ] Included for each change/fix? NOT NEEDED. 
- [ ] Passing? (Merge will not be approved unless this is checked) NOT NEEDED

## Documentation
- [ ] swagger documentation updated \[required\] NOT NEEDED
- [ ] official documentation updated \[nice-to-have] NOT NEEDED

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included

Documentation added in the FE repo

