### PR TITLE
ci(py-sdk): fix python package names

### DIFF
--- a/.github/openapi/python-config.json
+++ b/.github/openapi/python-config.json
@@ -1,5 +1,5 @@
 {
   "generatorName": "python",
-  "packageName": "scicat-sdk-py",
+  "packageName": "scicat_sdk_py",
   "projectName": "scicat-sdk-py"
 }

--- a/.github/openapi/python-config.json
+++ b/.github/openapi/python-config.json
@@ -1,5 +1,5 @@
 {
   "generatorName": "python",
   "packageName": "scicat_sdk_py",
-  "projectName": "scicat-sdk-py"
+  "projectName": "scicat_sdk_py"
 }

--- a/.github/openapi/python-pydantic-v1-config.json
+++ b/.github/openapi/python-pydantic-v1-config.json
@@ -1,5 +1,5 @@
 {
   "generatorName": "python-pydantic-v1",
   "packageName": "scicat_sdk_pydantic",
-  "projectName": "scicat-sdk-pydantic"
+  "projectName": "scicat_sdk_pydantic"
 }

--- a/.github/openapi/python-pydantic-v1-config.json
+++ b/.github/openapi/python-pydantic-v1-config.json
@@ -1,5 +1,5 @@
 {
   "generatorName": "python-pydantic-v1",
-  "packageName": "scicat-sdk-pydantic",
+  "packageName": "scicat_sdk_pydantic",
   "projectName": "scicat-sdk-pydantic"
 }


### PR DESCRIPTION
Python package names are not allowed to contain '-', which is a syntax error. Replace with '_'.

<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
The package names in Python shouldn't contain hyphens, as this is a syntax error.

Replacing with underscore fixes this, but the drawback is that now project and package names differ. This is fine but not recommended. But whether only the pacakge name should be changed or you also modify the project names on Pypi is your call. 

## Motivation
Both Python sdk are not usable as the import fails with a syntax error. 


## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* rename Python sdk package names

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
