### PR TITLE
Validate actions during their creation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,5 +178,5 @@ jobs:
         run: |
           cp CI/ESS/docker-compose.api.yaml docker-compose.yaml
           cp functionalAccounts.json.test functionalAccounts.json
-          docker-compose up --build -d
+          docker compose up --build -d
           npm run test:api

--- a/src/jobs/actions/emailaction.ts
+++ b/src/jobs/actions/emailaction.ts
@@ -65,13 +65,6 @@ export class EmailJobAction<T> implements JobAction<T> {
     this.bodyTemplate = compile(data["body"]);
   }
 
-  async validate(dto: T) {
-    Logger.log(
-      "Validating EmailJobAction: " + JSON.stringify(dto),
-      "EmailJobAction",
-    );
-  }
-
   async performJob(job: JobClass) {
     Logger.log(
       "Performing EmailJobAction: " + JSON.stringify(job),

--- a/src/jobs/actions/logaction.ts
+++ b/src/jobs/actions/logaction.ts
@@ -14,10 +14,6 @@ export class LogJobAction<T> implements JobAction<T> {
     return LogJobAction.actionType;
   }
 
-  async validate(dto: T) {
-    Logger.log("Validating job: " + JSON.stringify(dto), "LogJobAction");
-  }
-
   async performJob(job: JobClass) {
     Logger.log("Performing job: " + JSON.stringify(job), "LogJobAction");
   }

--- a/src/jobs/actions/rabbitmqaction.ts
+++ b/src/jobs/actions/rabbitmqaction.ts
@@ -54,9 +54,6 @@ export class RabbitMQJobAction<T> implements JobAction<T> {
     return RabbitMQJobAction.actionType;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async validate(dto: T) {}
-
   async performJob(job: JobClass) {
     Logger.log(
       "Performing RabbitMQJobAction: " + JSON.stringify(job),

--- a/src/jobs/actions/urlaction.ts
+++ b/src/jobs/actions/urlaction.ts
@@ -52,12 +52,9 @@ export class URLAction<T> implements JobAction<T> {
     return URLAction.actionType;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async validate(dto: T) {}
-
   async performJob(job: JobClass) {
     const url = encodeURI(this.urlTemplate(job, jobTemplateOptions));
-    Logger.log(`Requesting ${url}`, "URLAction");
+    Logger.log(`Requesting ${url}`, "UrlJobAction");
 
     const response = await fetch(url, {
       method: this.method,
@@ -74,7 +71,7 @@ export class URLAction<T> implements JobAction<T> {
         : undefined,
     });
 
-    Logger.log(`Request for ${url} returned ${response.status}`, "URLAction");
+    Logger.log(`Request for ${url} returned ${response.status}`, "UrlJobAction");
     if (!response.ok) {
       throw new HttpException(
         {
@@ -101,13 +98,20 @@ export class URLAction<T> implements JobAction<T> {
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   constructor(data: Record<string, any>) {
+    Logger.log(
+      "Initializing UrlJobAction. Params: " + JSON.stringify(data),
+      "UrlJobAction",
+    );
+
     if (!data["url"]) {
       throw new NotFoundException("Param 'url' is undefined in url action");
     }
     this.urlTemplate = Handlebars.compile(data.url);
+
     if (data["method"]) {
       this.method = data.method;
     }
+
     if (data["headers"]) {
       if (!isStringRecord(data.headers)) {
         throw new NotFoundException(
@@ -121,6 +125,7 @@ export class URLAction<T> implements JobAction<T> {
         ]),
       );
     }
+
     if (data["body"]) {
       this.bodyTemplate = Handlebars.compile(data["body"]);
     }

--- a/src/jobs/actions/urlaction.ts
+++ b/src/jobs/actions/urlaction.ts
@@ -73,7 +73,7 @@ export class URLAction<T> implements JobAction<T> {
 
     Logger.log(
       `Request for ${url} returned ${response.status}`,
-      "UrlJobAction"
+      "UrlJobAction",
     );
 
     if (!response.ok) {

--- a/src/jobs/actions/urlaction.ts
+++ b/src/jobs/actions/urlaction.ts
@@ -71,7 +71,11 @@ export class URLAction<T> implements JobAction<T> {
         : undefined,
     });
 
-    Logger.log(`Request for ${url} returned ${response.status}`, "UrlJobAction");
+    Logger.log(
+      `Request for ${url} returned ${response.status}`,
+      "UrlJobAction"
+    );
+
     if (!response.ok) {
       throw new HttpException(
         {

--- a/src/jobs/config/jobconfig.spec.ts
+++ b/src/jobs/config/jobconfig.spec.ts
@@ -22,6 +22,6 @@ describe("Job configuration", () => {
     const action = create.actions[0];
     expect(action instanceof LogJobAction);
     expect(action.getActionType()).toBe("log");
-    action.validate({ config: null });
+    // action.validate({ config: null });
   });
 });

--- a/src/jobs/config/jobconfig.ts
+++ b/src/jobs/config/jobconfig.ts
@@ -155,11 +155,6 @@ function parseAction<DtoType>(
  */
 export interface JobAction<DtoType> {
   /**
-   * Validate the DTO, throwing an HttpException for problems
-   */
-  validate: (dto: DtoType) => Promise<void>;
-
-  /**
    * Respond to the action
    */
   performJob: (job: JobClass) => Promise<void>;

--- a/src/jobs/interceptors/job-create.interceptor.ts
+++ b/src/jobs/interceptors/job-create.interceptor.ts
@@ -60,21 +60,21 @@ export class JobCreateInterceptor implements NestInterceptor {
 
     // await Promise.all(
     //   jc.create.actions.map((action) => {
-        // return action.validate(createJobDto).catch((err) => {
-        //   Logger.error(err);
-        //   if (err instanceof HttpException) {
-        //     throw err;
-        //   }
-        //   throw new HttpException(
-        //     {
-        //       status: HttpStatus.BAD_REQUEST,
-        //       message: `Invalid job input. Action ${action.getActionType()} unable to validate ${
-        //         createJobDto.type
-        //       } job due to ${err}`,
-        //     },
-        //     HttpStatus.BAD_REQUEST,
-        //   );
-        // });
+    //     return action.validate(createJobDto).catch((err) => {
+    //       Logger.error(err);
+    //       if (err instanceof HttpException) {
+    //         throw err;
+    //       }
+    //       throw new HttpException(
+    //         {
+    //           status: HttpStatus.BAD_REQUEST,
+    //           message: `Invalid job input. Action ${action.getActionType()} unable to validate ${
+    //             createJobDto.type
+    //           } job due to ${err}`,
+    //         },
+    //         HttpStatus.BAD_REQUEST,
+    //       );
+    //     });
     //   }),
     // );
 

--- a/src/jobs/interceptors/job-create.interceptor.ts
+++ b/src/jobs/interceptors/job-create.interceptor.ts
@@ -58,14 +58,13 @@ export class JobCreateInterceptor implements NestInterceptor {
     }
     const jc = matchingConfig[0];
 
-    await Promise.all(
-      jc.create.actions.map((action) => {
+    // await Promise.all(
+    //   jc.create.actions.map((action) => {
         // return action.validate(createJobDto).catch((err) => {
         //   Logger.error(err);
         //   if (err instanceof HttpException) {
         //     throw err;
         //   }
-
         //   throw new HttpException(
         //     {
         //       status: HttpStatus.BAD_REQUEST,
@@ -76,8 +75,8 @@ export class JobCreateInterceptor implements NestInterceptor {
         //     HttpStatus.BAD_REQUEST,
         //   );
         // });
-      }),
-    );
+    //   }),
+    // );
 
     return jc;
   }

--- a/src/jobs/interceptors/job-create.interceptor.ts
+++ b/src/jobs/interceptors/job-create.interceptor.ts
@@ -60,22 +60,22 @@ export class JobCreateInterceptor implements NestInterceptor {
 
     await Promise.all(
       jc.create.actions.map((action) => {
-        return action.validate(createJobDto).catch((err) => {
-          Logger.error(err);
-          if (err instanceof HttpException) {
-            throw err;
-          }
+        // return action.validate(createJobDto).catch((err) => {
+        //   Logger.error(err);
+        //   if (err instanceof HttpException) {
+        //     throw err;
+        //   }
 
-          throw new HttpException(
-            {
-              status: HttpStatus.BAD_REQUEST,
-              message: `Invalid job input. Action ${action.getActionType()} unable to validate ${
-                createJobDto.type
-              } job due to ${err}`,
-            },
-            HttpStatus.BAD_REQUEST,
-          );
-        });
+        //   throw new HttpException(
+        //     {
+        //       status: HttpStatus.BAD_REQUEST,
+        //       message: `Invalid job input. Action ${action.getActionType()} unable to validate ${
+        //         createJobDto.type
+        //       } job due to ${err}`,
+        //     },
+        //     HttpStatus.BAD_REQUEST,
+        //   );
+        // });
       }),
     );
 

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -277,20 +277,6 @@ export class JobsController {
   };
 
   /**
-   * Check that the user is authenticated
-   */
-  checkAuthenticatedUser = (user: JWTUser) => {
-    if (user === null) {
-      throw new HttpException(
-        {
-          status: HttpStatus.UNAUTHORIZED,
-        },
-        HttpStatus.UNAUTHORIZED,
-      );
-    }
-  };
-
-  /**
    * Check that the dataset ids list is valid
    */
   async checkDatasetIds(jobParams: Record<string, unknown>): Promise<string[]> {
@@ -310,11 +296,6 @@ export class JobsController {
         HttpStatus.BAD_REQUEST,
       );
     }
-    interface condition {
-      where: {
-        pid: { $in: string[] };
-      };
-    }
     if (datasetIds.length == 0) {
       throw new HttpException(
         {
@@ -325,11 +306,17 @@ export class JobsController {
       );
     }
 
+    interface condition {
+      where: {
+        pid: { $in: string[] };
+      };
+    }
     const filter: condition = {
       where: {
         pid: { $in: datasetIds },
       },
     };
+
     const findDatasetsById = await this.datasetsService.findAll(filter);
     const findIds = findDatasetsById.map(({ pid }) => pid);
     const nonExistIds = datasetIds.filter((x) => !findIds.includes(x));
@@ -337,7 +324,7 @@ export class JobsController {
       throw new HttpException(
         {
           status: HttpStatus.BAD_REQUEST,
-          message: ` Datasets with pid ${nonExistIds} don't exist.`,
+          message: `Datasets with pid ${nonExistIds} don't exist.`,
         },
         HttpStatus.BAD_REQUEST,
       );
@@ -350,10 +337,10 @@ export class JobsController {
    */
   async generateJobInstanceForPermissions(job: JobClass): Promise<JobClass> {
     const jobInstance = new JobClass();
+
     jobInstance._id = job._id;
     jobInstance.id = job.id;
     jobInstance.type = job.type;
-    //jobInstance.configuration = configuration().statusUpdateJobGroups;
     jobInstance.ownerGroup = job.ownerGroup;
     jobInstance.ownerUser = job.ownerUser;
 
@@ -363,25 +350,25 @@ export class JobsController {
   /**
    * Check job type matching configuration
    */
-  getJobMatchingConfiguration = (createJobDtoType: string) => {
+  getJobTypeConfiguration = (jobType: string) => {
     const jobConfigs = configuration().jobConfiguration;
     const matchingConfig = jobConfigs.filter(
-      (j) => j.jobType == createJobDtoType,
+      (j) => j.jobType == jobType,
     );
 
     if (matchingConfig.length != 1) {
       if (matchingConfig.length > 1) {
         Logger.error(
-          "More than one job configurations matching type " + createJobDtoType,
+          "More than one job configurations matching type " + jobType,
         );
       } else {
-        Logger.error("No job configuration matching type " + createJobDtoType);
+        Logger.error("No job configuration matching type " + jobType);
       }
       // return error that job type does not exists
       throw new HttpException(
         {
           status: HttpStatus.BAD_REQUEST,
-          message: "Invalid job type: " + createJobDtoType,
+          message: "Invalid job type: " + jobType,
         },
         HttpStatus.BAD_REQUEST,
       );
@@ -393,13 +380,13 @@ export class JobsController {
    * Checking if user is allowed to create job according to auth field of job configuration
    */
   async instanceAuthorizationJobCreate(
-    jobCreateDto: CreateJobDtoWithConfig,
+    jobCreateDto: CreateJobDto,
     user: JWTUser,
   ): Promise<JobClass> {
     // NOTE: We need JobClass instance because casl module works only on that.
     // If other fields are needed can be added later.
     const jobInstance = new JobClass();
-    const jobConfiguration = this.getJobMatchingConfiguration(
+    const jobConfiguration = this.getJobTypeConfiguration(
       jobCreateDto.type,
     );
 
@@ -409,7 +396,7 @@ export class JobsController {
     jobInstance.contactEmail = jobCreateDto.contactEmail;
     jobInstance.jobParams = jobCreateDto.jobParams;
     jobInstance.datasetsValidation = false;
-    jobInstance.configuration = jobConfiguration;
+    jobInstance.configVersion = jobConfiguration[JobsConfigSchema.ConfigVersion];
     jobInstance.statusCode = "Initializing";
     jobInstance.statusMessage =
       "Building and validating job, verifying authorization";
@@ -537,14 +524,14 @@ export class JobsController {
 
     // instantiate the casl matrix for the user
     const ability = this.caslAbilityFactory.createForUser(user);
-    // check if he/she can create this dataset
+    // check if the user can create this job
     const canCreate =
       ability.can(AuthOp.JobCreateAny, JobClass) ||
       ability.can(AuthOp.JobCreateOwner, jobInstance) ||
       ability.can(AuthOp.JobCreateConfiguration, jobInstance);
 
     if (!canCreate) {
-      throw new ForbiddenException("Unauthorized to create this dataset.");
+      throw new ForbiddenException("Unauthorized to create this job.");
     }
 
     return jobInstance;
@@ -564,9 +551,9 @@ export class JobsController {
       throw new HttpException(
         {
           status: HttpStatus.BAD_REQUEST,
-          message: `Invalid job input. Action ${action.getActionType()} unable to validate ${
+          message: `Invalid job input. Action ${action.getActionType()} unable to perform ${
             jobInstance.type
-          } job due to ${err}`,
+          } job ${action.getActionType()} action due to ${err}`,
         },
         HttpStatus.BAD_REQUEST,
       );
@@ -574,7 +561,7 @@ export class JobsController {
   }
 
   async performJobCreateAction(jobInstance: JobClass): Promise<void> {
-    const jobConfig = this.getJobMatchingConfiguration(jobInstance.type);
+    const jobConfig = this.getJobTypeConfiguration(jobInstance.type);
     for (const action of jobConfig.create.actions) {
       await this.performJobAction(jobInstance, action);
     }
@@ -582,28 +569,17 @@ export class JobsController {
   }
 
   async performJobStatusUpdateAction(jobInstance: JobClass): Promise<void> {
-    const jobConfig = this.getJobMatchingConfiguration(jobInstance.type);
+    const jobConfig = this.getJobTypeConfiguration(jobInstance.type);
 
-    await Promise.all(
-      jobConfig.statusUpdate.actions.map((action) => {
-        return action.validate(jobInstance).catch((err) => {
-          Logger.error(err);
-          if (err instanceof HttpException) {
-            throw err;
-          }
-
-          throw new HttpException(
-            {
-              status: HttpStatus.BAD_REQUEST,
-              message: `Invalid job input. Action ${action.getActionType()} unable to validate ${
-                jobInstance.type
-              } job due to ${err}`,
-            },
-            HttpStatus.BAD_REQUEST,
-          );
-        });
-      }),
-    );
+    // TODO - do we need to do something with the new configVersion ?
+    if (jobConfig.configVersion !== jobInstance.configVersion) {
+      Logger.log(`
+          Job was created with configVersion ${jobInstance.configVersion}.
+          Current configVersion is ${jobConfig.configVersion}.
+        `,
+        "JobStatusUpdate",
+      )
+    }
 
     for (const action of jobConfig.statusUpdate.actions) {
       await this.performJobAction(jobInstance, action);
@@ -618,7 +594,7 @@ export class JobsController {
   @CheckPolicies((ability: AppAbility) =>
     ability.can(AuthOp.JobCreate, JobClass),
   )
-  @UseInterceptors(JobCreateInterceptor)
+  // @UseInterceptors(JobCreateInterceptor)
   @Post()
   @ApiOperation({
     summary: "It creates a new job.",
@@ -636,13 +612,13 @@ export class JobsController {
   })
   async create(
     @Req() request: Request,
-    @Body() createJobDtoWithConfig: CreateJobDtoWithConfig,
+    @Body() createJobDto: CreateJobDto,
   ): Promise<JobClass | null> {
     Logger.log("Creating job!");
     // throw an error if no jobParams are passed
     if (
-      !createJobDtoWithConfig.jobParams ||
-      Object.keys(createJobDtoWithConfig.jobParams).length == 0
+      !createJobDto.jobParams ||
+      Object.keys(createJobDto.jobParams).length == 0
     ) {
       throw new HttpException(
         {
@@ -655,7 +631,7 @@ export class JobsController {
     // Validate that request matches the current configuration
     // Check job authorization
     const jobInstance = await this.instanceAuthorizationJobCreate(
-      createJobDtoWithConfig,
+      createJobDto,
       request.user as JWTUser,
     );
     // Create actual job in database
@@ -706,9 +682,9 @@ export class JobsController {
     }
     const currentJobInstance =
       await this.generateJobInstanceForPermissions(currentJob);
-    currentJobInstance.configuration = this.getJobMatchingConfiguration(
+    currentJobInstance.configVersion = this.getJobTypeConfiguration(
       currentJobInstance.type,
-    );
+    )[JobsConfigSchema.ConfigVersion];
 
     const ability = this.caslAbilityFactory.createForUser(
       request.user as JWTUser,

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -547,9 +547,8 @@ export class JobsController {
       throw new HttpException(
         {
           status: HttpStatus.BAD_REQUEST,
-          message: `Invalid job input. Action ${action.getActionType()} unable to perform ${
-            jobInstance.type
-          } job ${action.getActionType()} action due to ${err}`,
+          message: `Invalid job input. Job '${jobInstance.type}' unable to perfom 
+            action '${action.getActionType()}' due to ${err}`,
         },
         HttpStatus.BAD_REQUEST,
       );

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -679,7 +679,9 @@ export class JobsController {
     }
     const currentJobInstance =
       await this.generateJobInstanceForPermissions(currentJob);
-    currentJobInstance.configuration = this.getJobTypeConfiguration(currentJobInstance.type);
+    currentJobInstance.configuration = this.getJobTypeConfiguration(
+      currentJobInstance.type,
+    );
 
     const ability = this.caslAbilityFactory.createForUser(
       request.user as JWTUser,

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -392,8 +392,7 @@ export class JobsController {
     jobInstance.contactEmail = jobCreateDto.contactEmail;
     jobInstance.jobParams = jobCreateDto.jobParams;
     jobInstance.datasetsValidation = false;
-    jobInstance.configVersion =
-      jobConfiguration[JobsConfigSchema.ConfigVersion];
+    jobInstance.configuration = jobConfiguration;
     jobInstance.statusCode = "Initializing";
     jobInstance.statusMessage =
       "Building and validating job, verifying authorization";
@@ -568,11 +567,11 @@ export class JobsController {
   async performJobStatusUpdateAction(jobInstance: JobClass): Promise<void> {
     const jobConfig = this.getJobTypeConfiguration(jobInstance.type);
 
-    // TODO - do we need to do something with the new configVersion ?
-    if (jobConfig.configVersion !== jobInstance.configVersion) {
+    // TODO - what shall we do when configVersion does not match?
+    if (jobConfig.configVersion !== jobInstance.configuration.configVersion) {
       Logger.log(
         `
-          Job was created with configVersion ${jobInstance.configVersion}.
+          Job was created with configVersion ${jobInstance.configuration.configVersion}.
           Current configVersion is ${jobConfig.configVersion}.
         `,
         "JobStatusUpdate",
@@ -680,9 +679,7 @@ export class JobsController {
     }
     const currentJobInstance =
       await this.generateJobInstanceForPermissions(currentJob);
-    currentJobInstance.configVersion = this.getJobTypeConfiguration(
-      currentJobInstance.type,
-    )[JobsConfigSchema.ConfigVersion];
+    currentJobInstance.configuration = this.getJobTypeConfiguration(currentJobInstance.type);
 
     const ability = this.caslAbilityFactory.createForUser(
       request.user as JWTUser,

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -352,9 +352,7 @@ export class JobsController {
    */
   getJobTypeConfiguration = (jobType: string) => {
     const jobConfigs = configuration().jobConfiguration;
-    const matchingConfig = jobConfigs.filter(
-      (j) => j.jobType == jobType,
-    );
+    const matchingConfig = jobConfigs.filter((j) => j.jobType == jobType);
 
     if (matchingConfig.length != 1) {
       if (matchingConfig.length > 1) {
@@ -386,9 +384,7 @@ export class JobsController {
     // NOTE: We need JobClass instance because casl module works only on that.
     // If other fields are needed can be added later.
     const jobInstance = new JobClass();
-    const jobConfiguration = this.getJobTypeConfiguration(
-      jobCreateDto.type,
-    );
+    const jobConfiguration = this.getJobTypeConfiguration(jobCreateDto.type);
 
     jobInstance._id = "";
     jobInstance.accessGroups = [];
@@ -396,7 +392,9 @@ export class JobsController {
     jobInstance.contactEmail = jobCreateDto.contactEmail;
     jobInstance.jobParams = jobCreateDto.jobParams;
     jobInstance.datasetsValidation = false;
-    jobInstance.configVersion = jobConfiguration[JobsConfigSchema.ConfigVersion];
+    jobInstance.configVersion = jobConfiguration[
+      JobsConfigSchema.ConfigVersion
+    ];
     jobInstance.statusCode = "Initializing";
     jobInstance.statusMessage =
       "Building and validating job, verifying authorization";
@@ -573,12 +571,13 @@ export class JobsController {
 
     // TODO - do we need to do something with the new configVersion ?
     if (jobConfig.configVersion !== jobInstance.configVersion) {
-      Logger.log(`
+      Logger.log(
+        `
           Job was created with configVersion ${jobInstance.configVersion}.
           Current configVersion is ${jobConfig.configVersion}.
         `,
         "JobStatusUpdate",
-      )
+      );
     }
 
     for (const action of jobConfig.statusUpdate.actions) {

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -392,9 +392,8 @@ export class JobsController {
     jobInstance.contactEmail = jobCreateDto.contactEmail;
     jobInstance.jobParams = jobCreateDto.jobParams;
     jobInstance.datasetsValidation = false;
-    jobInstance.configVersion = jobConfiguration[
-      JobsConfigSchema.ConfigVersion
-    ];
+    jobInstance.configVersion =
+      jobConfiguration[JobsConfigSchema.ConfigVersion];
     jobInstance.statusCode = "Initializing";
     jobInstance.statusMessage =
       "Building and validating job, verifying authorization";

--- a/src/jobs/schemas/job.schema.ts
+++ b/src/jobs/schemas/job.schema.ts
@@ -3,7 +3,6 @@ import { ApiProperty } from "@nestjs/swagger";
 import { Document } from "mongoose";
 import { v4 as uuidv4 } from "uuid";
 import { OwnableClass } from "src/common/schemas/ownable.schema";
-import { JobConfig } from "../config/jobconfig";
 
 export type JobDocument = JobClass & Document;
 
@@ -123,14 +122,14 @@ export class JobClass extends OwnableClass {
 
   @ApiProperty({
     type: Object,
-    description: "Configuration that was used to create this job.",
+    description: "Configuration version that was used to create this job.",
     required: true,
   })
   @Prop({
     type: Object,
     required: true,
   })
-  configuration: JobConfig;
+  configVersion: string;
 }
 export const JobSchema = SchemaFactory.createForClass(JobClass);
 

--- a/src/jobs/schemas/job.schema.ts
+++ b/src/jobs/schemas/job.schema.ts
@@ -3,6 +3,7 @@ import { ApiProperty } from "@nestjs/swagger";
 import { Document } from "mongoose";
 import { v4 as uuidv4 } from "uuid";
 import { OwnableClass } from "src/common/schemas/ownable.schema";
+import { JobConfig } from "../config/jobconfig";
 
 export type JobDocument = JobClass & Document;
 
@@ -122,14 +123,14 @@ export class JobClass extends OwnableClass {
 
   @ApiProperty({
     type: Object,
-    description: "Configuration version that was used to create this job.",
+    description: "Configuration that was used to create this job.",
     required: true,
   })
   @Prop({
     type: Object,
     required: true,
   })
-  configVersion: string;
+  configuration: JobConfig;
 }
 export const JobSchema = SchemaFactory.createForClass(JobClass);
 

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -340,7 +340,6 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.not.have.property("id");
-        res.body.should.have.property("message").and.be.equal("Job parameters need to be defined.");
       });
   });
 
@@ -349,6 +348,8 @@ describe("1100: Jobs: Test New Job Model", () => {
       type: "all_access",
       ownerUser: "admin",
       ownerGroup: "admin",
+      jobParams: {
+      },
     };
 
     return request(appUrl)
@@ -967,7 +968,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       });
   });
   
-  it("0310: Add a new job as a normal user himself/herself in '#datasetPublic' configuration with one unpublished dataset, which should fail ad forbidden", async () => {
+  it("0310: Add a new job as a normal user himself/herself in '#datasetPublic' configuration with one unpublished dataset, which should fail as forbidden", async () => {
     const newDataset = {
       ...jobDatasetPublic,
       ownerUser: "user5.1",
@@ -987,7 +988,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.not.have.property("id");
-        res.body.should.have.property("message").and.be.equal("Unauthorized to create this dataset.");
+        res.body.should.have.property("message").and.be.equal("Unauthorized to create this job.");
       });
   });
 
@@ -1031,7 +1032,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.not.have.property("id");
-        res.body.should.have.property("message").and.be.equal("Unauthorized to create this dataset.");
+        res.body.should.have.property("message").and.be.equal("Unauthorized to create this job.");
       });
   });
 
@@ -1204,7 +1205,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.not.have.property("id");
-        res.body.should.have.property("message").and.be.equal("Unauthorized to create this dataset.");
+        res.body.should.have.property("message").and.be.equal("Unauthorized to create this job.");
       });
   });
  
@@ -1467,7 +1468,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.not.have.property("id");
-        res.body.should.have.property("message").and.be.equal("Unauthorized to create this dataset.");
+        res.body.should.have.property("message").and.be.equal("Unauthorized to create this job.");
       });
   });
 
@@ -1733,7 +1734,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.not.have.property("id");
-        res.body.should.have.property("message").and.be.equal("Unauthorized to create this dataset.");
+        res.body.should.have.property("message").and.be.equal("Unauthorized to create this job.");
       });
   });
 
@@ -2025,7 +2026,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.not.have.property("id");
-        res.body.should.have.property("message").and.be.equal("Unauthorized to create this dataset.");
+        res.body.should.have.property("message").and.be.equal("Unauthorized to create this job.");
       });
   });
 
@@ -2344,7 +2345,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.not.have.property("id");
-        res.body.should.have.property("message").and.be.equal("Unauthorized to create this dataset.");
+        res.body.should.have.property("message").and.be.equal("Unauthorized to create this job.");
       });
   });
 


### PR DESCRIPTION
## Description

As seen in issue #1341 

## Motivation

Method `validate()` in the `JobAction` class was never used. All validation was done inside the action's constructor.

## Changes:

- Removed method `validate()` from the `JobAction` class and all its subclasses.
- There is no longer the need to validate the actions before creating a job. This part has been commented out in the interceptor.
- In fact, there is no longer the need to use `job-create.interceptor` at all. It has been removed from `create` in the `jobs.controller`. The reason for this is that the interceptor was doing two things: Apart from action validation which has already been removed, it was also adding the `configuration` field in the job instance to be created. However this part is already covered by the `instanceAuthorizationJobCreate` function in  `jobs.controller`.
- `checkAuthenticatedUser` has been removed from `jobs.controller`, as it was never used.
- Before `statusUpdate` we check whether the configuration file has been updated by comparing the new with the one stored inside the job. However, even if they are different, we still proceed with the update as usual, as all actions have been automatically re-initialized with the new configuration. _This is a point to be discussed later._