### PR TITLE
fix: handle logbook room not found without throwing an error

### DIFF
--- a/src/logbooks/logbooks.service.ts
+++ b/src/logbooks/logbooks.service.ts
@@ -66,6 +66,11 @@ export class LogbooksService {
           ),
         );
 
+        if (!res.data) {
+          Logger.log("Logbook not found", { name });
+          return null;
+        }
+
         Logger.log("Found logbook " + name, "LogbooksService.findByName");
         const { skip, limit, sortField } = JSON.parse(filters);
         Logger.log(


### PR DESCRIPTION
## Description

Added a check for !res.data in findByName to handle cases where the logbook is not found, preventing further processing on missing data.

## Motivation

 This ensures that if a logbook doesn’t exist, the function returns null gracefully, improving error handling and preventing potential issues when no data is returned.

## Fixes:
Please provide a list of the fixes implemented by this PR

* Items added

## Changes:
Please provide a list of the changes implemented by this PR

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included


