### PR TITLE
Jobs: implement fullfacet

### DIFF
--- a/src/jobs/interfaces/job-filters.interface.ts
+++ b/src/jobs/interfaces/job-filters.interface.ts
@@ -1,0 +1,28 @@
+interface IDateRange {
+  begin: string;
+  end: string;
+}
+
+interface IJobFieldObject {
+  $regex: string;
+  $options: string;
+}
+
+interface IJobIdsFieldObject {
+  $in: string[];
+}
+
+export interface IJobFields {
+  mode?: Record<string, unknown>;
+  text?: string;
+  createdAt?: IDateRange;
+  id?: IJobFieldObject;
+  _id?: IJobIdsFieldObject;
+  type?: IJobFieldObject;
+  statusCode?: IJobFieldObject;
+  jobParams?: IJobFieldObject;
+  jobResultObject?: IJobFieldObject;
+  ownerUser?: IJobFieldObject;
+  ownerGroup?: string[];
+  accessGroups?: string[];
+}

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -789,7 +789,8 @@ export class JobsController {
   @Get("/fullfacet")
   @ApiOperation({
     summary: "It returns a list of job facets matching the filter provided.",
-    description: "It returns a list of job facets matching the filter provided.",
+    description:
+      "It returns a list of job facets matching the filter provided.",
   })
   @ApiQuery({
     name: "fields",

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -22,6 +22,7 @@ import {
 import { CreateJobDto } from "./dto/create-job.dto";
 import { StatusUpdateJobDto } from "./dto/status-update-job.dto";
 import { JobClass, JobDocument } from "./schemas/job.schema";
+import { IJobFields } from "./interfaces/job-filters.interface";
 
 @Injectable({ scope: Scope.REQUEST })
 export class JobsService {
@@ -76,14 +77,14 @@ export class JobsService {
   }
 
   async fullfacet(
-    filters: IFacets<FilterQuery<JobDocument>>,
-  ): Promise<JobClass[]> {
+    filters: IFacets<IJobFields>,
+  ): Promise<Record<string, unknown>[]> {
     const fields = filters.fields ?? {};
     const facets = filters.facets ?? [];
 
     const pipeline: PipelineStage[] = createFullfacetPipeline<
       JobDocument,
-      FilterQuery<JobDocument>
+      IJobFields
     >(this.jobModel, "id", fields, facets);
 
     return await this.jobModel.aggregate(pipeline).exec();

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -3877,7 +3877,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       });
   });
 
-  it("2000: Fullquery jobs as a user from ADMIN_GROUPS that were created by User5.1", async () => {
+  it("2000: Fullquery jobs as a user from ADMIN_GROUPS that were created by User5.1, limited by 5", async () => {
     const queryFields = { createdBy: "user5.1" };
     const queryLimits = { limit: 5 };
     return request(appUrl)
@@ -4004,19 +4004,6 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect("Content-Type", /json/);
   });
 
-  it("3000: Fullfacet jobs as a user from ADMIN_GROUPS, which should always return an empty array", async () => {
-    return request(appUrl)
-      .get(`/api/v3/Jobs/fullfacet`)
-      .send({})
-      .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
-      .expect(TestData.SuccessfulGetStatusCode)
-      .expect("Content-Type", /json/)
-      .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(0);
-      });
-  });
-
   it("3010: Fullfacet jobs as unauthenticated user, which should be forbidden", async () => {
     return request(appUrl)
       .get(`/api/v3/Jobs/fullfacet`)
@@ -4026,4 +4013,149 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect("Content-Type", /json/);
   });
 
+  it("3020: Fullfacet jobs as a user from ADMIN_GROUPS that were created by admin", async () => {
+    const query = { createdBy: "admin" };
+    return request(appUrl)
+      .get(`/api/v3/Jobs/fullfacet`)
+      .send({})        
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 36 }] });
+      });
+  });
+
+  it("3030: Fullfacet jobs as a user from ADMIN_GROUPS that were created by User1", async () => {
+    const query = { createdBy: "user1" };
+    return request(appUrl)
+      .get(`/api/v3/Jobs/fullfacet`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 11 }] });
+      });
+  });
+
+  it("3040: Fullfacet jobs as a user from ADMIN_GROUPS that were created by User5.1", async () => {
+    const queryFields = { createdBy: "user5.1" };
+    return request(appUrl)
+      .get(`/api/v3/Jobs/fullfacet`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(queryFields)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 10 }] });
+      });
+  });
+
+  it("3050: Fullfacet jobs as a user from ADMIN_GROUPS that were created by User5.2", async () => {
+    const query = { createdBy: "user5.2" };
+    return request(appUrl)
+      .get(`/api/v3/Jobs/fullfacet`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 1 }] });
+      });
+  });
+
+  it("3060: Fullfacet jobs as a user from ADMIN_GROUPS that were created by anonymous user", async () => {
+    const query = { createdBy: "anonymous" };
+    return request(appUrl)
+      .get(`/api/v3/Jobs/fullfacet`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 2 }] });
+      });
+  });
+
+  it("3070: Fullfacet jobs as a user from CREATE_JOB_GROUPS that were created by admin", async () => {
+    const query = { createdBy: "admin" };
+    return request(appUrl)
+      .get(`/api/v3/Jobs/fullfacet`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 14 }] });
+      });
+  });
+
+  it("3080: Fullfacet jobs as a user from CREATE_JOB_GROUPS that were created by User1", async () => {
+    const query = { createdBy: "user1" };
+    return request(appUrl)
+      .get(`/api/v3/Jobs/fullfacet`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 11 }] });
+      });
+  });
+
+  it("3090: Fullfacet jobs as a normal user", async () => {
+    return request(appUrl)
+      .get(`/api/v3/Jobs/fullfacet`)
+      .send({})
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser51}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 10 }] });
+      });
+  });
+
+  it("3100: Fullfacet jobs as a normal user (user5.1) that were created by admin", async () => {
+    const query = { createdBy: "admin" };
+    return request(appUrl)
+      .get(`/api/v3/Jobs/fullfacet`)
+      .send({})
+      .query("fields=" + encodeURIComponent(JSON.stringify(query)))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser51}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").that.deep.contains({ all: [] });
+      });
+  });
+
+  it("3110: Fullfacet jobs as another normal user (user5.2)", async () => {
+    return request(appUrl)
+      .get(`/api/v3/Jobs/fullfacet`)
+      .send({})
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser52}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 2 }] });
+      });
+  });
 });


### PR DESCRIPTION
## Description

Fully implement the `fullfacet` endpoint for Jobs.

## Motivation

As seen here: https://github.com/SciCatProject/scicat-backend-next/pull/1422, the `fullfacet` endpoint was previously set to always return an empty array.

## Changes

To be able to properly check the authorization, we first execute a `fullquery` with the same filters that the `fullfacet` is going to be executed with. This allows us to access the job configuration, based on the job type, which is needed to perform `jobsInstanceAccess` authorization and ability checks. This was the only feasible workaround to be able to retrieve this information. After performing the checks we keep a list of ids of the jobs that are accessible by the user, and add it to the facet filters. This way when the `fullfacet` is executed, it will only run on these specific jobs accessible. 

## Tests

Added more `fullfacet` tests in the `Jobs.js` test file.