### PR TITLE
docs: update github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue-template.md
+++ b/.github/ISSUE_TEMPLATE/issue-template.md
@@ -1,25 +1,23 @@
 ---
 name: Issue template
-about: Describe this issue purpose here.
-
+about: Generic template for backend issues
 ---
 
-## Issue Name (title)
-Please enter the title for this github issue
+## Summary
+<!-- Description of the issue -->
 
-### Summary
-Description of the issue
+## Steps to Reproduce
+<!-- Describe how to reproduce the issue -->
 
-### Steps to Reproduce
-Describe how to reproduce the issue
+## Current Behaviour
+<!-- Describe the current behavior if it is relevant -->
 
-### Current Behaviour
-Describe the current behavior if it is relevant
+## Expected Behaviour
+<!-- Describe the expected behavior if it is relevant -->
 
-### Expected Behaviour
-Describe the expected behavior if it is relevant
+## Details
+<!-- Provide all the details related to this issue. Also include screenshots, wireframes or mockups if they help.
+Link related issues in the frontend or other repositories if relevant. -->
 
-### Details
-Provide all the details related to this issue. Also include screenshots, wireframes or mockups if they help.
 
-__PS__: make sure to add the proper tags to the issue
+<!-- P.S. Make sure to add the proper tags to the issue -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,38 @@
-## Description
+<!--
+Follow semantic-release guidelines for the PR title, which is used in the changelog.
 
-Short description of the pull request
+Title should follow the format `<type>(<scope>): <subject>`, where
+- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
+- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
+- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period
+
+See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
+-->
+
+## Description
+<!-- Short description of the pull request -->
 
 ## Motivation
+<!-- Background on use case, changes needed -->
 
-Background on use case, changes needed
+## Fixes
+<!-- Please provide a list of the issues fixed by this PR -->
 
-## Fixes:
-Please provide a list of the fixes implemented by this PR
-
-* Items added
+* Bug fixed (#X)
 
 ## Changes:
-Please provide a list of the changes implemented by this PR
+<!-- Please provide a list of the changes implemented by this PR -->
 
 * changes made
 
 ## Tests included
 
 - [ ] Included for each change/fix?
-- [ ] Passing? (Merge will not be approved unless this is checked) 
+- [ ] Passing? <!-- Merge will not be approved unless tests pass -->
 
 ## Documentation
-- [ ] swagger documentation updated \[required\]
-- [ ] official documentation updated \[nice-to-have]
+- [ ] swagger documentation updated (required for API changes)
+- [ ] official documentation updated
 
 ### official documentation info
-If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included
-
-
+<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

--- a/.github/pr-title-checker-config.json
+++ b/.github/pr-title-checker-config.json
@@ -9,7 +9,7 @@
   },
   "MESSAGES": {
     "success": "All OK",
-    "failure": "PR title not following the semantic-release guidelines. Please check https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more information.",
+    "failure": "PR title not following the semantic-release guidelines (<type>(<scope>): <subject>). Please check https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more information.",
     "notice": ""
   }
 }


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->
## Description
Updates the PR and issue templates

## Motivation
<!-- Background on use case, changes needed -->

PRs were failing the pr-title-checker action because the title format wasn't well documented. Rather than add this to our documentation, I think it is easier to just mention it in the PR template.

While I was doing that I also changed both templates to include instructions as comments. I think this is common in other github projects.

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* New github templates

## Tests included

- [x] Included for each change/fix? (N/A)
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [x] swagger documentation updated (required for API changes) (N/A)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
I think the PR template is a better place for documentation than the other repo.