### PR TITLE
fix: swagger-schema artifact is missing commit id

### DIFF
--- a/.github/workflows/release-and-publish-sdk.yml
+++ b/.github/workflows/release-and-publish-sdk.yml
@@ -121,7 +121,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: swagger-schema
+          name: swagger-schema-${{ github.sha }}
           path: ./swagger-schema.json
 
   generate-upload-sdk:
@@ -139,7 +139,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: swagger-schema
+          name: swagger-schema-${{ github.sha }}
           path: .
 
       - name: Generate Client

--- a/.github/workflows/upload-sdk-artifact.yml
+++ b/.github/workflows/upload-sdk-artifact.yml
@@ -39,7 +39,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: swagger-schema
+          name: swagger-schema-${{ github.sha }}
           path: ./swagger-schema.json
 
   generate-and-upload-sdk:
@@ -56,7 +56,7 @@ jobs:
 
       - uses: actions/download-artifact@v4
         with:
-          name: swagger-schema
+          name: swagger-schema-${{ github.sha }}
           path: .
 
       - name: Generate Client

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![Test](https://github.com/SciCatProject/scicat-backend-next/actions/workflows/test.yml/badge.svg)](https://github.com/SciCatProject/scicat-backend-next/actions/workflows/test.yml)
 [![Deploy](https://github.com/SciCatProject/scicat-backend-next/actions/workflows/deploy.yml/badge.svg)](https://github.com/SciCatProject/scicat-backend-next/actions/workflows/deploy.yml)
+[![Generate and upload latest SDK artifacts](https://github.com/SciCatProject/scicat-backend-next/actions/workflows/upload-sdk-artifact.yml/badge.svg?branch=master)](https://github.com/SciCatProject/scicat-backend-next/actions/workflows/upload-sdk-artifact.yml)
 [![DeepScan grade](https://deepscan.io/api/teams/8394/projects/19251/branches/494247/badge/grade.svg)](https://deepscan.io/dashboard#view=project&tid=8394&pid=19251&bid=494247)
 [![Known Vulnerabilities](https://snyk.io/test/github/SciCatProject/scicat-backend-next/master/badge.svg?targetFile=package.json)](https://snyk.io/test/github/SciCatProject/scicat-backend-next/master?targetFile=package.json)
 


### PR DESCRIPTION
## Description

Added commit ID to the swagger-schema artifact name in GitHub workflows for better traceability.

## Motivation
Ensures the generated swagger-schema artifacts are tagged with the specific commit ID, making it easier to track and associate with the corresponding build.

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included


