### PR TITLE
refactor: enable versioing for routes

### DIFF
--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -59,7 +59,7 @@ const configuration = () => {
 
   const config = {
     versions: {
-      api: "v3",
+      api: "3",
     },
     swaggerPath: process.env.SWAGGER_PATH || "explorer",
     loggerConfigs: jsonConfigMap.loggers || [defaultLogger],

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import {
   SwaggerModule,
 } from "@nestjs/swagger";
 import { AppModule } from "./app.module";
-import { Logger, ValidationPipe } from "@nestjs/common";
+import { Logger, ValidationPipe, VersioningType } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { AllExceptionsFilter, ScicatLogger } from "./loggers/logger.service";
 
@@ -29,11 +29,20 @@ async function bootstrap() {
 
   app.enableCors();
 
-  app.setGlobalPrefix(`api/${apiVersion}`);
+  app.setGlobalPrefix("api");
+
+  // NOTE: This is a workaround to enable versioning for individual routes
+  // Version decorator can be used to specify the version for a route
+  // Read more on https://docs.nestjs.com/techniques/versioning
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: apiVersion,
+  });
+
   const config = new DocumentBuilder()
     .setTitle("SciCat backend API")
     .setDescription("This is the API for the SciCat Backend")
-    .setVersion(`api/${apiVersion}`)
+    .setVersion(`api/v${apiVersion}`)
     .addBearerAuth()
     .build();
 


### PR DESCRIPTION
## Description

This PR introduces URI versioning using app.enableVersioning() to support individual route versions, with the default version set from the configuration file (versions.api).

## Motivation

Background on use case, changes needed

## Fixes:
Please provide a list of the fixes implemented by this PR

* Items added

## Changes:
Please provide a list of the changes implemented by this PR

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included


