### PR TITLE
remove nested structure in tests authorization

### DIFF
--- a/test/DatasetAuthorization.js
+++ b/test/DatasetAuthorization.js
@@ -45,71 +45,38 @@ describe("0300: DatasetAuthorization: Test access to dataset", () => {
   before(() => {
     db.collection("Dataset").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "user1",
-            password: TestData.Accounts["user1"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenUser1 = tokenVal;
-            utils.getToken(
-              appUrl,
-              {
-                username: "user2",
-                password: TestData.Accounts["user2"]["password"],
-              },
-              (tokenVal) => {
-                accessTokenUser2 = tokenVal;
-                utils.getToken(
-                  appUrl,
-                  {
-                    username: "user3",
-                    password: TestData.Accounts["user3"]["password"],
-                  },
-                  (tokenVal) => {
-                    accessTokenUser3 = tokenVal;
-                    utils.getToken(
-                      appUrl,
-                      {
-                        username: "archiveManager",
-                        password:
-                          TestData.Accounts["archiveManager"]["password"],
-                      },
-                      (tokenVal) => {
-                        accessTokenArchiveManager = tokenVal;
-                        utils.getToken(
-                          appUrl,
-                          {
-                            username: "admin",
-                            password: TestData.Accounts["admin"]["password"],
-                          },
-                          (tokenVal) => {
-                            accessTokenAdmin = tokenVal;
-                            done();
-                          },
-                        );
-                      },
-                    );
-                  },
-                );
-              },
-            );
-          },
-        );
-      },
-    );
-  });
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
 
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenUser2 = await utils.getToken(appUrl, {
+      username: "user2",
+      password: TestData.Accounts["user2"]["password"],
+    });
+
+    accessTokenUser3 = await utils.getToken(appUrl, {
+      username: "user3",
+      password: TestData.Accounts["user3"]["password"],
+    });
+
+    accessTokenAdmin = await utils.getToken(appUrl, {
+      username: "admin",
+      password: TestData.Accounts["admin"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
+  });
+  
   afterEach((done) => {
     sandbox.restore();
     done();

--- a/test/DatasetFilter.js
+++ b/test/DatasetFilter.js
@@ -96,59 +96,31 @@ describe("0400: DatasetFilter: Test retrieving datasets using filtering capabili
   before(() => {
     db.collection("Dataset").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "user1",
-            password: TestData.Accounts["user1"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenUser1 = tokenVal;
-            utils.getToken(
-              appUrl,
-              {
-                username: "user2",
-                password: TestData.Accounts["user2"]["password"],
-              },
-              (tokenVal) => {
-                accessTokenUser2 = tokenVal;
-                utils.getToken(
-                  appUrl,
-                  {
-                    username: "user3",
-                    password: TestData.Accounts["user2"]["password"],
-                  },
-                  (tokenVal) => {
-                    accessTokenUser3 = tokenVal;
-                    utils.getToken(
-                      appUrl,
-                      {
-                        username: "archiveManager",
-                        password:
-                          TestData.Accounts["archiveManager"]["password"],
-                      },
-                      (tokenVal) => {
-                        accessTokenArchiveManager = tokenVal;
-                        done();
-                      },
-                    );
-                  },
-                );
-              },
-            );
-          },
-        );
-      },
-    );
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenUser2 = await utils.getToken(appUrl, {
+      username: "user2",
+      password: TestData.Accounts["user2"]["password"],
+    });
+
+    accessTokenUser3 = await utils.getToken(appUrl, {
+      username: "user3",
+      password: TestData.Accounts["user3"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   afterEach((done) => {

--- a/test/DatasetLifecycle.js
+++ b/test/DatasetLifecycle.js
@@ -12,33 +12,22 @@ var pidRaw2 = null;
 var policyIds = null;
 const raw2 = { ...TestData.RawCorrect };
 
-describe("0500: DatasetLifecycle: Test facet and filter queries", () => {
+describe.only("0500: DatasetLifecycle: Test facet and filter queries", () => {
   before(() => {
     db.collection("Dataset").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "archiveManager",
-            password: TestData.Accounts["archiveManager"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenArchiveManager = tokenVal;
-            done();
-          },
-        );
-      },
-    );
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
+
 
   it("0010: adds a new raw dataset", async () => {
     return request(appUrl)

--- a/test/DatasetLifecycle.js
+++ b/test/DatasetLifecycle.js
@@ -12,7 +12,7 @@ var pidRaw2 = null;
 var policyIds = null;
 const raw2 = { ...TestData.RawCorrect };
 
-describe.only("0500: DatasetLifecycle: Test facet and filter queries", () => {
+describe("0500: DatasetLifecycle: Test facet and filter queries", () => {
   before(() => {
     db.collection("Dataset").deleteMany({});
   });

--- a/test/DatasetSimple.js
+++ b/test/DatasetSimple.js
@@ -16,28 +16,16 @@ describe("0200: Dataset Simple: Check different dataset types and their inherita
     db.collection("Dataset").deleteMany({});
   });
 
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "archiveManager",
-            password: TestData.Accounts["archiveManager"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenArchiveManager = tokenVal;
-            done();
-          },
-        );
-      },
-    );
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   function deleteDataset(item) {

--- a/test/DerivedDataset.js
+++ b/test/DerivedDataset.js
@@ -17,48 +17,26 @@ describe("0700: DerivedDataset: Derived Datasets", () => {
   before(() => {
     db.collection("Dataset").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "user1",
-            password: TestData.Accounts["user1"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenUser1 = tokenVal;
-            utils.getToken(
-              appUrl,
-              {
-                username: "user2",
-                password: TestData.Accounts["user2"]["password"],
-              },
-              (tokenVal) => {
-                accessTokenUser2 = tokenVal;
-                utils.getToken(
-                  appUrl,
-                  {
-                    username: "archiveManager",
-                    password: TestData.Accounts["archiveManager"]["password"],
-                  },
-                  (tokenVal) => {
-                    accessTokenArchiveManager = tokenVal;
-                    done();
-                  },
-                );
-              },
-            );
-          },
-        );
-      },
-    );
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenUser2 = await utils.getToken(appUrl, {
+      username: "user2",
+      password: TestData.Accounts["user2"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   async function deleteDataset(item) {

--- a/test/DerivedDatasetDatablock.js
+++ b/test/DerivedDatasetDatablock.js
@@ -10,11 +10,10 @@ describe("0750: DerivedDatasetDatablock: Test Datablocks and their relation to d
 
   let datablockId1 = null;
   let datablockId2 = null;
- 
+  before(() => {
+    db.collection("Dataset").deleteMany({});
+  });
   beforeEach(async() => {
-    before(() => {
-      db.collection("Dataset").deleteMany({});
-    });
     accessTokenAdminIngestor = await utils.getToken(appUrl, {
       username: "adminIngestor",
       password: TestData.Accounts["adminIngestor"]["password"],

--- a/test/DerivedDatasetDatablock.js
+++ b/test/DerivedDatasetDatablock.js
@@ -10,32 +10,20 @@ describe("0750: DerivedDatasetDatablock: Test Datablocks and their relation to d
 
   let datablockId1 = null;
   let datablockId2 = null;
-
-  beforeEach((done) => {
+ 
+  beforeEach(async() => {
     before(() => {
       db.collection("Dataset").deleteMany({});
     });
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "archiveManager",
-            password: TestData.Accounts["archiveManager"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenArchiveManager = tokenVal;
-            done();
-          },
-        );
-      },
-    );
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   it("0100:adds a new derived dataset", async () => {

--- a/test/DerivedDatasetOrigDatablock.js
+++ b/test/DerivedDatasetOrigDatablock.js
@@ -11,32 +11,20 @@ describe("0800: DerivedDatasetOrigDatablock: Test OrigDatablocks and their relat
   let origDatablockId1 = null;
   let origDatablockId2 = null;
 
-  beforeEach((done) => {
+  beforeEach(async() => {
     before(() => {
       db.collection("Dataset").deleteMany({});
       db.collection("OrigDatablock").deleteMany({});
     });
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "archiveManager",
-            password: TestData.Accounts["archiveManager"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenArchiveManager = tokenVal;
-            done();
-          },
-        );
-      },
-    );
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   it("0010: adds a new derived dataset", async () => {

--- a/test/DerivedDatasetOrigDatablock.js
+++ b/test/DerivedDatasetOrigDatablock.js
@@ -11,11 +11,11 @@ describe("0800: DerivedDatasetOrigDatablock: Test OrigDatablocks and their relat
   let origDatablockId1 = null;
   let origDatablockId2 = null;
 
+  before(() => {
+    db.collection("Dataset").deleteMany({});
+    db.collection("OrigDatablock").deleteMany({});
+  });
   beforeEach(async() => {
-    before(() => {
-      db.collection("Dataset").deleteMany({});
-      db.collection("OrigDatablock").deleteMany({});
-    });
     accessTokenAdminIngestor = await utils.getToken(appUrl, {
       username: "adminIngestor",
       password: TestData.Accounts["adminIngestor"]["password"],

--- a/test/ElasticSearch.js
+++ b/test/ElasticSearch.js
@@ -45,28 +45,16 @@ const scientificMetadata = (values) => {
     before(() => {
       db.collection("Dataset").deleteMany({});
     });
-    beforeEach((done) => {
-      utils.getToken(
-        appUrl,
-        {
-          username: "adminIngestor",
-          password: TestData.Accounts["adminIngestor"]["password"],
-        },
-        (tokenVal) => {
-          accessTokenAdminIngestor = tokenVal;
-          utils.getToken(
-            appUrl,
-            {
-              username: "archiveManager",
-              password: TestData.Accounts["archiveManager"]["password"],
-            },
-            (tokenVal) => {
-              accessTokenArchiveManager = tokenVal;
-              done();
-            },
-          );
-        },
-      );
+    beforeEach(async() => {
+      accessTokenAdminIngestor = await utils.getToken(appUrl, {
+        username: "adminIngestor",
+        password: TestData.Accounts["adminIngestor"]["password"],
+      });
+  
+      accessTokenArchiveManager = await utils.getToken(appUrl, {
+        username: "archiveManager",
+        password: TestData.Accounts["archiveManager"]["password"],
+      });
     });
 
     it("0010: adds a new raw dataset with scientificMetadata", async () => {

--- a/test/Instrument.js
+++ b/test/Instrument.js
@@ -20,38 +20,21 @@ describe("0900: Instrument: instrument management, creation, update, deletion an
   before(() => {
     db.collection("Instrument").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "archiveManager",
-            password: TestData.Accounts["archiveManager"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenArchiveManager = tokenVal;
-            utils.getToken(
-              appUrl,
-              {
-                username: "user1",
-                password: TestData.Accounts["user1"]["password"],
-              },
-              (tokenVal) => {
-                accessTokenUser1 = tokenVal;
-                done();
-              },
-            );
-          },
-        );
-      },
-    );
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   it("0010: adds new instrument #1 as ingestor", async () => {

--- a/test/InstrumentsFilter.js
+++ b/test/InstrumentsFilter.js
@@ -45,59 +45,31 @@ describe("1000: InstrumentFilter: Test retrieving instruments using filtering ca
   before(() => {
     db.collection("Instrument").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "user1",
-            password: TestData.Accounts["user1"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenUser1 = tokenVal;
-            utils.getToken(
-              appUrl,
-              {
-                username: "user2",
-                password: TestData.Accounts["user2"]["password"],
-              },
-              (tokenVal) => {
-                accessTokenUser2 = tokenVal;
-                utils.getToken(
-                  appUrl,
-                  {
-                    username: "user3",
-                    password: TestData.Accounts["user3"]["password"],
-                  },
-                  (tokenVal) => {
-                    accessTokenUser3 = tokenVal;
-                    utils.getToken(
-                      appUrl,
-                      {
-                        username: "archiveManager",
-                        password:
-                          TestData.Accounts["archiveManager"]["password"],
-                      },
-                      (tokenVal) => {
-                        accessTokenArchiveManager = tokenVal;
-                        done();
-                      },
-                    );
-                  },
-                );
-              },
-            );
-          },
-        );
-      },
-    );
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenUser2 = await utils.getToken(appUrl, {
+      username: "user2",
+      password: TestData.Accounts["user2"]["password"],
+    });
+
+    accessTokenUser3 = await utils.getToken(appUrl, {
+      username: "user3",
+      password: TestData.Accounts["user3"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   afterEach((done) => {

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -21,38 +21,46 @@ var publicJobIds = [];
 var origDatablockId = null;
 
 describe.skip("1100: Jobs: Test New Job Model", () => {
-  before((done) => {
+  before(() => {
     db.collection("Dataset").deleteMany({});
     db.collection("Job").deleteMany({});
-
-    archiveJob = { ...TestData.ArchiveJob };
-    retrieveJob = { ...TestData.RetrieveJob };
-    publicJob = { ...TestData.PublicJob };
-    done();
   });
 
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "archiveManager",
-            password: TestData.Accounts["archiveManager"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenArchiveManager = tokenVal;
-            done();
-          },
-        );
-      },
-    );
+  beforeEach(async () => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenUser3 = await utils.getToken(appUrl, {
+      username: "user3",
+      password: TestData.Accounts["user3"]["password"],
+    });
+
+    accessTokenUser51 = await utils.getToken(appUrl, {
+      username: "user5.1",
+      password: TestData.Accounts["user5.1"]["password"],
+    });
+
+    accessTokenUser52 = await utils.getToken(appUrl, {
+      username: "user5.2",
+      password: TestData.Accounts["user5.2"]["password"],
+    });
+
+    accessTokenAdmin = await utils.getToken(appUrl, {
+      username: "admin",
+      password: TestData.Accounts["admin"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   it("0010: adds a new raw dataset", async () => {

--- a/test/LoginUtils.js
+++ b/test/LoginUtils.js
@@ -1,31 +1,35 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 var request = require("supertest");
 
-exports.getToken = function (appUrl, user, cb) {
-  request(appUrl)
-    .post("/api/v3/Users/Login?include=user")
-    .send(user)
-    .set("Accept", "application/json")
-    .end((err, res) => {
-      if (err) {
-        cb(err);
-      } else {
-        cb(res.body.id);
-      }
-    });
+exports.getToken = function (appUrl, user) {
+  return new Promise((resolve, reject) => {
+    request(appUrl)
+      .post("/api/v3/Users/Login?include=user")
+      .send(user)
+      .set("Accept", "application/json")
+      .end((err, res) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(res.body.id);
+        }
+      });
+  });
 };
 
-exports.getIdAndToken = function (appUrl, user, cb) {
-  request(appUrl)
-    .post("/api/v3/Users/Login?include=user")
-    .send(user)
-    .set("Accept", "application/json")
-    .end((err, res) => {
-      if (err) {
-        cb(err);
-      } else {
-        cb(res.body.userId, res.body.id);
-      }
+exports.getIdAndToken = function (appUrl, user) {
+  return new Promise((resolve, reject) => {
+    request(appUrl)
+      .post("/api/v3/Users/Login?include=user")
+      .send(user)
+      .set("Accept", "application/json")
+      .end((err, res) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve({userId:res.body.userId,  token:res.body.id});
+        }
+      });
     });
 };
 

--- a/test/OrigDatablockForRawDataset.js
+++ b/test/OrigDatablockForRawDataset.js
@@ -23,28 +23,16 @@ describe("1200: OrigDatablockForRawDataset: Test OrigDatablocks and their relati
     db.collection("Dataset").deleteMany({});
     db.collection("OrigDatablock").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "archiveManager",
-            password: TestData.Accounts["archiveManager"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenArchiveManager = tokenVal;
-            done();
-          },
-        );
-      },
-    );
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
 
     origDatablockData1 = {
       ...TestData.OrigDataBlockCorrect1,

--- a/test/Policy.js
+++ b/test/Policy.js
@@ -25,30 +25,18 @@ describe("1300: Policy: Simple Policy tests", () => {
   before(() => {
     db.collection("Policy").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "archiveManager",
-            password: TestData.Accounts["archiveManager"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenArchiveManager = tokenVal;
-            done();
-          },
-        );
-      },
-    );
-  });
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
 
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
+  });
+  
   it("0010: adds a new policy", async () => {
     return request(appUrl)
       .post("/api/v3/Policies")

--- a/test/Proposal.js
+++ b/test/Proposal.js
@@ -15,38 +15,21 @@ describe("1500: Proposal: Simple Proposal", () => {
   before(() => {
     db.collection("Proposal").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "proposalIngestor",
-        password: TestData.Accounts["proposalIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenProposalIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "adminIngestor",
-            password: TestData.Accounts["adminIngestor"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenAdminIngestor = tokenVal;
-            utils.getToken(
-              appUrl,
-              {
-                username: "archiveManager",
-                password: TestData.Accounts["archiveManager"]["password"],
-              },
-              (tokenVal) => {
-                accessTokenArchiveManager = tokenVal;
-                done();
-              },
-            );
-          },
-        );
-      },
-    );
+  beforeEach(async() => {
+    accessTokenProposalIngestor = await utils.getToken(appUrl, {
+      username: "proposalIngestor",
+      password: TestData.Accounts["proposalIngestor"]["password"],
+    });
+
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   // the following two function definition prepare for

--- a/test/ProposalAuthorization.js
+++ b/test/ProposalAuthorization.js
@@ -9,7 +9,7 @@ let accessTokenProposalIngestor = null,
   accessTokenArchiveManager = null,
   accessTokenAdminIngestor = null,
   accessTokenUser1 = null,
-  accessTokenUser2 = null;
+  accessTokenUser3 = null;
 
 let proposalPid1 = null,
   encodedProposalPid1 = null,
@@ -53,60 +53,31 @@ describe("1400: ProposalAuthorization: Test access to proposal", () => {
   before(() => {
     db.collection("Proposal").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
 
-        utils.getToken(
-          appUrl,
-          {
-            username: "proposalIngestor",
-            password: TestData.Accounts["proposalIngestor"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenProposalIngestor = tokenVal;
-            utils.getToken(
-              appUrl,
-              {
-                username: "user1",
-                password: TestData.Accounts["user1"]["password"],
-              },
-              (tokenVal) => {
-                accessTokenUser1 = tokenVal;
-                utils.getToken(
-                  appUrl,
-                  {
-                    username: "user3",
-                    password: TestData.Accounts["user3"]["password"],
-                  },
-                  (tokenVal) => {
-                    accessTokenUser2 = tokenVal;
-                    utils.getToken(
-                      appUrl,
-                      {
-                        username: "archiveManager",
-                        password:
-                          TestData.Accounts["archiveManager"]["password"],
-                      },
-                      (tokenVal) => {
-                        accessTokenArchiveManager = tokenVal;
-                        done();
-                      },
-                    );
-                  },
-                );
-              },
-            );
-          },
-        );
-      },
-    );
+    accessTokenProposalIngestor = await utils.getToken(appUrl, {
+      username: "proposalIngestor",
+      password: TestData.Accounts["proposalIngestor"]["password"],
+    });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenUser3 = await utils.getToken(appUrl, {
+      username: "user3",
+      password: TestData.Accounts["user3"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   afterEach((done) => {
@@ -386,7 +357,7 @@ describe("1400: ProposalAuthorization: Test access to proposal", () => {
     return request(appUrl)
       .get("/api/v3/proposals")
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenUser2}` })
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
@@ -399,7 +370,7 @@ describe("1400: ProposalAuthorization: Test access to proposal", () => {
     return request(appUrl)
       .get("/api/v3/proposals/" + encodedProposalPid1)
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenUser2}` })
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
       .expect("Content-Type", /json/)
       .expect(TestData.AccessForbiddenStatusCode);
   });
@@ -408,7 +379,7 @@ describe("1400: ProposalAuthorization: Test access to proposal", () => {
     return request(appUrl)
       .get("/api/v3/proposals/" + encodedProposalPid1 + "/authorization")
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenUser2}` })
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
       .expect("Content-Type", /json/)
       .expect(TestData.SuccessfulGetStatusCode)
       .then((res) => {
@@ -420,7 +391,7 @@ describe("1400: ProposalAuthorization: Test access to proposal", () => {
     return request(appUrl)
       .get("/api/v3/proposals/" + encodedProposalPid2)
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenUser2}` })
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
       .expect("Content-Type", /json/)
       .expect(TestData.SuccessfulGetStatusCode)
       .then((res) => {
@@ -432,7 +403,7 @@ describe("1400: ProposalAuthorization: Test access to proposal", () => {
     return request(appUrl)
       .get("/api/v3/proposals/" + encodedProposalPid2 + "/authorization")
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenUser2}` })
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
       .expect("Content-Type", /json/)
       .expect(TestData.SuccessfulGetStatusCode)
       .then((res) => {
@@ -444,7 +415,7 @@ describe("1400: ProposalAuthorization: Test access to proposal", () => {
     return request(appUrl)
       .get("/api/v3/proposals/" + encodedProposalPid3)
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenUser2}` })
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
       .expect("Content-Type", /json/)
       .expect(TestData.SuccessfulGetStatusCode)
       .then((res) => {
@@ -456,7 +427,7 @@ describe("1400: ProposalAuthorization: Test access to proposal", () => {
     return request(appUrl)
       .get("/api/v3/proposals/" + encodedProposalPid3 + "/authorization")
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenUser2}` })
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
       .expect("Content-Type", /json/)
       .expect(TestData.SuccessfulGetStatusCode)
       .then((res) => {
@@ -468,7 +439,7 @@ describe("1400: ProposalAuthorization: Test access to proposal", () => {
     return request(appUrl)
       .get("/api/v3/proposals/fullquery")
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenUser2}` })
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
@@ -482,7 +453,7 @@ describe("1400: ProposalAuthorization: Test access to proposal", () => {
     return request(appUrl)
       .get(`/api/v3/proposals/fullfacet`)
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenUser2}` })
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {

--- a/test/PublishedData.js
+++ b/test/PublishedData.js
@@ -38,28 +38,16 @@ describe("1600: PublishedData: Test of access to published data", () => {
     db.collection("Dataset").deleteMany({});
     db.collection("PublishedData").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "archiveManager",
-            password: TestData.Accounts["archiveManager"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenArchiveManager = tokenVal;
-            done();
-          },
-        );
-      },
-    );
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   afterEach((done) => {

--- a/test/RandomizedDatasetPermissions.js
+++ b/test/RandomizedDatasetPermissions.js
@@ -188,61 +188,33 @@ describe("1700: Randomized Datasets: permission test with bigger amount of data"
   before(() => {
     db.collection("Dataset").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "user1",
-            password: TestData.Accounts["user1"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenUser1 = tokenVal;
-            utils.getToken(
-              appUrl,
-              {
-                username: "user2",
-                password: TestData.Accounts["user2"]["password"],
-              },
-              (tokenVal) => {
-                accessTokenUser2 = tokenVal;
-                utils.getToken(
-                  appUrl,
-                  {
-                    username: "user3",
-                    password: TestData.Accounts["user3"]["password"],
-                  },
-                  (tokenVal) => {
-                    accessTokenUser3 = tokenVal;
-                    utils.getToken(
-                      appUrl,
-                      {
-                        username: "archiveManager",
-                        password:
-                          TestData.Accounts["archiveManager"]["password"],
-                      },
-                      (tokenVal) => {
-                        accessTokenArchiveManager = tokenVal;
-                        done();
-                      },
-                    );
-                  },
-                );
-              },
-            );
-          },
-        );
-      },
-    );
-  });
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
 
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenUser2 = await utils.getToken(appUrl, {
+      username: "user2",
+      password: TestData.Accounts["user2"]["password"],
+    });
+
+    accessTokenUser3 = await utils.getToken(appUrl, {
+      username: "user3",
+      password: TestData.Accounts["user3"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
+  });
+  
   it("0010: access private dataset as unauthenticated user", async () => {
     await addAllDatasets();
     const randomGroup = randomIntFromInterval(1, 4);

--- a/test/RawDataset.js
+++ b/test/RawDataset.js
@@ -18,38 +18,21 @@ describe("1900: RawDataset: Raw Datasets", () => {
     db.collection("Dataset").deleteMany({});
     db.collection("Proposals").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "proposalIngestor",
-            password: TestData.Accounts["proposalIngestor"]["password"],
-          },
-          (tokenVal) => {
-            accessProposalToken = tokenVal;
-            utils.getToken(
-              appUrl,
-              {
-                username: "archiveManager",
-                password: TestData.Accounts["archiveManager"]["password"],
-              },
-              (tokenVal) => {
-                accessTokenArchiveManager = tokenVal;
-                done();
-              },
-            );
-          },
-        );
-      },
-    );
+  beforeEach(async() => {
+    accessProposalToken = await utils.getToken(appUrl, {
+      username: "proposalIngestor",
+      password: TestData.Accounts["proposalIngestor"]["password"],
+    });
+
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   it("0010: adds a new proposal", async () => {

--- a/test/RawDatasetDatablock.js
+++ b/test/RawDatasetDatablock.js
@@ -10,31 +10,19 @@ describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw D
   var datablockId = null;
   var datablockId2 = null;
 
-  beforeEach((done) => {
+  beforeEach(async() => {
     before(() => {
       db.collection("Dataset").deleteMany({});
     });
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "archiveManager",
-            password: TestData.Accounts["archiveManager"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenArchiveManager = tokenVal;
-            done();
-          },
-        );
-      },
-    );
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   it("0010: adds a new raw dataset", async () => {

--- a/test/RawDatasetDatablock.js
+++ b/test/RawDatasetDatablock.js
@@ -9,11 +9,11 @@ describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw D
   var datasetPid = null;
   var datablockId = null;
   var datablockId2 = null;
-
+  
+  before(() => {
+    db.collection("Dataset").deleteMany({});
+  });
   beforeEach(async() => {
-    before(() => {
-      db.collection("Dataset").deleteMany({});
-    });
     accessTokenAdminIngestor = await utils.getToken(appUrl, {
       username: "adminIngestor",
       password: TestData.Accounts["adminIngestor"]["password"],

--- a/test/RawDatasetOrigDatablock.js
+++ b/test/RawDatasetOrigDatablock.js
@@ -14,11 +14,11 @@ describe("2000: RawDatasetOrigDatablock: Test OrigDatablocks and their relation 
     origDatablockWithEmptyChkAlg = null,
     origDatablockWithValidChkAlg = null;
 
-  beforeEach(async() => {
     before(() => {
       db.collection("Dataset").deleteMany({});
       db.collection("OrigDatablock").deleteMany({});
     });
+  beforeEach(async() => {
     accessTokenAdminIngestor = await utils.getToken(appUrl, {
       username: "adminIngestor",
       password: TestData.Accounts["adminIngestor"]["password"],

--- a/test/RawDatasetOrigDatablock.js
+++ b/test/RawDatasetOrigDatablock.js
@@ -14,10 +14,10 @@ describe("2000: RawDatasetOrigDatablock: Test OrigDatablocks and their relation 
     origDatablockWithEmptyChkAlg = null,
     origDatablockWithValidChkAlg = null;
 
-    before(() => {
-      db.collection("Dataset").deleteMany({});
-      db.collection("OrigDatablock").deleteMany({});
-    });
+  before(() => {
+    db.collection("Dataset").deleteMany({});
+    db.collection("OrigDatablock").deleteMany({});
+  });
   beforeEach(async() => {
     accessTokenAdminIngestor = await utils.getToken(appUrl, {
       username: "adminIngestor",

--- a/test/RawDatasetOrigDatablock.js
+++ b/test/RawDatasetOrigDatablock.js
@@ -14,32 +14,20 @@ describe("2000: RawDatasetOrigDatablock: Test OrigDatablocks and their relation 
     origDatablockWithEmptyChkAlg = null,
     origDatablockWithValidChkAlg = null;
 
-  beforeEach((done) => {
+  beforeEach(async() => {
     before(() => {
       db.collection("Dataset").deleteMany({});
       db.collection("OrigDatablock").deleteMany({});
     });
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "archiveManager",
-            password: TestData.Accounts["archiveManager"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenArchiveManager = tokenVal;
-            done();
-          },
-        );
-      },
-    );
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
 
     origDatablockData1 = { ...TestData.OrigDataBlockCorrect1 };
     origDatablockData2 = { ...TestData.OrigDataBlockCorrect2 };

--- a/test/ResetDataset.js
+++ b/test/ResetDataset.js
@@ -150,28 +150,16 @@ var foundId1 = null;
 var foundId2 = null;
 
 describe("2100: ResetDataset: Create Dataset and its Datablocks, then reset Datablocks and embedded Datasetlifecycle status", () => {
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "archiveManager",
-            password: TestData.Accounts["archiveManager"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenArchiveManager = tokenVal;
-            done();
-          },
-        );
-      },
-    );
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   // first get existing datasets with the test archieId to allow to delete them

--- a/test/Sample.js
+++ b/test/Sample.js
@@ -14,29 +14,17 @@ describe("2200: Sample: Simple Sample", () => {
   before(() => {
     db.collection("Sample").deleteMany({});
     db.collection("Dataset").deleteMany({});
-  });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "archiveManager",
-            password: TestData.Accounts["archiveManager"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenArchiveManager = tokenVal;
-            done();
-          },
-        );
-      },
-    );
+  });  
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
   });
 
   it("0010: adds a new sample", async () => {

--- a/test/SampleAuthorization.js
+++ b/test/SampleAuthorization.js
@@ -39,93 +39,47 @@ describe("2250: Sample Authorization", () => {
   before(() => {
     db.collection("Sample").deleteMany({});
   });
-  beforeEach((done) => {
-    utils.getToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        utils.getToken(
-          appUrl,
-          {
-            username: "sampleIngestor",
-            password: TestData.Accounts["sampleIngestor"]["password"],
-          },
-          (tokenVal) => {
-            accessTokenSampleIngestor = tokenVal;
-            utils.getToken(
-              appUrl,
-              {
-                username: "user1",
-                password: TestData.Accounts["user1"]["password"],
-              },
-              (tokenVal) => {
-                accessTokenUser1 = tokenVal;
-                utils.getToken(
-                  appUrl,
-                  {
-                    username: "user2",
-                    password: TestData.Accounts["user2"]["password"],
-                  },
-                  (tokenVal) => {
-                    accessTokenUser2 = tokenVal;
-                    utils.getToken(
-                      appUrl,
-                      {
-                        username: "archiveManager",
-                        password:
-                          TestData.Accounts["archiveManager"]["password"],
-                      },
-                      (tokenVal) => {
-                        accessTokenArchiveManager = tokenVal;
-                        utils.getToken(
-                          appUrl,
-                          {
-                            username: "user3",
-                            password: TestData.Accounts["user3"]["password"],
-                          },
-                          (tokenVal) => {
-                            accessTokenUser3 = tokenVal;
-                            utils.getToken(
-                              appUrl,
-                              {
-                                username: "user4",
-                                password:
-                                  TestData.Accounts["user4"]["password"],
-                              },
-                              (tokenVal) => {
-                                accessTokenUser4 = tokenVal;
-                                utils.getToken(
-                                  appUrl,
-                                  {
-                                    username: "user5.1",
-                                    password:
-                                      TestData.Accounts["user5.1"]["password"],
-                                  },
-                                  (tokenVal) => {
-                                    accessTokenUser5 = tokenVal;
-                                    done();
-                                  },
-                                );
-                              },
-                            );
-                          },
-                        );
-                      },
-                    );
-                  },
-                );
-              },
-            );
-          },
-        );
-      },
-    );
-  });
+  beforeEach(async() => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
 
+    accessTokenSampleIngestor = await utils.getToken(appUrl, {
+      username: "sampleIngestor",
+      password: TestData.Accounts["sampleIngestor"]["password"],
+    });
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenUser2 = await utils.getToken(appUrl, {
+      username: "user2",
+      password: TestData.Accounts["user2"]["password"],
+    });
+
+    accessTokenUser3 = await utils.getToken(appUrl, {
+      username: "user3",
+      password: TestData.Accounts["user3"]["password"],
+    });
+
+    accessTokenUser4 = await utils.getToken(appUrl, {
+      username: "user4",
+      password: TestData.Accounts["user4"]["password"],
+    });
+
+    accessTokenUser5 = await utils.getToken(appUrl, {
+      username: "user5.1",
+      password: TestData.Accounts["user5.1"]["password"],
+    });
+
+    accessTokenArchiveManager = await utils.getToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
+  });
+  
   it("0010: adds sample 1 as Admin Ingestor with owner group its own group", async () => {
     let sample = {
       ...TestData.SampleCorrect,

--- a/test/UserAuthorization.js
+++ b/test/UserAuthorization.js
@@ -26,22 +26,22 @@ describe("2300: User Authorization: test that user authorization are correct", (
       username: "adminIngestor",
       password: TestData.Accounts["adminIngestor"]["password"],
     });
-    userIdIngestor = loginResponseIngestor.userId
-    accessTokenAdminIngestor = loginResponseIngestor.token
+    userIdIngestor = loginResponseIngestor.userId;
+    accessTokenAdminIngestor = loginResponseIngestor.token;
 
     const loginResponseUser1 = await utils.getIdAndToken(appUrl, {
       username: "user1",
       password: TestData.Accounts["user1"]["password"],
     });
-    userIdUser1 = loginResponseUser1.userId
-    accessTokenUser1  = loginResponseUser1.token
+    userIdUser1 = loginResponseUser1.userId;
+    accessTokenUser1  = loginResponseUser1.token;
 
     const loginResponseUser2 = await utils.getIdAndToken(appUrl, {
       username: "user2",
       password: TestData.Accounts["user2"]["password"],
     });
-    userIdUser2 = loginResponseUser2.userId
-    accessTokenUser2 = loginResponseUser2.token
+    userIdUser2 = loginResponseUser2.userId;
+    accessTokenUser2 = loginResponseUser2.token;
 
     const loginResponseUser3 = await utils.getIdAndToken(appUrl, {
       username: "user3",
@@ -54,22 +54,22 @@ describe("2300: User Authorization: test that user authorization are correct", (
       username: "user4",
       password: TestData.Accounts["user4"]["password"],
     });
-    userIdUser4 = loginResponseUser4.userId
-    accessTokenUser4 = loginResponseUser4.token
+    userIdUser4 = loginResponseUser4.userId;
+    accessTokenUser4 = loginResponseUser4.token;
     
     const loginResponseAdmin = await utils.getIdAndToken(appUrl, {
       username: "admin",
       password: TestData.Accounts["admin"]["password"],
     });
-    userIdAdmin = loginResponseAdmin.userId
-    accessTokenAdmin = loginResponseAdmin.token
+    userIdAdmin = loginResponseAdmin.userId;
+    accessTokenAdmin = loginResponseAdmin.token;
 
     const loginResponseArchiveManager = await utils.getIdAndToken(appUrl, {
       username: "archiveManager",
       password: TestData.Accounts["archiveManager"]["password"],
     });
-    userIdArchiveManager = loginResponseArchiveManager.userId
-    accessTokenArchiveManager = loginResponseArchiveManager.token
+    userIdArchiveManager = loginResponseArchiveManager.userId;
+    accessTokenArchiveManager = loginResponseArchiveManager.token;
   });
   
   afterEach((done) => {

--- a/test/UserAuthorization.js
+++ b/test/UserAuthorization.js
@@ -21,87 +21,57 @@ let accessTokenAdminIngestor = null,
   userIdArchiveManager = null;
 
 describe("2300: User Authorization: test that user authorization are correct", () => {
-  beforeEach((done) => {
-    utils.getIdAndToken(
-      appUrl,
-      {
-        username: "adminIngestor",
-        password: TestData.Accounts["adminIngestor"]["password"],
-      },
-      (idVal, tokenVal) => {
-        accessTokenAdminIngestor = tokenVal;
-        userIdIngestor = idVal;
-        utils.getIdAndToken(
-          appUrl,
-          {
-            username: "user1",
-            password: TestData.Accounts["user1"]["password"],
-          },
-          (idVal, tokenVal) => {
-            accessTokenUser1 = tokenVal;
-            userIdUser1 = idVal;
-            utils.getIdAndToken(
-              appUrl,
-              {
-                username: "user2",
-                password: TestData.Accounts["user2"]["password"],
-              },
-              (idVal, tokenVal) => {
-                accessTokenUser2 = tokenVal;
-                userIdUser2 = idVal;
-                utils.getIdAndToken(
-                  appUrl,
-                  {
-                    username: "user3",
-                    password: TestData.Accounts["user3"]["password"],
-                  },
-                  (idVal, tokenVal) => {
-                    accessTokenUser3 = tokenVal;
-                    userIdUser3 = idVal;
-                    utils.getIdAndToken(
-                      appUrl,
-                      {
-                        username: "user4",
-                        password: TestData.Accounts["user4"]["password"],
-                      },
-                      (idVal, tokenVal) => {
-                        accessTokenUser4 = tokenVal;
-                        userIdUser4 = idVal;
-                        utils.getIdAndToken(
-                          appUrl,
-                          {
-                            username: "archiveManager",
-                            password: TestData.Accounts["archiveManager"]["password"],
-                          },
-                          (idVal, tokenVal) => {
-                            accessTokenArchiveManager = tokenVal;
-                            userIdArchiveManager = idVal;
-                            utils.getIdAndToken(
-                              appUrl,
-                              {
-                                username: "admin",
-                                password: TestData.Accounts["admin"]["password"],
-                              },
-                              (idVal, tokenVal) => {
-                                accessTokenAdmin = tokenVal;
-                                userIdAdmin = idVal;
-                                done();
-                              },
-                            );
-                          },
-                        );
-                      },
-                    );
-                  },
-                );
-              },
-            );
-          },
-        );
-      },
-    );
-  });
+  beforeEach(async() => {
+    const loginResponseIngestor = await utils.getIdAndToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+    userIdIngestor = loginResponseIngestor.userId
+    accessTokenAdminIngestor = loginResponseIngestor.token
 
+    const loginResponseUser1 = await utils.getIdAndToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+    userIdUser1 = loginResponseUser1.userId
+    accessTokenUser1  = loginResponseUser1.token
+
+    const loginResponseUser2 = await utils.getIdAndToken(appUrl, {
+      username: "user2",
+      password: TestData.Accounts["user2"]["password"],
+    });
+    userIdUser2 = loginResponseUser2.userId
+    accessTokenUser2 = loginResponseUser2.token
+
+    const loginResponseUser3 = await utils.getIdAndToken(appUrl, {
+      username: "user3",
+      password: TestData.Accounts["user3"]["password"],
+    });
+    userIdUser3 = loginResponseUser3.userId
+    accessTokenUser3 = loginResponseUser3.token
+
+    const loginResponseUser4 = await utils.getIdAndToken(appUrl, {
+      username: "user4",
+      password: TestData.Accounts["user4"]["password"],
+    });
+    userIdUser4 = loginResponseUser4.userId
+    accessTokenUser4 = loginResponseUser4.token
+    
+    const loginResponseAdmin = await utils.getIdAndToken(appUrl, {
+      username: "admin",
+      password: TestData.Accounts["admin"]["password"],
+    });
+    userIdAdmin = loginResponseAdmin.userId
+    accessTokenAdmin = loginResponseAdmin.token
+
+    const loginResponseArchiveManager = await utils.getIdAndToken(appUrl, {
+      username: "archiveManager",
+      password: TestData.Accounts["archiveManager"]["password"],
+    });
+    userIdArchiveManager = loginResponseArchiveManager.userId
+    accessTokenArchiveManager = loginResponseArchiveManager.token
+  });
+  
   afterEach((done) => {
     sandbox.restore();
     done();

--- a/test/Users.js
+++ b/test/Users.js
@@ -38,19 +38,13 @@ describe("2350: Users: Login with functional accounts", () => {
 });
 
 describe("2360: Users settings", () => {
-  beforeEach((done) => {
-    utils.getIdAndToken(
-      appUrl,
-      {
-        username: "user1",
-        password: TestData.Accounts["user1"]["password"],
-      },
-      (idVal, tokenVal) => {
-        accessTokenUser1 = tokenVal;
-        userIdUser1 = idVal;
-        done();
-      },
-    );
+  beforeEach(async() => {
+    const loginResponseUser1 = await utils.getIdAndToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+    userIdUser1 = loginResponseUser1.userId
+    accessTokenUser1  = loginResponseUser1.token
   });
 
   it("0010: Update users settings with valid value should sucess ", async () => {

--- a/test/Users.js
+++ b/test/Users.js
@@ -43,8 +43,8 @@ describe("2360: Users settings", () => {
       username: "user1",
       password: TestData.Accounts["user1"]["password"],
     });
-    userIdUser1 = loginResponseUser1.userId
-    accessTokenUser1  = loginResponseUser1.token
+    userIdUser1 = loginResponseUser1.userId;
+    accessTokenUser1  = loginResponseUser1.token;
   });
 
   it("0010: Update users settings with valid value should sucess ", async () => {


### PR DESCRIPTION
## Description

As commented by @sbliven in PR #1286, the extraction of token for each user is implemented within a very nested structure. This PR removes nested structure

## Motivation

Improve readability of extraction of authorization token


## Changes:
almost all test/*.js 

* test/LoginUtils.js: the first two functions `getToken` and `getIdAndToken` are rewritten to return a promise. 
* in the rest of test files the pyramid structure is replaced by async mechanism to retrieve the authorization token

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

