### PR TITLE
fix: replace docker-compose with docker compose on github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,5 +173,5 @@ jobs:
         run: |
           cp CI/ESS/docker-compose.api.yaml docker-compose.yaml
           cp functionalAccounts.json.test functionalAccounts.json
-          docker-compose up --build -d
+          docker compose up --build -d
           npm run test:api


### PR DESCRIPTION
## Description

Replaced docker-compose command with docker compose for github job

## Motivation
docker-compose command is deprecated 

## Fixes:
Please provide a list of the fixes implemented by this PR

* Items added

## Changes:
Please provide a list of the changes implemented by this PR

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included


