### PR TITLE
fix: patch dataset

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -1222,7 +1222,7 @@ export class DatasetsController {
     @Req() request: Request,
     @Param("pid") pid: string,
     @Body()
-    updateDatasetDto:
+    updateDatasetObsoleteDto:
       | PartialUpdateRawDatasetObsoleteDto
       | PartialUpdateDerivedDatasetObsoleteDto,
   ): Promise<OutputDatasetObsoleteDto | null> {
@@ -1234,7 +1234,7 @@ export class DatasetsController {
 
     // NOTE: Default validation pipe does not validate union types. So we need custom validation.
     await this.validateDatasetObsolete(
-      updateDatasetDto,
+      updateDatasetObsoleteDto,
       foundDataset.type === "raw"
         ? PartialUpdateRawDatasetObsoleteDto
         : PartialUpdateDerivedDatasetObsoleteDto,
@@ -1255,6 +1255,10 @@ export class DatasetsController {
     if (!canUpdate) {
       throw new ForbiddenException("Unauthorized to update this dataset");
     }
+
+    const updateDatasetDto = this.convertObsoleteToCurrentSchema(
+      updateDatasetObsoleteDto,
+    ) as UpdateDatasetDto;
 
     return this.convertCurrentToObsoleteSchema(
       await this.datasetsService.findByIdAndUpdate(pid, updateDatasetDto),

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -1233,12 +1233,15 @@ export class DatasetsController {
     }
 
     // NOTE: Default validation pipe does not validate union types. So we need custom validation.
-    await this.validateDatasetObsolete(
-      updateDatasetObsoleteDto,
-      foundDataset.type === "raw"
-        ? PartialUpdateRawDatasetObsoleteDto
-        : PartialUpdateDerivedDatasetObsoleteDto,
-    );
+    const validatedUpdateDatasetObsoleteDto =
+      (await this.validateDatasetObsolete(
+        updateDatasetObsoleteDto,
+        foundDataset.type === "raw"
+          ? PartialUpdateRawDatasetObsoleteDto
+          : PartialUpdateDerivedDatasetObsoleteDto,
+      )) as
+        | PartialUpdateRawDatasetObsoleteDto
+        | PartialUpdateDerivedDatasetObsoleteDto;
 
     // NOTE: We need DatasetClass instance because casl module can not recognize the type from dataset mongo database model. If other fields are needed can be added later.
     const datasetInstance =
@@ -1257,12 +1260,13 @@ export class DatasetsController {
     }
 
     const updateDatasetDto = this.convertObsoleteToCurrentSchema(
-      updateDatasetObsoleteDto,
+      validatedUpdateDatasetObsoleteDto,
     ) as UpdateDatasetDto;
 
-    return this.convertCurrentToObsoleteSchema(
+    const res = this.convertCurrentToObsoleteSchema(
       await this.datasetsService.findByIdAndUpdate(pid, updateDatasetDto),
     );
+    return res;
   }
 
   // PUT /datasets/:id

--- a/test/DatasetAuthorization.js
+++ b/test/DatasetAuthorization.js
@@ -504,7 +504,11 @@ describe("0300: DatasetAuthorization: Test access to dataset", () => {
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
       .expect(TestData.SuccessfulPatchStatusCode)
-      .expect("Content-Type", /json/);
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body["pid"].should.be.equal(datasetPid2);
+        res.body["isPublished"].should.be.equal(true);
+      });
   });
 
   it("0350: full query for datasets for User 2", async () => {

--- a/test/RawDataset.js
+++ b/test/RawDataset.js
@@ -276,6 +276,22 @@ describe("1900: RawDataset: Raw Datasets", () => {
     );
   });
 
+  it("0125: should update proposal of the dataset", async () => {
+    return request(appUrl)
+      .patch("/api/v3/datasets/" + pid)
+      .send(TestData.PatchProposal1)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulPatchStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("proposalId").and.be.string;
+        res.body.should.have
+          .property("proposalId")
+          .and.be.equal(TestData.PatchProposal1["proposal"]);
+      });
+  });
+
   it("0130: should update comment of the dataset", async () => {
     return request(appUrl)
       .patch("/api/v3/datasets/" + pid)

--- a/test/RawDataset.js
+++ b/test/RawDataset.js
@@ -288,7 +288,39 @@ describe("1900: RawDataset: Raw Datasets", () => {
         res.body.should.have.property("proposalId").and.be.string;
         res.body.should.have
           .property("proposalId")
-          .and.be.equal(TestData.PatchProposal1["proposal"]);
+          .and.be.equal(TestData.PatchProposal1["proposalId"]);
+      });
+  });
+
+  it("0126: should update instrument of the dataset", async () => {
+    return request(appUrl)
+      .patch("/api/v3/datasets/" + pid)
+      .send(TestData.PatchInstrument1)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulPatchStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("instrumentId").and.be.string;
+        res.body.should.have
+          .property("instrumentId")
+          .and.be.equal(TestData.PatchInstrument1["instrumentId"]);
+      });
+  });
+
+  it("0127: should update sample of the dataset", async () => {
+    return request(appUrl)
+      .patch("/api/v3/datasets/" + pid)
+      .send(TestData.PatchSample1)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulPatchStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("sampleId").and.be.string;
+        res.body.should.have
+          .property("sampleId")
+          .and.be.equal(TestData.PatchSample1["sampleId"]);
       });
   });
 

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -838,6 +838,14 @@ const TestData = {
     proposalId: "10.540.16635/20240124",
   },
 
+  PatchInstrument1: {
+    instrumentId: "fb0f3b58-92c9-11ef-9aeb-632c6e2960a1",
+  },
+
+  PatchSample1: {
+    sampleId: "f3cfc114-92c9-11ef-8ed4-f3b97158e36b",
+  },
+
   PatchComment: {
     comment: "test",
   },

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -834,6 +834,10 @@ const TestData = {
     name: "ESS-wrong",
   },
 
+  PatchProposal1: {
+    proposalId: "10.540.16635/20240124",
+  },
+
   PatchComment: {
     comment: "test",
   },


### PR DESCRIPTION
## Description
This PR fixes the issues found that an update on a dataset does not update proposal id or any of the fields introduced with the unified dataset schema

## Motivation
This PR is getting us closer to the a unified dataset schema

## Fixes
* Dataset controller
* Raw Dataset tests
* Derived dataset tests

## Tests included

- [X] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [X] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
