### PR TITLE
ci(ts-sdk): npm publish dist folder only

### DIFF
--- a/.github/workflows/release-and-publish-sdk.yml
+++ b/.github/workflows/release-and-publish-sdk.yml
@@ -193,6 +193,7 @@ jobs:
         run: |
           npm install
           npm run build
+          cd dist
           npm publish --access public
         working-directory: ./sdk/typescript-angular/
         env:


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This pull request addresses the issue where the npm publish job was incorrectly uploading the original .ts TypeScript files instead of the intended .d.ts TypeScript Declaration Files.

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
