### PR TITLE
fix issue 1411: allow jobParams 

### DIFF
--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -621,19 +621,6 @@ export class JobsController {
     @Body() createJobDto: CreateJobDto,
   ): Promise<JobClass | null> {
     Logger.log("Creating job!");
-    // throw an error if no jobParams are passed
-    if (
-      !createJobDto.jobParams ||
-      Object.keys(createJobDto.jobParams).length == 0
-    ) {
-      throw new HttpException(
-        {
-          status: HttpStatus.BAD_REQUEST,
-          message: "Job parameters need to be defined.",
-        },
-        HttpStatus.BAD_REQUEST,
-      );
-    }
     // Validate that request matches the current configuration
     // Check job authorization
     const jobInstance = await this.instanceAuthorizationJobCreate(

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -304,7 +304,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       });
   });
 
-  it("0065: Add a new job as a user from ADMIN_GROUPS for himself/herself in '#datasetPublic' configuration with empty jobParams parameter, which should fail", async () => {
+  it("0065: Add a new job as a user from ADMIN_GROUPS for himself/herself in '#datasetPublic' configuration with empty jobParams parameter", async () => {
     const newDataset = {
       type: "all_access",
       ownerUser: "admin",
@@ -318,11 +318,13 @@ describe("1100: Jobs: Test New Job Model", () => {
       .send(newDataset)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdmin}` })
-      .expect(TestData.BadRequestStatusCode)
+      .expect(TestData.EntryCreatedStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.not.have.property("id");
-        res.body.should.have.property("message").and.be.equal("Job parameters need to be defined.");
+        res.body.should.have.property("type").and.be.string;
+        res.body.should.have.property("ownerGroup").and.be.equal("admin");
+        res.body.should.have.property("ownerUser").and.be.equal("admin");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
 
@@ -3405,7 +3407,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         .expect(TestData.SuccessfulGetStatusCode)
         .expect("Content-Type", /json/)
         .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(60);
+          res.body.should.be.an("array").to.have.lengthOf(61);
         });
   });
 
@@ -3420,7 +3422,7 @@ describe("1100: Jobs: Test New Job Model", () => {
         .expect(TestData.SuccessfulGetStatusCode)
         .expect("Content-Type", /json/)
         .then((res) => {
-          res.body.should.be.an("array").to.have.lengthOf(36);
+          res.body.should.be.an("array").to.have.lengthOf(37);
         });
   });
 
@@ -3826,7 +3828,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(59);
+        res.body.should.be.an("array").to.have.lengthOf(60);
       });
   }); 
 
@@ -3856,7 +3858,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(35);
+        res.body.should.be.an("array").to.have.lengthOf(36);
       });
   });
 


### PR DESCRIPTION
## Description
addresses issue #1411. Now user can pass empty object as jobParams.
You still must pass the jobParams however, as it is a required property in the DTO.

## Motivation

testing, etc

## Fixes:
Doesn't throw an error on empty JobParams anymore

## Changes:

test counts are adopted 

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included


