### PR TITLE
feat: allow the swagger path to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `ES_FIELDS_LIMIT` | number | | The total number of fields in an index. | 1000 |
 | `ES_REFRESH` | string | | If set to `wait_for`, Elasticsearch will wait till data is inserted into the specified index before returning a response. | false |
 | `LOGGERS_CONFIG_FILE` | string | | The file name for loggers configuration, located in the project root directory. | "loggers.json" |
+| `SWAGGER_PATH` | string | Yes | swaggerPath is the path where the swagger UI will be available| "explorer"|
 
 ## Migrating from the old SciCat Backend
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scicat-backend-next",
-  "version": "4.0.0",
+  "version": "4.5.0",
   "description": "scicat-backend-next",
   "author": "",
   "private": true,

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -58,8 +58,8 @@ const configuration = () => {
   });
 
   const config = {
-    versions: {
-      api: process.env.API_VERSION || "v3",
+    VERSIONS: {
+      API: "v3",
     },
     swaggerPath: process.env.SWAGGER_PATH || "explorer",
     loggerConfigs: jsonConfigMap.loggers || [defaultLogger],

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -58,8 +58,8 @@ const configuration = () => {
   });
 
   const config = {
-    VERSIONS: {
-      API: "v3",
+    versions: {
+      api: "v3",
     },
     swaggerPath: process.env.SWAGGER_PATH || "explorer",
     loggerConfigs: jsonConfigMap.loggers || [defaultLogger],

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -58,6 +58,10 @@ const configuration = () => {
   });
 
   const config = {
+    versions: {
+      api: process.env.API_VERSION || "v3",
+    },
+    swaggerPath: process.env.SWAGGER_PATH || "explorer",
     loggerConfigs: jsonConfigMap.loggers || [defaultLogger],
     adminGroups: adminGroups.split(",").map((v) => v.trim()) ?? [],
     deleteGroups: deleteGroups.split(",").map((v) => v.trim()) ?? [],

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ async function bootstrap() {
   const configService: ConfigService<Record<string, unknown>, false> = app.get(
     ConfigService,
   );
-  const apiVersion = configService.get<string>("versions.api") ?? "v3";
+  const apiVersion = configService.get<string>("VERSIONS.API");
   const swaggerPath = `${configService.get<string>("swaggerPath")}`;
 
   const scicatLogger = app.get<ScicatLogger>(ScicatLogger);

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,8 +36,9 @@ async function bootstrap() {
       docExpansion: "none",
     },
   };
+  const swaggerPath = process.env.SWAGGER_PATH || "explorer";
 
-  SwaggerModule.setup("explorer", app, document, swaggerOptions);
+  SwaggerModule.setup(swaggerPath, app, document, swaggerOptions);
 
   app.useGlobalPipes(
     /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ async function bootstrap() {
   const configService: ConfigService<Record<string, unknown>, false> = app.get(
     ConfigService,
   );
-  const apiVersion = configService.get<string>("VERSIONS.API");
+  const apiVersion = configService.get<string>("versions.api");
   const swaggerPath = `${configService.get<string>("swaggerPath")}`;
 
   const scicatLogger = app.get<ScicatLogger>(ScicatLogger);


### PR DESCRIPTION
## Description

This PR makes the Swagger path configurable by allowing it to be set through the SWAGGER_PATH environment variable. If not provided, it defaults to “explorer.”

## Motivation

Making the Swagger path configurable improves flexibility, allowing different paths for different environments 

## Fixes:
Please provide a list of the fixes implemented by this PR

* Items added

## Changes:
Please provide a list of the changes implemented by this PR

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included


