### PR TITLE
chore: enbaled datasetReduce in config

### DIFF
--- a/src/config/frontend.config.json
+++ b/src/config/frontend.config.json
@@ -2,7 +2,7 @@
   "accessTokenPrefix": "Bearer ",
   "addDatasetEnabled": false,
   "archiveWorkflowEnabled": false,
-  "datasetReduceEnabled": false,
+  "datasetReduceEnabled": true,
   "datasetJsonScientificMetadata": true,
   "editDatasetSampleEnabled": true,
   "editMetadataEnabled": true,
@@ -135,50 +135,50 @@
   "datasetDetailsShowMissingProposalId": false,
   "notificationInterceptorEnabled": true,
   "metadataEditingUnitListDisabled": true,
-  "datafilesActionsEnabled" : true,
-  "datafilesActions" : [
+  "datafilesActionsEnabled": true,
+  "datafilesActions": [
     {
-      "id" : "eed8efec-4354-11ef-a3b5-d75573a5d37f",
-      "order" : 4,
-      "label" : "Download All",
-      "files" : "all",
-      "mat_icon" : "download",
-      "url" : "",
-      "target" : "_blank",
-      "enabled" : "#SizeLimit",
-      "authorization" : ["#datasetAccess", "#datasetPublic" ]
+      "id": "eed8efec-4354-11ef-a3b5-d75573a5d37f",
+      "order": 4,
+      "label": "Download All",
+      "files": "all",
+      "mat_icon": "download",
+      "url": "",
+      "target": "_blank",
+      "enabled": "#SizeLimit",
+      "authorization": ["#datasetAccess", "#datasetPublic"]
     },
     {
-      "id" : "3072fafc-4363-11ef-b9f9-ebf568222d26",
-      "order" : 3,
-      "label" : "Download Selected",
-      "files" : "selected",
-      "mat_icon" : "download",
-      "url" : "",
-      "target" : "_blank",
-      "enabled" : "#Selected && #SizeLimit",
-      "authorization" : ["#datasetAccess", "#datasetPublic" ]
+      "id": "3072fafc-4363-11ef-b9f9-ebf568222d26",
+      "order": 3,
+      "label": "Download Selected",
+      "files": "selected",
+      "mat_icon": "download",
+      "url": "",
+      "target": "_blank",
+      "enabled": "#Selected && #SizeLimit",
+      "authorization": ["#datasetAccess", "#datasetPublic"]
     },
     {
-      "id" : "4f974f0e-4364-11ef-9c63-03d19f813f4e",
-      "order" : 2,
-      "label" : "Notebook All",
-      "files" : "all",
-      "icon" : "/assets/icons/jupyter_logo.png",
-      "url" : "",
-      "target" : "_blank",
-      "authorization" : ["#datasetAccess", "#datasetPublic" ]
+      "id": "4f974f0e-4364-11ef-9c63-03d19f813f4e",
+      "order": 2,
+      "label": "Notebook All",
+      "files": "all",
+      "icon": "/assets/icons/jupyter_logo.png",
+      "url": "",
+      "target": "_blank",
+      "authorization": ["#datasetAccess", "#datasetPublic"]
     },
     {
-      "id" : "fa3ce6ee-482d-11ef-95e9-ff2c80dd50bd",
-      "order" : 1,
-      "label" : "Notebook Selected",
-      "files" : "selected",
-      "icon" : "/assets/icons/jupyter_logo.png",
-      "url" : "",
-      "target" : "_blank",
-      "enabled" : "#Selected",
-      "authorization" : ["#datasetAccess", "#datasetPublic" ]
+      "id": "fa3ce6ee-482d-11ef-95e9-ff2c80dd50bd",
+      "order": 1,
+      "label": "Notebook Selected",
+      "files": "selected",
+      "icon": "/assets/icons/jupyter_logo.png",
+      "url": "",
+      "target": "_blank",
+      "enabled": "#Selected",
+      "authorization": ["#datasetAccess", "#datasetPublic"]
     }
   ]
 }


### PR DESCRIPTION
## Description

Enabled `datasetReduce` for default frontend config.

## Motivation

When disabled `datasetReduce`, the e2e case on the frontend for datasetReduce fails. 


## Changes:
src/config/frontend.config.json

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included


