### PR TITLE
fix: renamed instrumentIds key to instrumentId key in convertObsolete…

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -557,7 +557,6 @@ export class DatasetsController {
         obsoleteDatasetDto,
       ) as CreateDatasetDto;
       const createdDataset = await this.datasetsService.create(datasetDto);
-      console.log("====createdDataset====", createdDataset);
       const outputObsoleteDatasetDto =
         this.convertCurrentToObsoleteSchema(createdDataset);
 

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -424,7 +424,7 @@ export class DatasetsController {
           (inputObsoleteDataset as CreateRawDatasetObsoleteDto).sampleId,
         ];
       }
-      if ("instrumentIds" in inputObsoleteDataset) {
+      if ("instrumentId" in inputObsoleteDataset) {
         propertiesModifier.instrumentIds = [
           (inputObsoleteDataset as CreateRawDatasetObsoleteDto).instrumentId,
         ];
@@ -557,7 +557,7 @@ export class DatasetsController {
         obsoleteDatasetDto,
       ) as CreateDatasetDto;
       const createdDataset = await this.datasetsService.create(datasetDto);
-
+      console.log("====createdDataset====", createdDataset);
       const outputObsoleteDatasetDto =
         this.convertCurrentToObsoleteSchema(createdDataset);
 

--- a/src/datasets/dto/update-raw-dataset-obsolete.dto.ts
+++ b/src/datasets/dto/update-raw-dataset-obsolete.dto.ts
@@ -77,7 +77,7 @@ export class UpdateRawDatasetObsoleteDto extends UpdateDatasetObsoleteDto {
   })
   @IsOptional()
   @IsString()
-  readonly instrumentId: string;
+  readonly instrumentId?: string;
 
   @IsOptional()
   investigator?: string;


### PR DESCRIPTION
…ToCurrentSchema function

## Description

convertObsoleteToCurrentSchema function contains wrong key name

## Motivation

Background on use case, changes needed

## Fixes:
Please provide a list of the fixes implemented by this PR

* Items added

## Changes:
Please provide a list of the changes implemented by this PR

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included


