### PR TITLE
feat: adding dataset start time

### DIFF
--- a/src/datasets/dto/update-dataset.dto.ts
+++ b/src/datasets/dto/update-dataset.dto.ts
@@ -137,7 +137,7 @@ export class UpdateDatasetDto extends OwnableDto {
     type: Date,
     required: true,
     description:
-      "Time when dataset became fully available on disk, i.e. all containing files have been written. Format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
+      "Time when dataset became fully available on disk, i.e. all containing files have been written,  or the dataset was created in SciCat.<br>It is expected to be in ISO8601 format according to specifications for internet date/time format in RFC 3339, chapter 5.6 (https://www.rfc-editor.org/rfc/rfc3339#section-5).<br>Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
   })
   @IsDateString()
   readonly creationTime: Date;

--- a/src/datasets/dto/update-raw-dataset.dto.ts
+++ b/src/datasets/dto/update-raw-dataset.dto.ts
@@ -17,7 +17,17 @@ export class UpdateRawDatasetDto extends UpdateDatasetDto {
     type: Date,
     required: false,
     description:
-      "End time of data acquisition for this dataset, format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
+      "Start time of data acquisition for the current dataset.<br>It is expected to be in ISO8601 format according to specifications for internet date/time format in RFC 3339, chapter 5.6 (https://www.rfc-editor.org/rfc/rfc3339#section-5).<br>Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
+  })
+  @IsOptional()
+  @IsDateString()
+  readonly startTime?: Date;
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description:
+      "End time of data acquisition for the current dataset.<br>It is expected to be in ISO8601 format according to specifications for internet date/time format in RFC 3339, chapter 5.6 (https://www.rfc-editor.org/rfc/rfc3339#section-5).<br>Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
   })
   @IsOptional()
   @IsDateString()

--- a/src/datasets/schemas/dataset.schema.ts
+++ b/src/datasets/schemas/dataset.schema.ts
@@ -418,7 +418,16 @@ export class DatasetClass extends OwnableClass {
     type: Date,
     required: false,
     description:
-      "End time of data acquisition for this dataset, format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
+      "Start time of data acquisition for the current dataset.<br>It is expected to be in ISO8601 format according to specifications for internet date/time format in RFC 3339, chapter 5.6 (https://www.rfc-editor.org/rfc/rfc3339#section-5).<br>Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
+  })
+  @Prop({ type: Date, required: false })
+  startTime?: Date;
+
+  @ApiProperty({
+    type: Date,
+    required: false,
+    description:
+      "End time of data acquisition for the current dataset.<br>It is expected to be in ISO8601 format according to specifications for internet date/time format in RFC 3339, chapter 5.6 (https://www.rfc-editor.org/rfc/rfc3339#section-5).<br>Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
   })
   @Prop({ type: Date, required: false })
   endTime?: Date;

--- a/src/datasets/schemas/dataset.schema.ts
+++ b/src/datasets/schemas/dataset.schema.ts
@@ -196,7 +196,7 @@ export class DatasetClass extends OwnableClass {
     type: Date,
     required: true,
     description:
-      "Time when dataset became fully available on disk, i.e. all containing files have been written. Format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
+      "Time when dataset became fully available on disk, i.e. all containing files have been written,  or the dataset was created in SciCat.<br>It is expected to be in ISO8601 format according to specifications for internet date/time format in RFC 3339, chapter 5.6 (https://www.rfc-editor.org/rfc/rfc3339#section-5).<br>Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
   })
   @Prop({ type: Date, required: true, index: true })
   creationTime: Date;

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -6,6 +6,12 @@ const TestAccounts = Object.fromEntries(
   RawTestAccounts.map((account) => [account.username, account]),
 );
 
+const DatasetDates = faker.date.betweens({
+  from: faker.date.recent({ days: 15 }).toISOString(),
+  to: faker.date.recent({ days: 10 }).toISOString(),
+  count: 2,
+});
+
 const TestData = {
   EntryCreatedStatusCode: 201,
   EntryValidStatusCode: 200,
@@ -117,6 +123,7 @@ const TestData = {
 
   RawCorrect: {
     principalInvestigator: "scicatingestor@your.site",
+    startTime: "2011-09-14T05:29:11.000Z",
     endTime: "2011-09-14T06:31:25.000Z",
     creationLocation: "/SU/XQX/RAMJET",
     dataFormat: "Upchuck pre 2017",
@@ -199,7 +206,8 @@ const TestData = {
 
   RawCorrectRandom: {
     principalInvestigator: faker.internet.email(),
-    endTime: faker.date.past().toISOString(),
+    startTime: DatasetDates[0],
+    endTime: DatasetDates[1],
     creationLocation: faker.system.directoryPath(),
     dataFormat: faker.lorem.words(3),
     scientificMetadata: {
@@ -299,6 +307,7 @@ const TestData = {
 
   RawWrong_2: {
     principalInvestigator: "bertram.astor@grumble.com",
+    startTime: "2011-09-15T02:13:52.000Z",
     endTime: "2011-09-14T06:31:25.000Z",
     creationLocation: "/SU/XQX/RAMJET",
     dataFormat: "Upchuck pre 2017",

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -8,7 +8,7 @@ const TestAccounts = Object.fromEntries(
 
 const DatasetDates = faker.date.betweens({
   from: faker.date.recent({ days: 15 }).toISOString(),
-  to: faker.date.recent({ days: 10 }).toISOString(),
+  to: faker.date.soon({ days: 10 }).toISOString(),
   count: 2,
 });
 


### PR DESCRIPTION
## Description
This PR add the field startTime to raw datasets to match the field endTime.

## Motivation
We were using scientific metadata to store start and end time of a data acquisition, without using the endTime field.
We wanted to enforce consistency and have both information in the high level fields of the datasets

## Fixes:
* datasets dto and schemas

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [x] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included


