### PR TITLE
fix: sdk generation error caused by incorrect swagger decorator

### DIFF
--- a/src/published-data/published-data.controller.ts
+++ b/src/published-data/published-data.controller.ts
@@ -22,6 +22,7 @@ import {
 } from "./dto/update-published-data.dto";
 import {
   ApiBearerAuth,
+  ApiBody,
   ApiOperation,
   ApiParam,
   ApiQuery,
@@ -76,10 +77,7 @@ export class PublishedDataController {
   async create(
     @Body() createPublishedDataDto: CreatePublishedDataDto,
   ): Promise<PublishedData> {
-    return this.publishedDataService.create({
-      ...createPublishedDataDto,
-      status: "pending_registration",
-    });
+    return this.publishedDataService.create(createPublishedDataDto);
   }
 
   // GET /publisheddata
@@ -445,8 +443,7 @@ export class PublishedDataController {
     description: "The DOI of the published data.",
     type: String,
   })
-  @ApiParam({
-    name: "data",
+  @ApiBody({
     description:
       "The edited data that will be updated in the database and with OAI Provider if defined.",
     type: UpdatePublishedDataDto,

--- a/src/published-data/schemas/published-data.schema.ts
+++ b/src/published-data/schemas/published-data.schema.ts
@@ -188,7 +188,7 @@ export class PublishedData {
     description:
       "Indication of position in publication workflow e.g. doiRegistered",
   })
-  @Prop({ type: String, required: false })
+  @Prop({ type: String, required: false, default: "pending_registration" })
   status: string;
 
   @ApiProperty({

--- a/test/PublishedData.js
+++ b/test/PublishedData.js
@@ -15,6 +15,7 @@ let accessTokenAdminIngestor = null,
   doi = null;
 
 const publishedData = { ...TestData.PublishedData };
+const defaultStatus = "pending_registration";
 
 const origDataBlock = { ...TestData.OrigDataBlockCorrect1 };
 
@@ -38,7 +39,7 @@ describe("1600: PublishedData: Test of access to published data", () => {
     db.collection("Dataset").deleteMany({});
     db.collection("PublishedData").deleteMany({});
   });
-  beforeEach(async() => {
+  beforeEach(async () => {
     accessTokenAdminIngestor = await utils.getToken(appUrl, {
       username: "adminIngestor",
       password: TestData.Accounts["adminIngestor"]["password"],
@@ -65,7 +66,22 @@ describe("1600: PublishedData: Test of access to published data", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have.property("publisher").and.be.string;
+        res.body.should.have.property("status").and.equal(defaultStatus);
         doi = encodeURIComponent(res.body["doi"]);
+      });
+  });
+
+  it("0015: adds a published data without specifying a status should assign the default status", async () => {
+    delete publishedData.status;
+    return request(appUrl)
+      .post("/api/v3/PublishedData")
+      .send(publishedData)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("status").and.equal(defaultStatus);
       });
   });
 


### PR DESCRIPTION
## Description

This PR aims to fix SDK generation error caused by incorrect swagger decorator.

The changes include:
- Replaced incorrect @ApiParam with @ApiBody in published-data controller
- Set a default value for the status field in the PublishedData schema to "pending_registration".

## Motivation

The github workflow for uploading latest SDK artifact dysfunctioning.

## Fixes:
Please provide a list of the fixes implemented by this PR

* Items added

## Changes:
Please provide a list of the changes implemented by this PR

* changes made

## Tests included

- [x] Included for each change/fix?
- [x] Passing? (Merge will not be approved unless this is checked) 

## Documentation
- [ ] swagger documentation updated \[required\]
- [ ] official documentation updated \[nice-to-have]

### official documentation info
If you have updated the official documentation, please provide PR # and URL of the pages where the updates are included


