### PR TITLE
Add fullfacet and fullquery for Jobs

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -873,9 +873,6 @@ export const filterDescription =
 export const fullQueryExampleLimits =
   '{"limit": 1, "skip": 1, "order": "creationTime:desc"}';
 
-export const datasetsFullQueryExampleFields =
-  '{"mode":{},"ownerGroup":["group1"],"scientific":[{"lhs":"sample","relation":"EQUAL_TO_STRING","rhs":"my sample"},{"lhs":"temperature","relation":"GREATER_THAN","rhs":10,"unit":"celsius"}]}';
-
 export const fullQueryDescriptionLimits =
   '<pre>\n \
 {\n \
@@ -884,6 +881,9 @@ export const fullQueryDescriptionLimits =
   "order": [ascending, descending]\n \
 }\n \
 </pre>';
+
+export const datasetsFullQueryExampleFields =
+  '{"mode":{},"ownerGroup":["group1"],"scientific":[{"lhs":"sample","relation":"EQUAL_TO_STRING","rhs":"my sample"},{"lhs":"temperature","relation":"GREATER_THAN","rhs":10,"unit":"celsius"}]}';
 
 export const datasetsFullQueryDescriptionFields =
   '<pre>\n  \
@@ -914,6 +914,29 @@ export const datasetsFullQueryDescriptionFields =
   "_id": "item id", <optional>\n \
   "userGroups": ["group1", ...], <optional>\n \
   "sharedWith": ["email", ...], <optional>\n \
+}\n \
+  </pre>';
+
+export const jobsFullQueryExampleFields =
+  '{"ownerGroup":["group1"], "statusCode": "jobCreated"}';
+
+
+export const jobsFullQueryDescriptionFields =
+  '<pre>\n  \
+{\n \
+  "createdBy": string, <optional>\n \
+  "updatedBy": string, <optional>\n \
+  "createdAt": { <optional>\n \
+    "begin": string,\n \
+    "end": string,\n \
+  },\n \
+  "ownerGroup": string, <optional>\n \
+  "accessGroups": ["group1", ...], <optional>\n \
+  "type": string, <optional>\n \
+  "id": string, <optional>\n \
+  "statusCode": string, <optional>\n \
+  "statusMessage": string, <optional>\n \
+  ... <optional>\n \
 }\n \
   </pre>';
 

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -920,7 +920,6 @@ export const datasetsFullQueryDescriptionFields =
 export const jobsFullQueryExampleFields =
   '{"ownerGroup":["group1"], "statusCode": "jobCreated"}';
 
-
 export const jobsFullQueryDescriptionFields =
   '<pre>\n  \
 {\n \

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -45,6 +45,10 @@ import { UsersService } from "src/users/users.service";
 import {
   filterDescriptionSimplified,
   filterExampleSimplified,
+  fullQueryDescriptionLimits,
+  fullQueryExampleLimits,
+  jobsFullQueryExampleFields,
+  jobsFullQueryDescriptionFields,
 } from "src/common/utils";
 import { JobCreateInterceptor } from "./interceptors/job-create.interceptor";
 import { JobAction } from "./config/jobconfig";
@@ -725,18 +729,20 @@ export class JobsController {
   })
   @ApiQuery({
     name: "fields",
-    description: "Filters to apply when retrieving jobs.",
+    description: "Filters to apply when retrieving jobs.\n" +
+      jobsFullQueryDescriptionFields,
     required: false,
     type: String,
-    example: {},
+    example: jobsFullQueryExampleFields,
   })
   @ApiQuery({
     name: "limits",
     description:
-      "Define further query parameters like skip, limit, order.",
+      "Define further query parameters like skip, limit, order.\n" +
+      fullQueryDescriptionLimits,
     required: false,
     type: String,
-    example: {},
+    example: fullQueryExampleLimits,
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -811,7 +817,6 @@ export class JobsController {
       "Define the filter conditions by specifying the name of values of fields requested.",
     required: false,
     type: String,
-    example: {},
   })
   @ApiQuery({
     name: "facets",
@@ -819,7 +824,6 @@ export class JobsController {
       "Define a list of field names, for which facet counts should be calculated.",
     required: false,
     type: String,
-    example: '["type","creationLocation","ownerGroup","keywords"]',
   })
   @ApiResponse({
     status: HttpStatus.OK,

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -711,6 +711,166 @@ export class JobsController {
   }
 
   /**
+   * Get fullquery
+   */
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("jobs", (ability: AppAbility) =>
+    ability.can(Action.JobRead, JobClass),
+  )
+  @Get("/fullquery")
+  @ApiOperation({
+    summary: "It returns a list of jobs matching the query provided.",
+    description:
+      "It returns a list of jobs matching the query provided.",
+  })
+  @ApiQuery({
+    name: "fields",
+    description: "Filters to apply when retrieving jobs.",
+    required: false,
+    type: String,
+    example: {},
+  })
+  @ApiQuery({
+    name: "limits",
+    description:
+      "Define further query parameters like skip, limit, order.",
+    required: false,
+    type: String,
+    example: {},
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: [JobClass],
+    description: "Return jobs requested.",
+  })
+  async fullQuery(
+    @Req() request: Request,
+    @Query() filters: { fields?: string; limits?: string },
+  ): Promise<JobClass[] | null> {
+    try {
+      const parsedFilters: IFilters<JobDocument, FilterQuery<JobDocument>> = {
+        fields: JSON.parse(filters.fields ?? "{}" as string),
+        limits: JSON.parse(filters.limits ?? "{}" as string),
+      };
+      const jobsFound = await this.jobsService.fullquery(parsedFilters);
+      const jobsAccessible: JobClass[] = [];
+
+      // for each job run a casl JobReadOwner on a jobInstance
+      if (jobsFound != null) {
+        for (const i in jobsFound) {
+          const jobConfiguration = this.getJobTypeConfiguration(
+            jobsFound[i].type,
+          );
+          const ability = this.caslAbilityFactory.jobsInstanceAccess(
+            request.user as JWTUser,
+            jobConfiguration,
+          );
+          // check if the user can get this job
+          const jobInstance = await this.generateJobInstanceForPermissions(
+            jobsFound[i],
+          );
+          const canCreate =
+            ability.can(Action.JobReadAny, JobClass) ||
+            ability.can(Action.JobReadAccess, jobInstance);
+          if (canCreate) {
+            jobsAccessible.push(jobsFound[i]);
+          }
+        }
+      }
+      return jobsAccessible;
+    } catch (e) {
+      throw new HttpException(
+        {
+          status: HttpStatus.BAD_REQUEST,
+          message: (e as Error).message,
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  /**
+   * Get fullfacet
+   */
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("jobs", (ability: AppAbility) =>
+    ability.can(Action.JobRead, JobClass),
+  )
+  @Get("/fullfacet")
+  @ApiOperation({
+    summary: "It returns a list of job facets matching the filter provided.",
+    description: `
+      This endpoint was added for completeness reasons, 
+      so that the frontend can work with the new backend version. 
+      For now, it always returns an empty array.
+    `,
+  })
+  @ApiQuery({
+    name: "fields",
+    description:
+      "Define the filter conditions by specifying the name of values of fields requested.",
+    required: false,
+    type: String,
+    example: {},
+  })
+  @ApiQuery({
+    name: "facets",
+    description:
+      "Define a list of field names, for which facet counts should be calculated.",
+    required: false,
+    type: String,
+    example: '["type","creationLocation","ownerGroup","keywords"]',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: [JobClass],
+    description: "Return jobs requested.",
+  })
+  async fullFacet(
+    @Req() request: Request,
+    @Query() filters: { fields?: string; facets?: string },
+  ): Promise<JobClass[]> {
+    try {
+      // const parsedFilters: IFacets<FilterQuery<JobDocument>> = {
+      //   fields: JSON.parse(filters.fields ?? "{}" as string),
+      //   facets: JSON.parse(filters.facets ?? "[]" as string),
+      // };
+      // const jobsFound = await this.jobsService.fullfacet(parsedFilters);
+      const jobsAccessible: JobClass[] = [];
+
+      // for each job run a casl JobReadOwner on a jobInstance
+      // for (const i in jobsFound) {
+      //   const jobConfiguration = this.getJobTypeConfiguration(
+      //     jobsFound[i].type,
+      //   );
+      //   const ability = this.caslAbilityFactory.jobsInstanceAccess(
+      //     request.user as JWTUser,
+      //     jobConfiguration,
+      //   );
+      //   // check if the user can get this job
+      //   const jobInstance = await this.generateJobInstanceForPermissions(
+      //     jobsFound[i],
+      //   );
+      //   const canCreate =
+      //     ability.can(Action.JobReadAny, JobClass) ||
+      //     ability.can(Action.JobReadAccess, jobInstance);
+      //   if (canCreate) {
+      //     jobsAccessible.push(jobsFound[i]);
+      //   }
+      // }
+      return jobsAccessible;
+    } catch (e) {
+      throw new HttpException(
+        {
+          status: HttpStatus.BAD_REQUEST,
+          message: (e as Error).message,
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  /**
    * Get job by id
    */
   @UseGuards(PoliciesGuard)
@@ -804,163 +964,6 @@ export class JobsController {
       const jobsFound = await this.jobsService.findAll(parsedFilter);
       const jobsAccessible: JobClass[] = [];
 
-      for (const i in jobsFound) {
-        const jobConfiguration = this.getJobTypeConfiguration(
-          jobsFound[i].type,
-        );
-        const ability = this.caslAbilityFactory.jobsInstanceAccess(
-          request.user as JWTUser,
-          jobConfiguration,
-        );
-        // check if the user can get this job
-        const jobInstance = await this.generateJobInstanceForPermissions(
-          jobsFound[i],
-        );
-        const canCreate =
-          ability.can(Action.JobReadAny, JobClass) ||
-          ability.can(Action.JobReadAccess, jobInstance);
-        if (canCreate) {
-          jobsAccessible.push(jobsFound[i]);
-        }
-      }
-      return jobsAccessible;
-    } catch (e) {
-      throw new HttpException(
-        {
-          status: HttpStatus.BAD_REQUEST,
-          message: (e as Error).message,
-        },
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-  }
-
-  /**
-   * Get fullquery
-   */
-  @UseGuards(PoliciesGuard)
-  @CheckPolicies("jobs", (ability: AppAbility) =>
-    ability.can(Action.JobRead, JobClass),
-  )
-  @Get("/fullquery")
-  @ApiOperation({
-    summary: "It returns a list of jobs matching the query provided.",
-    description:
-      "It returns a list of jobs matching the query provided.",
-  })
-  @ApiQuery({
-    name: "fields",
-    description: "Filters to apply when retrieving jobs.",
-    required: false,
-    type: String,
-    example: {},
-  })
-  @ApiQuery({
-    name: "limits",
-    description:
-      "Define further query parameters like skip, limit, order.",
-    required: false,
-    type: String,
-    example: {},
-  })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    type: [JobClass],
-    description: "Return jobs requested.",
-  })
-  async fullQuery(
-    @Req() request: Request,
-    @Query() filters: { fields?: string; limits?: string },
-  ): Promise<JobClass[] | null> {
-    try {
-      const parsedFilters: IFilters<JobDocument, FilterQuery<JobDocument>> = {
-        fields: JSON.parse(filters.fields ?? "{}" as string),
-        limits: JSON.parse(filters.limits ?? "{}" as string),
-      };
-      const jobsFound = await this.jobsService.fullquery(parsedFilters);
-      const jobsAccessible: JobClass[] = [];
-
-      // for each job run a casl JobReadOwner on a jobInstance
-      if (jobsFound != null) {
-        for (const i in jobsFound) {
-          const jobConfiguration = this.getJobTypeConfiguration(
-            jobsFound[i].type,
-          );
-          const ability = this.caslAbilityFactory.jobsInstanceAccess(
-            request.user as JWTUser,
-            jobConfiguration,
-          );
-          // check if the user can get this job
-          const jobInstance = await this.generateJobInstanceForPermissions(
-            jobsFound[i],
-          );
-          const canCreate =
-            ability.can(Action.JobReadAny, JobClass) ||
-            ability.can(Action.JobReadAccess, jobInstance);
-          if (canCreate) {
-            jobsAccessible.push(jobsFound[i]);
-          }
-        }
-      }
-      return jobsAccessible;
-    } catch (e) {
-      throw new HttpException(
-        {
-          status: HttpStatus.BAD_REQUEST,
-          message: (e as Error).message,
-        },
-        HttpStatus.BAD_REQUEST,
-      );
-    }
-  }
-
-  /**
-   * Get fullfacet
-   */
-  @UseGuards(PoliciesGuard)
-  @CheckPolicies("jobs", (ability: AppAbility) =>
-    ability.can(Action.JobRead, JobClass),
-  )
-  @Get("/fullfacet")
-  @ApiOperation({
-    summary: "It returns a list of job facets matching the filter provided.",
-    description:
-      "It returns a list of job facets matching the filter provided.",
-  })
-  @ApiQuery({
-    name: "fields",
-    description:
-      "Define the filter conditions by specifying the name of values of fields requested.",
-    required: false,
-    type: String,
-    example: {},
-  })
-  @ApiQuery({
-    name: "facets",
-    description:
-      "Define a list of field names, for which facet counts should be calculated.",
-    required: false,
-    type: String,
-    example: '["type","creationLocation","ownerGroup","keywords"]',
-  })
-  @ApiResponse({
-    status: HttpStatus.OK,
-    type: [JobClass],
-    description: "Return jobs requested.",
-  })
-  async fullFacet(
-    @Req() request: Request,
-    @Query() filters: { fields?: string; facets?: string },
-  ): Promise<JobClass[]> {
-    try {
-      const parsedFilters: IFacets<FilterQuery<JobDocument>> = {
-        fields: JSON.parse(filters.fields ?? "{}" as string),
-        facets: JSON.parse(filters.facets ?? "[]" as string),
-      };
-      const jobsFound = await this.jobsService.fullfacet(parsedFilters);
-      const jobsAccessible: JobClass[] = [];
-
-      // for each job run a casl JobReadOwner on a jobInstance
       for (const i in jobsFound) {
         const jobConfiguration = this.getJobTypeConfiguration(
           jobsFound[i].type,

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -33,7 +33,7 @@ import {
   ApiResponse,
   ApiTags,
 } from "@nestjs/swagger";
-import { IFilters } from "src/common/interfaces/common.interface";
+import { IFacets, IFilters } from "src/common/interfaces/common.interface";
 import { DatasetsService } from "src/datasets/datasets.service";
 import { JobsConfigSchema } from "./types/jobs-config-schema.enum";
 import configuration from "src/config/configuration";
@@ -804,6 +804,163 @@ export class JobsController {
       const jobsFound = await this.jobsService.findAll(parsedFilter);
       const jobsAccessible: JobClass[] = [];
 
+      for (const i in jobsFound) {
+        const jobConfiguration = this.getJobTypeConfiguration(
+          jobsFound[i].type,
+        );
+        const ability = this.caslAbilityFactory.jobsInstanceAccess(
+          request.user as JWTUser,
+          jobConfiguration,
+        );
+        // check if the user can get this job
+        const jobInstance = await this.generateJobInstanceForPermissions(
+          jobsFound[i],
+        );
+        const canCreate =
+          ability.can(Action.JobReadAny, JobClass) ||
+          ability.can(Action.JobReadAccess, jobInstance);
+        if (canCreate) {
+          jobsAccessible.push(jobsFound[i]);
+        }
+      }
+      return jobsAccessible;
+    } catch (e) {
+      throw new HttpException(
+        {
+          status: HttpStatus.BAD_REQUEST,
+          message: (e as Error).message,
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  /**
+   * Get fullquery
+   */
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("jobs", (ability: AppAbility) =>
+    ability.can(Action.JobRead, JobClass),
+  )
+  @Get("/fullquery")
+  @ApiOperation({
+    summary: "It returns a list of jobs matching the query provided.",
+    description:
+      "It returns a list of jobs matching the query provided.",
+  })
+  @ApiQuery({
+    name: "fields",
+    description: "Filters to apply when retrieving jobs.",
+    required: false,
+    type: String,
+    example: {},
+  })
+  @ApiQuery({
+    name: "limits",
+    description:
+      "Define further query parameters like skip, limit, order.",
+    required: false,
+    type: String,
+    example: {},
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: [JobClass],
+    description: "Return jobs requested.",
+  })
+  async fullQuery(
+    @Req() request: Request,
+    @Query() filters: { fields?: string; limits?: string },
+  ): Promise<JobClass[] | null> {
+    try {
+      const parsedFilters: IFilters<JobDocument, FilterQuery<JobDocument>> = {
+        fields: JSON.parse(filters.fields ?? "{}" as string),
+        limits: JSON.parse(filters.limits ?? "{}" as string),
+      };
+      const jobsFound = await this.jobsService.fullquery(parsedFilters);
+      const jobsAccessible: JobClass[] = [];
+
+      // for each job run a casl JobReadOwner on a jobInstance
+      if (jobsFound != null) {
+        for (const i in jobsFound) {
+          const jobConfiguration = this.getJobTypeConfiguration(
+            jobsFound[i].type,
+          );
+          const ability = this.caslAbilityFactory.jobsInstanceAccess(
+            request.user as JWTUser,
+            jobConfiguration,
+          );
+          // check if the user can get this job
+          const jobInstance = await this.generateJobInstanceForPermissions(
+            jobsFound[i],
+          );
+          const canCreate =
+            ability.can(Action.JobReadAny, JobClass) ||
+            ability.can(Action.JobReadAccess, jobInstance);
+          if (canCreate) {
+            jobsAccessible.push(jobsFound[i]);
+          }
+        }
+      }
+      return jobsAccessible;
+    } catch (e) {
+      throw new HttpException(
+        {
+          status: HttpStatus.BAD_REQUEST,
+          message: (e as Error).message,
+        },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  /**
+   * Get fullfacet
+   */
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("jobs", (ability: AppAbility) =>
+    ability.can(Action.JobRead, JobClass),
+  )
+  @Get("/fullfacet")
+  @ApiOperation({
+    summary: "It returns a list of job facets matching the filter provided.",
+    description:
+      "It returns a list of job facets matching the filter provided.",
+  })
+  @ApiQuery({
+    name: "fields",
+    description:
+      "Define the filter conditions by specifying the name of values of fields requested.",
+    required: false,
+    type: String,
+    example: {},
+  })
+  @ApiQuery({
+    name: "facets",
+    description:
+      "Define a list of field names, for which facet counts should be calculated.",
+    required: false,
+    type: String,
+    example: '["type","creationLocation","ownerGroup","keywords"]',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: [JobClass],
+    description: "Return jobs requested.",
+  })
+  async fullFacet(
+    @Req() request: Request,
+    @Query() filters: { fields?: string; facets?: string },
+  ): Promise<JobClass[]> {
+    try {
+      const parsedFilters: IFacets<FilterQuery<JobDocument>> = {
+        fields: JSON.parse(filters.fields ?? "{}" as string),
+        facets: JSON.parse(filters.facets ?? "[]" as string),
+      };
+      const jobsFound = await this.jobsService.fullfacet(parsedFilters);
+      const jobsAccessible: JobClass[] = [];
+
+      // for each job run a casl JobReadOwner on a jobInstance
       for (const i in jobsFound) {
         const jobConfiguration = this.getJobTypeConfiguration(
           jobsFound[i].type,

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -724,12 +724,12 @@ export class JobsController {
   @Get("/fullquery")
   @ApiOperation({
     summary: "It returns a list of jobs matching the query provided.",
-    description:
-      "It returns a list of jobs matching the query provided.",
+    description: "It returns a list of jobs matching the query provided.",
   })
   @ApiQuery({
     name: "fields",
-    description: "Filters to apply when retrieving jobs.\n" +
+    description:
+      "Filters to apply when retrieving jobs.\n" +
       jobsFullQueryDescriptionFields,
     required: false,
     type: String,
@@ -755,8 +755,8 @@ export class JobsController {
   ): Promise<JobClass[] | null> {
     try {
       const parsedFilters: IFilters<JobDocument, FilterQuery<JobDocument>> = {
-        fields: JSON.parse(filters.fields ?? "{}" as string),
-        limits: JSON.parse(filters.limits ?? "{}" as string),
+        fields: JSON.parse(filters.fields ?? ("{}" as string)),
+        limits: JSON.parse(filters.limits ?? ("{}" as string)),
       };
       const jobsFound = await this.jobsService.fullquery(parsedFilters);
       const jobsAccessible: JobClass[] = [];

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -43,8 +43,8 @@ export class JobsService {
     const createdJob = new this.jobModel(
       addStatusFields(
         addCreatedByFields(createJobDto, username),
-        "Job has been created.",
         "jobCreated",
+        "Job has been created.",
         {},
       ),
     );
@@ -77,7 +77,7 @@ export class JobsService {
 
   async fullfacet(
     filters: IFacets<FilterQuery<JobDocument>>,
-  ): Promise<Record<string, unknown>[]> {
+  ): Promise<JobClass[]> {
     const fields = filters.fields ?? {};
     const facets = filters.facets ?? [];
 

--- a/src/jobs/schemas/job.schema.ts
+++ b/src/jobs/schemas/job.schema.ts
@@ -9,7 +9,7 @@ export type JobDocument = JobClass & Document;
 @Schema({
   collection: "Job",
   minimize: false,
-  timestamps: { createdAt: "DateTime", updatedAt: false },
+  timestamps: true,
   toJSON: {
     getters: true,
   },

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -348,7 +348,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobId1 = res.body["id"];
         encodedJobId1 = encodeURIComponent(jobId1);
       });
@@ -376,7 +376,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobId2 = res.body["id"];
         encodedJobId2 = encodeURIComponent(jobId2);
       });
@@ -403,7 +403,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobId3 = res.body["id"];
         encodedJobId3 = encodeURIComponent(jobId3);
       });
@@ -429,7 +429,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerGroup");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobId6 = res.body["id"];
         encodedJobId6 = encodeURIComponent(jobId6);
       });
@@ -457,7 +457,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -482,7 +482,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -577,7 +577,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobId4 = res.body["id"];
         encodedJobId4 = encodeURIComponent(jobId4);
       });
@@ -604,7 +604,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobId5 = res.body["id"];
         encodedJobId5 = encodeURIComponent(jobId5);
       });
@@ -698,7 +698,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerUser");
         res.body.should.not.have.property("ownerGroup");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -746,7 +746,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -772,7 +772,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -798,7 +798,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -823,7 +823,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -847,7 +847,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerGroup");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -873,7 +873,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
   
@@ -899,7 +899,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -925,7 +925,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
   
@@ -972,7 +972,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerUser");
         res.body.should.not.have.property("ownerGroup");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -1019,7 +1019,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -1045,7 +1045,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });  
   it("0360: Add a new job as a user from ADMIN_GROUPS for another group in '#authenticated' configuration", async () => {
@@ -1069,7 +1069,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -1093,7 +1093,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerGroup");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -1119,7 +1119,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -1145,7 +1145,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -1192,7 +1192,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroup1 = res.body["id"];
         encodedJobIdGroup1 = encodeURIComponent(jobIdGroup1);
       });
@@ -1220,7 +1220,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroup2 = res.body["id"];
         encodedJobIdGroup2 = encodeURIComponent(jobIdGroup2);
       });
@@ -1247,7 +1247,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroup3 = res.body["id"];
         encodedJobIdGroup3 = encodeURIComponent(jobIdGroup3);
       });
@@ -1274,7 +1274,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroup5 = res.body["id"];
         encodedJobIdGroup5 = encodeURIComponent(jobIdGroup5);
       });
@@ -1300,7 +1300,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerGroup");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroup6 = res.body["id"];
         encodedJobIdGroup6 = encodeURIComponent(jobIdGroup6);
       });
@@ -1328,7 +1328,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -1354,7 +1354,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -1403,7 +1403,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroup4 = res.body["id"];
         encodedJobIdGroup4 = encodeURIComponent(jobIdGroup4);
       });
@@ -1455,7 +1455,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdUser1 = res.body["id"];
         encodedJobIdUser1 = encodeURIComponent(jobIdUser1);
       });
@@ -1483,7 +1483,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -1509,7 +1509,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdUser2 = res.body["id"];
         encodedJobIdUser2 = encodeURIComponent(jobIdUser2);
       });
@@ -1536,7 +1536,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdUser3 = res.body["id"];
         encodedJobIdUser3 = encodeURIComponent(jobIdUser3);
       });
@@ -1563,7 +1563,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdUser5 = res.body["id"];
         encodedJobIdUser5 = encodeURIComponent(jobIdUser5);
       });
@@ -1589,7 +1589,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerGroup");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdUser6 = res.body["id"];
         encodedJobIdUser6 = encodeURIComponent(jobIdUser6);
       });
@@ -1617,7 +1617,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -1643,7 +1643,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -1669,7 +1669,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdUser4 = res.body["id"];
         encodedJobIdUser4 = encodeURIComponent(jobIdUser4);
       });
@@ -1721,7 +1721,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdUserSpec1 = res.body["id"];
         encodedJobIdUserSpec1 = encodeURIComponent(jobIdUserSpec1);
       });
@@ -1749,7 +1749,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdUserSpec2 = res.body["id"];
         encodedJobIdUserSpec2 = encodeURIComponent(jobIdUserSpec2);
       });
@@ -1776,7 +1776,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdUserSpec3 = res.body["id"];
         encodedJobIdUserSpec3 = encodeURIComponent(jobIdUserSpec3);
       });
@@ -1803,7 +1803,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdUserSpec5 = res.body["id"];
         encodedJobIdUserSpec5 = encodeURIComponent(jobIdUserSpec5);
       });
@@ -1831,7 +1831,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.2");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdUserSpec7 = res.body["id"];
         encodedJobIdUserSpec7 = encodeURIComponent(jobIdUserSpec7);
       });
@@ -1858,7 +1858,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerGroup");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdUserSpec6 = res.body["id"];
         encodedJobIdUserSpec6 = encodeURIComponent(jobIdUserSpec6);
       });
@@ -1886,7 +1886,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -1936,7 +1936,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdUserSpec4 = res.body["id"];
         encodedJobIdUserSpec4 = encodeURIComponent(jobIdUserSpec4);
       });
@@ -1963,7 +1963,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -2013,7 +2013,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroupSpec1 = res.body["id"];
         encodedJobIdGroupSpec1 = encodeURIComponent(jobIdGroupSpec1);
       });
@@ -2041,7 +2041,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroupSpec2 = res.body["id"];
         encodedJobIdGroupSpec2 = encodeURIComponent(jobIdGroupSpec2);
       });
@@ -2068,7 +2068,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroupSpec3 = res.body["id"];
         encodedJobIdGroupSpec3 = encodeURIComponent(jobIdGroupSpec3);
       });
@@ -2095,7 +2095,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroupSpec5 = res.body["id"];
         encodedJobIdGroupSpec5 = encodeURIComponent(jobIdGroupSpec5);
       });
@@ -2123,7 +2123,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group3");
         res.body.should.have.property("ownerUser").and.be.equal("user3");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroupSpec8 = res.body["id"];
         encodedJobIdGroupSpec8 = encodeURIComponent(jobIdGroupSpec8);
       });
@@ -2149,7 +2149,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerGroup");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroupSpec6 = res.body["id"];
         encodedJobIdGroupSpec6 = encodeURIComponent(jobIdGroupSpec6);
       });
@@ -2177,7 +2177,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -2227,7 +2227,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroupSpec4 = res.body["id"];
         encodedJobIdGroupSpec4 = encodeURIComponent(jobIdGroupSpec4);
       });
@@ -2254,7 +2254,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -2280,7 +2280,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.2");
-        res.body.should.have.property("statusMessage").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobIdGroupSpec7 = res.body["id"];
         encodedJobIdGroupSpec7 = encodeURIComponent(jobIdGroupSpec7);
       });
@@ -2314,8 +2314,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId1}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2327,8 +2327,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId2}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2340,8 +2340,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId3}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2353,8 +2353,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2367,8 +2367,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId2}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2380,8 +2380,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2393,8 +2393,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId3}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2406,8 +2406,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId5}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2419,8 +2419,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2432,8 +2432,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2445,8 +2445,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId2}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2458,8 +2458,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId5}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2471,8 +2471,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId3}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2484,8 +2484,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2497,8 +2497,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .expect(TestData.SuccessfulPatchStatusCode)
@@ -2509,8 +2509,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId3}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .expect(TestData.AccessForbiddenStatusCode)
@@ -2521,8 +2521,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId2}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .expect(TestData.AccessForbiddenStatusCode)
@@ -2533,8 +2533,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUser1}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2546,8 +2546,8 @@ describe("1100: Jobs: Test New Job Model", () => {
   return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobIdUser2}`)
       .send({ 
-        statusCode: "update status of a job", 
-        statusMessage: "job finished/blocked/etc", 
+        statusMessage: "update status of a job", 
+        statusCode: "job finished/blocked/etc", 
       })
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2559,8 +2559,8 @@ describe("1100: Jobs: Test New Job Model", () => {
   return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobIdUser3}`)
       .send({ 
-        statusCode: "update status of a job", 
-        statusMessage: "job finished/blocked/etc", 
+        statusMessage: "update status of a job", 
+        statusCode: "job finished/blocked/etc", 
       })
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2572,8 +2572,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUser6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2585,8 +2585,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUser2}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2598,8 +2598,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUser4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2611,8 +2611,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUser3}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2624,8 +2624,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUser5}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2637,8 +2637,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUser6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2650,8 +2650,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUser4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2663,8 +2663,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUser2}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2676,8 +2676,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUser5}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2689,8 +2689,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUser3}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2702,8 +2702,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUser6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2715,8 +2715,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUser6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .expect(TestData.AccessForbiddenStatusCode)
@@ -2727,8 +2727,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroup1}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2740,8 +2740,8 @@ describe("1100: Jobs: Test New Job Model", () => {
   return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobIdGroup2}`)
       .send({ 
-        statusCode: "update status of a job", 
-        statusMessage: "job finished/blocked/etc", 
+        statusMessage: "update status of a job", 
+        statusCode: "job finished/blocked/etc", 
       })
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2753,8 +2753,8 @@ describe("1100: Jobs: Test New Job Model", () => {
   return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobIdGroup3}`)
       .send({ 
-        statusCode: "update status of a job", 
-        statusMessage: "job finished/blocked/etc", 
+        statusMessage: "update status of a job", 
+        statusCode: "job finished/blocked/etc", 
       })
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2766,8 +2766,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroup6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2780,8 +2780,8 @@ describe("1100: Jobs: Test New Job Model", () => {
       return request(appUrl)
           .patch(`/api/v3/Jobs/${encodedJobIdGroup2}`)
           .send({ 
-            statusCode: "update status of a job", 
-            statusMessage: "job finished/blocked/etc", 
+            statusMessage: "update status of a job", 
+            statusCode: "job finished/blocked/etc", 
           })
           .set("Accept", "application/json")
           .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2792,8 +2792,8 @@ describe("1100: Jobs: Test New Job Model", () => {
       return request(appUrl)
           .patch(`/api/v3/Jobs/${encodedJobIdGroup4}`)
           .send({ 
-            statusCode: "update status of a job", 
-            statusMessage: "job finished/blocked/etc", 
+            statusMessage: "update status of a job", 
+            statusCode: "job finished/blocked/etc", 
           })
           .set("Accept", "application/json")
           .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2804,8 +2804,8 @@ describe("1100: Jobs: Test New Job Model", () => {
       return request(appUrl)
           .patch(`/api/v3/Jobs/${encodedJobIdGroup3}`)
           .send({ 
-            statusCode: "update status of a job", 
-            statusMessage: "job finished/blocked/etc", 
+            statusMessage: "update status of a job", 
+            statusCode: "job finished/blocked/etc", 
           })
           .set("Accept", "application/json")
           .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2816,8 +2816,8 @@ describe("1100: Jobs: Test New Job Model", () => {
       return request(appUrl)
           .patch(`/api/v3/Jobs/${encodedJobIdGroup5}`)
           .send({ 
-            statusCode: "update status of a job", 
-            statusMessage: "job finished/blocked/etc", 
+            statusMessage: "update status of a job", 
+            statusCode: "job finished/blocked/etc", 
           })
           .set("Accept", "application/json")
           .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2829,8 +2829,8 @@ describe("1100: Jobs: Test New Job Model", () => {
       return request(appUrl)
           .patch(`/api/v3/Jobs/${encodedJobIdGroup6}`)
           .send({ 
-            statusCode: "update status of a job", 
-            statusMessage: "job finished/blocked/etc", 
+            statusMessage: "update status of a job", 
+            statusCode: "job finished/blocked/etc", 
           })
           .set("Accept", "application/json")
           .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2842,8 +2842,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroup4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2855,8 +2855,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroup2}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2868,8 +2868,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroup5}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2881,8 +2881,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroup3}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2894,8 +2894,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroup6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -2907,8 +2907,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroup6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .expect(TestData.AccessForbiddenStatusCode)
@@ -2919,8 +2919,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec1}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2932,8 +2932,8 @@ describe("1100: Jobs: Test New Job Model", () => {
   return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobIdUserSpec2}`)
       .send({ 
-        statusCode: "update status of a job", 
-        statusMessage: "job finished/blocked/etc", 
+        statusMessage: "update status of a job", 
+        statusCode: "job finished/blocked/etc", 
       })
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2945,8 +2945,8 @@ describe("1100: Jobs: Test New Job Model", () => {
   return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobIdUserSpec3}`)
       .send({ 
-        statusCode: "update status of a job", 
-        statusMessage: "job finished/blocked/etc", 
+        statusMessage: "update status of a job", 
+        statusCode: "job finished/blocked/etc", 
       })
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2958,8 +2958,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -2971,8 +2971,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec2}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2984,8 +2984,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -2997,8 +2997,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec3}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -3010,8 +3010,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec5}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -3023,8 +3023,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -3036,8 +3036,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -3049,8 +3049,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec2}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -3062,8 +3062,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec5}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -3075,8 +3075,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -3088,8 +3088,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -3101,8 +3101,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec7}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser52}` })
@@ -3114,8 +3114,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser52}` })
@@ -3127,8 +3127,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdUserSpec5}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser52}` })
@@ -3140,8 +3140,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec1}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -3153,8 +3153,8 @@ describe("1100: Jobs: Test New Job Model", () => {
   return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec2}`)
       .send({ 
-        statusCode: "update status of a job", 
-        statusMessage: "job finished/blocked/etc", 
+        statusMessage: "update status of a job", 
+        statusCode: "job finished/blocked/etc", 
       })
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -3166,8 +3166,8 @@ describe("1100: Jobs: Test New Job Model", () => {
   return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec3}`)
       .send({ 
-        statusCode: "update status of a job", 
-        statusMessage: "job finished/blocked/etc", 
+        statusMessage: "update status of a job", 
+        statusCode: "job finished/blocked/etc", 
       })
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -3179,8 +3179,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenAdmin}` })
@@ -3192,8 +3192,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec2}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -3205,8 +3205,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -3218,8 +3218,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec3}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -3231,8 +3231,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec5}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -3244,8 +3244,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
@@ -3257,8 +3257,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -3270,8 +3270,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec2}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -3283,8 +3283,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec5}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -3296,8 +3296,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -3309,8 +3309,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec6}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
@@ -3322,8 +3322,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec7}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser52}` })
@@ -3336,8 +3336,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser52}` })
@@ -3349,8 +3349,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec5}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser52}` })
@@ -3362,8 +3362,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec8}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser3}` })
@@ -3375,8 +3375,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobIdGroupSpec4}`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser3}` })
@@ -3388,8 +3388,8 @@ describe("1100: Jobs: Test New Job Model", () => {
     return request(appUrl)
         .patch(`/api/v3/Jobs/badJobId`)
         .send({ 
-          statusCode: "update status of a job", 
-          statusMessage: "job finished/blocked/etc", 
+          statusMessage: "update status of a job", 
+          statusCode: "job finished/blocked/etc", 
         })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenAdmin}` })

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -2363,7 +2363,6 @@ describe("1100: Jobs: Test New Job Model", () => {
   });
 
   it("0820: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in '#all' configuration", async () => {
-    
     return request(appUrl)
         .patch(`/api/v3/Jobs/${encodedJobId2}`)
         .send({ 
@@ -3818,7 +3817,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect("Content-Type", /json/);
   });
 
-  it("1960: Access jobs as a user from ADMIN_GROUPS, which should be one less that before prooving that delete works.", async () => {
+  it("1960: Access jobs as a user from ADMIN_GROUPS, which should be one less than before proving that delete works.", async () => {
     return request(appUrl)
         .get(`/api/v3/Jobs/`)
         .send({})
@@ -3830,5 +3829,192 @@ describe("1100: Jobs: Test New Job Model", () => {
           res.body.should.be.an("array").to.have.lengthOf(59);
         });
   }); 
+
+  it("1970: Fullquery jobs as a user from ADMIN_GROUPS ", async () => {
+    return request(appUrl)
+        .get(`/api/v3/Jobs/fullquery`)
+        .send({})
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.an("array").to.have.lengthOf(59);
+        });
+  });
+
+  it("1980: Fullquery jobs as a user from ADMIN_GROUPS that were created by admin", async () => {
+    const query = { createdBy: "admin" };
+    return request(appUrl)
+        .get(`/api/v3/Jobs/fullquery`)
+        .send({})        
+        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.an("array").to.have.lengthOf(35);
+        });
+  });
+
+  it("1990: Fullquery jobs as a user from ADMIN_GROUPS that were created by User1", async () => {
+    const query = { createdBy: "user1" };
+    return request(appUrl)
+        .get(`/api/v3/Jobs/fullquery`)
+        .send({})
+        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.an("array").to.have.lengthOf(11);
+        });
+  });
+
+  it("2000: Fullquery jobs as a user from ADMIN_GROUPS that were created by User5.1", async () => {
+    const query = { createdBy: "user5.1" };
+    return request(appUrl)
+        .get(`/api/v3/Jobs/fullquery`)
+        .send({})
+        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.an("array").to.have.lengthOf(10);
+        });
+  });
+
+  it("2010: Fullquery jobs as a user from ADMIN_GROUPS that were created by User5.2", async () => {
+    const query = { createdBy: "user5.2" };
+    return request(appUrl)
+        .get(`/api/v3/Jobs/fullquery`)
+        .send({})
+        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.an("array").to.have.lengthOf(1);
+        });
+  });
+
+  it("2020: Fullquery jobs as a user from ADMIN_GROUPS that were created by anonymous user", async () => {
+    const query = { createdBy: "anonymous" };
+    return request(appUrl)
+        .get(`/api/v3/Jobs/fullquery`)
+        .send({})
+        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.an("array").to.have.lengthOf(2);
+        });
+  });
+
+  it("2030: Fullquery jobs as a user from CREATE_JOB_GROUPS, limited by 1", async () => {
+    const query = { limit: 1 };
+    return request(appUrl)
+        .get(`/api/v3/Jobs/fullquery`)
+        .send({})
+        .query("limits=" + encodeURIComponent(JSON.stringify(query)))
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenUser1}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.an("array").to.have.lengthOf(1);
+        });
+  });
+
+  it("2040: Fullquery jobs as a user from CREATE_JOB_GROUPS that were created by admin, limited by 1", async () => {
+    const query1 = { createdBy: "admin" };
+    const query2 = { limit: 1 };
+    return request(appUrl)
+        .get(`/api/v3/Jobs/fullquery`)
+        .send({})
+        .query(
+          "fields=" + encodeURIComponent(JSON.stringify(query1)) +
+          "&limits=" + encodeURIComponent(JSON.stringify(query2))
+        )
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenUser1}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.an("array").to.have.lengthOf(1);
+        });
+  });
+
+  it("2050: Fullquery jobs as a user from CREATE_JOB_GROUPS that were created by User1", async () => {
+    const query = { createdBy: "user1" };
+    return request(appUrl)
+        .get(`/api/v3/Jobs/fullquery`)
+        .send({})
+        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenUser1}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.an("array").to.have.lengthOf(11);
+        });
+  });
+
+  it("2060: Fullquery jobs as a normal user", async () => {
+    return request(appUrl)
+        .get(`/api/v3/Jobs/fullquery`)
+        .send({})
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenUser51}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.an("array").to.have.lengthOf(10);
+        });
+  });
+
+  it("2070: Fullquery jobs as a normal user (user5.1) that were created by admin", async () => {
+    const query = { createdBy: "admin" };
+    return request(appUrl)
+        .get(`/api/v3/Jobs/fullquery`)
+        .send({})
+        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenUser51}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.an("array").to.have.lengthOf(0);
+        });
+  });
+
+  it("2080: Fullquery jobs as another normal user (user5.2)", async () => {
+    return request(appUrl)
+        .get(`/api/v3/Jobs/fullquery`)
+        .send({})
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenUser52}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.an("array").to.have.lengthOf(2);
+        });
+  });
+  
+  it("2090: Fullquery jobs as unauthenticated user, which should be forbidden", async () => {
+    return request(appUrl)
+        .get(`/api/v3/Jobs/fullquery`)
+        .send({})
+        .set("Accept", "application/json")
+        .expect(TestData.AccessForbiddenStatusCode)
+        .expect("Content-Type", /json/);
+  });
 
 });

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -3819,202 +3819,209 @@ describe("1100: Jobs: Test New Job Model", () => {
 
   it("1960: Access jobs as a user from ADMIN_GROUPS, which should be one less than before proving that delete works.", async () => {
     return request(appUrl)
-        .get(`/api/v3/Jobs/`)
-        .send({})
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenAdmin}` })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(59);
-        });
+      .get(`/api/v3/Jobs/`)
+      .send({})
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(59);
+      });
   }); 
 
-  it("1970: Fullquery jobs as a user from ADMIN_GROUPS ", async () => {
+  it("1970: Fullquery jobs as a user from ADMIN_GROUPS, limited by 5", async () => {
+    const query = { limit: 5 };
     return request(appUrl)
-        .get(`/api/v3/Jobs/fullquery`)
-        .send({})
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenAdmin}` })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(59);
-        });
+      .get(`/api/v3/Jobs/fullquery`)
+      .send({})
+      .set("Accept", "application/json")
+      .query("limits=" + encodeURIComponent(JSON.stringify(query)))
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(5);
+      });
   });
 
   it("1980: Fullquery jobs as a user from ADMIN_GROUPS that were created by admin", async () => {
     const query = { createdBy: "admin" };
     return request(appUrl)
-        .get(`/api/v3/Jobs/fullquery`)
-        .send({})        
-        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenAdmin}` })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(35);
-        });
+      .get(`/api/v3/Jobs/fullquery`)
+      .send({})        
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(35);
+      });
   });
 
   it("1990: Fullquery jobs as a user from ADMIN_GROUPS that were created by User1", async () => {
     const query = { createdBy: "user1" };
     return request(appUrl)
-        .get(`/api/v3/Jobs/fullquery`)
-        .send({})
-        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenAdmin}` })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(11);
-        });
+      .get(`/api/v3/Jobs/fullquery`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(11);
+      });
   });
 
   it("2000: Fullquery jobs as a user from ADMIN_GROUPS that were created by User5.1", async () => {
-    const query = { createdBy: "user5.1" };
+    const queryFields = { createdBy: "user5.1" };
+    const queryLimits = { limit: 5 };
     return request(appUrl)
-        .get(`/api/v3/Jobs/fullquery`)
-        .send({})
-        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenAdmin}` })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(10);
-        });
+      .get(`/api/v3/Jobs/fullquery`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(queryFields)))
+      .query("limits=" + encodeURIComponent(JSON.stringify(queryLimits)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(5);
+      });
   });
 
   it("2010: Fullquery jobs as a user from ADMIN_GROUPS that were created by User5.2", async () => {
     const query = { createdBy: "user5.2" };
     return request(appUrl)
-        .get(`/api/v3/Jobs/fullquery`)
-        .send({})
-        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenAdmin}` })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(1);
-        });
+      .get(`/api/v3/Jobs/fullquery`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(1);
+      });
   });
 
   it("2020: Fullquery jobs as a user from ADMIN_GROUPS that were created by anonymous user", async () => {
     const query = { createdBy: "anonymous" };
     return request(appUrl)
-        .get(`/api/v3/Jobs/fullquery`)
-        .send({})
-        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenAdmin}` })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(2);
-        });
+      .get(`/api/v3/Jobs/fullquery`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(2);
+      });
   });
 
-  it("2030: Fullquery jobs as a user from CREATE_JOB_GROUPS, limited by 1", async () => {
-    const query = { limit: 1 };
+  it("2040: Fullquery jobs as a user from CREATE_JOB_GROUPS that were created by admin", async () => {
+    const query = { createdBy: "admin" };
     return request(appUrl)
-        .get(`/api/v3/Jobs/fullquery`)
-        .send({})
-        .query("limits=" + encodeURIComponent(JSON.stringify(query)))
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenUser1}` })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(1);
-        });
-  });
-
-  it("2040: Fullquery jobs as a user from CREATE_JOB_GROUPS that were created by admin, limited by 1", async () => {
-    const query1 = { createdBy: "admin" };
-    const query2 = { limit: 1 };
-    return request(appUrl)
-        .get(`/api/v3/Jobs/fullquery`)
-        .send({})
-        .query(
-          "fields=" + encodeURIComponent(JSON.stringify(query1)) +
-          "&limits=" + encodeURIComponent(JSON.stringify(query2))
-        )
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenUser1}` })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(1);
-        });
+      .get(`/api/v3/Jobs/fullquery`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(14);
+      });
   });
 
   it("2050: Fullquery jobs as a user from CREATE_JOB_GROUPS that were created by User1", async () => {
     const query = { createdBy: "user1" };
     return request(appUrl)
-        .get(`/api/v3/Jobs/fullquery`)
-        .send({})
-        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenUser1}` })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(11);
-        });
+      .get(`/api/v3/Jobs/fullquery`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(11);
+      });
   });
 
   it("2060: Fullquery jobs as a normal user", async () => {
     return request(appUrl)
-        .get(`/api/v3/Jobs/fullquery`)
-        .send({})
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenUser51}` })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(10);
-        });
+      .get(`/api/v3/Jobs/fullquery`)
+      .send({})
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser51}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(10);
+      });
   });
 
   it("2070: Fullquery jobs as a normal user (user5.1) that were created by admin", async () => {
     const query = { createdBy: "admin" };
     return request(appUrl)
-        .get(`/api/v3/Jobs/fullquery`)
-        .send({})
-        .query("fields=" + encodeURIComponent(JSON.stringify(query)))
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenUser51}` })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(0);
-        });
+      .get(`/api/v3/Jobs/fullquery`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser51}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(0);
+      });
   });
 
   it("2080: Fullquery jobs as another normal user (user5.2)", async () => {
     return request(appUrl)
-        .get(`/api/v3/Jobs/fullquery`)
-        .send({})
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenUser52}` })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(2);
-        });
+      .get(`/api/v3/Jobs/fullquery`)
+      .send({})
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser52}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(2);
+      });
   });
   
   it("2090: Fullquery jobs as unauthenticated user, which should be forbidden", async () => {
     return request(appUrl)
-        .get(`/api/v3/Jobs/fullquery`)
-        .send({})
-        .set("Accept", "application/json")
-        .expect(TestData.AccessForbiddenStatusCode)
-        .expect("Content-Type", /json/);
+      .get(`/api/v3/Jobs/fullquery`)
+      .send({})
+      .set("Accept", "application/json")
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/);
+  });
+
+  it("3000: Fullfacet jobs as a user from ADMIN_GROUPS, which should always return an empty array", async () => {
+    return request(appUrl)
+      .get(`/api/v3/Jobs/fullfacet`)
+      .send({})
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(0);
+      });
+  });
+
+  it("3010: Fullfacet jobs as unauthenticated user, which should be forbidden", async () => {
+    return request(appUrl)
+      .get(`/api/v3/Jobs/fullfacet`)
+      .send({})
+      .set("Accept", "application/json")
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/);
   });
 
 });


### PR DESCRIPTION
## Description

Add `fullfacet` and `fullquery` endpoints, which were omitted before, for the new Jobs implementation.

## Motivation

While trying to see whether the `release-jobs` backend is compatible with the frontend, we realized that these two endpoints were still needed.

## Changes:

- Adding the new endpoints in `jobs.controller`. To implement them, we use the same authorization model as the one for `GET/jobs`, combined with their previous implementations, as seen on `master` branch [here](https://github.com/SciCatProject/scicat-backend-next/blob/master/src/jobs/jobs.controller.ts#L313).
- As `fullfacet` was still producing errors, due to its complicated nature, together with @nitrosx we decided it is not a necessary fix for the MVP implementation, so most of its code is commented out and it is set to always return an empty array. It will be updated in an upcoming PR.
- In `utils.ts`, the examples that were added are being used to describe the expected parameters for the `fullquery` endpoint.

## Fixes:

- Fixed the timestamps that are automatically added to the `Job schema`. Previously `createdAt` would be renamed to `DateTime` and `updatedAt` would be omitted. Now both fields are added as expected.
- In `jobs.service` fixed the order of parameters passed when calling `addCreatedByFields` during `create`. Previously `statusCode` and `statusMessage` were passed in opposite places and one would take the place the other. To complete this fix, all relevant tests were updated.

## Tests included

- Added 12 tests for `fullquery`.
- Added 2 tests for `fullfacet`. More will be added when the implementation is finished. 