### PR TITLE
feat: add parent proposal to the proposal document

### DIFF
--- a/src/proposals/dto/update-proposal.dto.ts
+++ b/src/proposals/dto/update-proposal.dto.ts
@@ -124,6 +124,15 @@ export class UpdateProposalDto extends OwnableDto {
   @IsOptional()
   @IsObject()
   readonly metadata?: Record<string, unknown>;
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Parent proposal id.",
+  })
+  @IsOptional()
+  @IsString()
+  readonly parentProposalId?: string;
 }
 
 export class PartialUpdateProposalDto extends PartialType(UpdateProposalDto) {}

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -17,6 +17,7 @@ import {
   BadRequestException,
   Logger,
   InternalServerErrorException,
+  NotFoundException,
 } from "@nestjs/common";
 import { Request } from "express";
 import { ProposalsService } from "./proposals.service";
@@ -578,7 +579,10 @@ export class ProposalsController {
     const proposal = await this.proposalsService.findOne({
       proposalId,
     });
-    if (!proposal) return { canAccess: false };
+
+    if (!proposal) {
+      throw new NotFoundException(`Proposal with ${proposalId} not found`);
+    }
 
     const canAccess = await this.permissionChecker(
       Action.ProposalsRead,

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -14,10 +14,8 @@ import {
   Req,
   ForbiddenException,
   ConflictException,
-  BadRequestException,
   Logger,
   InternalServerErrorException,
-  NotFoundException,
 } from "@nestjs/common";
 import { Request } from "express";
 import { ProposalsService } from "./proposals.service";
@@ -90,14 +88,17 @@ export class ProposalsController {
     return proposalInstance;
   }
 
-  private async permissionChecker(
+  private permissionChecker(
     group: Action,
-    proposal: ProposalClass | CreateProposalDto,
+    proposal: ProposalClass | CreateProposalDto | null,
     request: Request,
   ) {
-    const proposalInstance = this.generateProposalInstanceForPermissions(
-      proposal as ProposalClass,
-    );
+    if (!proposal) {
+      return false;
+    }
+
+    const proposalInstance =
+      this.generateProposalInstanceForPermissions(proposal);
 
     const user: JWTUser = request.user as JWTUser;
     const ability = this.caslAbilityFactory.proposalsInstanceAccess(user);
@@ -173,34 +174,29 @@ export class ProposalsController {
       proposalId: id,
     });
 
-    if (proposal) {
-      const canDoAction = await this.permissionChecker(
-        group,
-        proposal,
-        request,
-      );
+    const canDoAction = this.permissionChecker(group, proposal, request);
 
-      if (!canDoAction) {
-        throw new ForbiddenException("Unauthorized to this proposal");
-      }
+    if (!canDoAction) {
+      throw new ForbiddenException("Unauthorized to this proposal");
     }
+
     return proposal;
   }
 
-  private async checkPermissionsForProposalCreate(
+  private checkPermissionsForProposalCreate(
     request: Request,
     proposal: CreateProposalDto,
     group: Action,
   ) {
-    if (!proposal) {
-      throw new BadRequestException("Not able to create this proposal");
-    }
-    const canDoAction = await this.permissionChecker(group, proposal, request);
+    const canDoAction = this.permissionChecker(group, proposal, request);
+
     if (!canDoAction) {
       throw new ForbiddenException("Unauthorized to create this proposal");
     }
+
     return proposal;
   }
+
   updateFiltersForList(
     request: Request,
     mergedFilters: IFilters<ProposalDocument, IProposalFields>,
@@ -273,7 +269,7 @@ export class ProposalsController {
     @Req() request: Request,
     @Body() createProposalDto: CreateProposalDto,
   ): Promise<ProposalClass> {
-    const proposalDTO = await this.checkPermissionsForProposalCreate(
+    const proposalDTO = this.checkPermissionsForProposalCreate(
       request,
       createProposalDto,
       Action.ProposalsCreate,
@@ -580,11 +576,7 @@ export class ProposalsController {
       proposalId,
     });
 
-    if (!proposal) {
-      throw new NotFoundException(`Proposal with ${proposalId} not found`);
-    }
-
-    const canAccess = await this.permissionChecker(
+    const canAccess = this.permissionChecker(
       Action.ProposalsRead,
       proposal,
       request,

--- a/src/proposals/schemas/proposal.schema.ts
+++ b/src/proposals/schemas/proposal.schema.ts
@@ -167,6 +167,21 @@ export class ProposalClass extends OwnableClass {
   })
   @Prop({ type: Object, required: false, default: {} })
   metadata?: Record<string, unknown>;
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Parent proposal id",
+    default: null,
+    nullable: true,
+  })
+  @Prop({
+    type: String,
+    required: false,
+    default: null,
+    ref: "Proposal",
+  })
+  parentProposalId: string;
 }
 
 export const ProposalSchema = SchemaFactory.createForClass(ProposalClass);

--- a/src/samples/samples.controller.ts
+++ b/src/samples/samples.controller.ts
@@ -87,14 +87,17 @@ export class SamplesController {
 
     return sampleInstance;
   }
-  private async permissionChecker(
+
+  private permissionChecker(
     group: Action,
-    sample: SampleClass | CreateSampleDto,
+    sample: SampleClass | CreateSampleDto | null,
     request: Request,
   ) {
-    const sampleInstance = this.generateSampleInstanceForPermissions(
-      sample as SampleClass,
-    );
+    if (!sample) {
+      return false;
+    }
+
+    const sampleInstance = this.generateSampleInstanceForPermissions(sample);
 
     const user: JWTUser = request.user as JWTUser;
     const ability = this.caslAbilityFactory.samplesInstanceAccess(user);
@@ -164,28 +167,26 @@ export class SamplesController {
       sampleId: id,
     });
 
-    if (sample) {
-      const canDoAction = await this.permissionChecker(group, sample, request);
-      if (!canDoAction) {
-        throw new ForbiddenException("Unauthorized to this sample");
-      }
+    const canDoAction = this.permissionChecker(group, sample, request);
+
+    if (!canDoAction) {
+      throw new ForbiddenException("Unauthorized to this sample");
     }
 
     return sample;
   }
 
-  private async checkPermissionsForSampleCreate(
+  private checkPermissionsForSampleCreate(
     request: Request,
     sample: CreateSampleDto,
     group: Action,
   ) {
-    if (!sample) {
-      throw new BadRequestException("Not able to create this sample");
-    }
-    const canDoAction = await this.permissionChecker(group, sample, request);
+    const canDoAction = this.permissionChecker(group, sample, request);
+
     if (!canDoAction) {
       throw new ForbiddenException("Unauthorized to create this sample");
     }
+
     return sample;
   }
 
@@ -271,11 +272,12 @@ export class SamplesController {
     @Req() request: Request,
     @Body() createSampleDto: CreateSampleDto,
   ): Promise<SampleClass> {
-    const sampleDTO = await this.checkPermissionsForSampleCreate(
+    const sampleDTO = this.checkPermissionsForSampleCreate(
       request,
       createSampleDto,
       Action.SampleCreate,
     );
+
     return this.samplesService.create(sampleDTO);
   }
 
@@ -551,6 +553,7 @@ export class SamplesController {
       id,
       Action.SampleRead,
     );
+
     return sample;
   }
 
@@ -583,8 +586,8 @@ export class SamplesController {
     const sample = await this.samplesService.findOne({
       sampleId: id,
     });
-    if (!sample) return { canAccess: false };
-    const canAccess = await this.permissionChecker(
+
+    const canAccess = this.permissionChecker(
       Action.SampleRead,
       sample,
       request,

--- a/src/users/users.controller.spec.ts
+++ b/src/users/users.controller.spec.ts
@@ -12,7 +12,7 @@ class UsersServiceMock {
     return { id };
   }
 
-  async findByIdUserSettings(userId: string) {
+  async findByIdUserSettings() {
     return mockUserSettings;
   }
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -106,7 +106,7 @@ export class UsersController {
     description:
       "This endpoint is deprecated and will be removed soon. Use /auth/login instead",
   })
-  async login(@Req() req: Record<string, unknown>): Promise<null> {
+  async login(): Promise<null> {
     return null;
   }
 

--- a/test/Proposal.js
+++ b/test/Proposal.js
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 "use strict";
-
+const { faker } = require("@faker-js/faker");
 const utils = require("./LoginUtils");
 const { TestData } = require("./TestData");
 

--- a/test/Proposal.js
+++ b/test/Proposal.js
@@ -8,14 +8,16 @@ let accessTokenProposalIngestor = null,
   accessTokenAdminIngestor = null,
   accessTokenArchiveManager = null,
   defaultProposalId = null,
+  minimalProposalId = null,
   proposalId = null,
+  proposalWithParentId = null,
   attachmentId = null;
 
 describe("1500: Proposal: Simple Proposal", () => {
   before(() => {
     db.collection("Proposal").deleteMany({});
   });
-  beforeEach(async() => {
+  beforeEach(async () => {
     accessTokenProposalIngestor = await utils.getToken(appUrl, {
       username: "proposalIngestor",
       password: TestData.Accounts["proposalIngestor"]["password"],
@@ -89,7 +91,7 @@ describe("1500: Proposal: Simple Proposal", () => {
         res.body.should.have.property("ownerGroup").and.be.string;
         res.body.should.have.property("proposalId").and.be.string;
         defaultProposalId = res.body["proposalId"];
-        proposalId = encodeURIComponent(res.body["proposalId"]);
+        minimalProposalId = encodeURIComponent(res.body["proposalId"]);
       });
   });
 
@@ -216,7 +218,46 @@ describe("1500: Proposal: Simple Proposal", () => {
       });
   });
 
-  it("0120: should delete this proposal attachment", async () => {
+  it("0120: adds a new proposal with parent proposal", async () => {
+    const proposalWithParentProposal = {
+      ...TestData.ProposalCorrectComplete,
+      proposalId: "20170268",
+      parentProposalId: proposalId,
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Proposals")
+      .send(proposalWithParentProposal)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenProposalIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("ownerGroup").and.be.string;
+        res.body.should.have.property("proposalId").and.be.string;
+        proposalWithParentId = res.body.proposalId;
+        res.body.should.have.property("parentProposalId").and.be.string;
+        res.body.parentProposalId.should.be.equal(proposalId);
+      });
+  });
+
+  it("0120: updates a proposal with a new parent proposal", async () => {
+    return request(appUrl)
+      .patch("/api/v3/Proposals/" + proposalWithParentId)
+      .send({ parentProposalId: minimalProposalId })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulPatchStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("ownerGroup").and.be.string;
+        res.body.should.have.property("proposalId").and.be.string;
+        res.body.should.have.property("parentProposalId").and.be.string;
+        res.body.parentProposalId.should.be.equal(minimalProposalId);
+      });
+  });
+
+  it("0130: should delete this proposal attachment", async () => {
     return request(appUrl)
       .delete(
         "/api/v3/Proposals/" + proposalId + "/attachments/" + attachmentId,
@@ -226,7 +267,7 @@ describe("1500: Proposal: Simple Proposal", () => {
       .expect(TestData.SuccessfulDeleteStatusCode);
   });
 
-  it("0130: admin can remove all existing proposals", async () => {
+  it("0140: admin can remove all existing proposals", async () => {
     return await request(appUrl)
       .get("/api/v3/Proposals")
       .set("Accept", "application/json")

--- a/test/Proposal.js
+++ b/test/Proposal.js
@@ -218,7 +218,7 @@ describe("1500: Proposal: Simple Proposal", () => {
       });
   });
 
-  it("0120: adds a new proposal with parent proposal", async () => {
+  it("0115: adds a new proposal with parent proposal", async () => {
     const proposalWithParentProposal = {
       ...TestData.ProposalCorrectComplete,
       proposalId: faker.string.numeric(8),

--- a/test/Proposal.js
+++ b/test/Proposal.js
@@ -221,7 +221,7 @@ describe("1500: Proposal: Simple Proposal", () => {
   it("0120: adds a new proposal with parent proposal", async () => {
     const proposalWithParentProposal = {
       ...TestData.ProposalCorrectComplete,
-      proposalId: "20170268",
+      proposalId: faker.string.numeric(8),
       parentProposalId: proposalId,
     };
 

--- a/test/ProposalAuthorization.js
+++ b/test/ProposalAuthorization.js
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 "use strict";
 
+const { faker } = require("@faker-js/faker");
 const utils = require("./LoginUtils");
 const { TestData } = require("./TestData");
 const sandbox = require("sinon").createSandbox();
@@ -22,21 +23,21 @@ let proposalPid1 = null,
 
 const proposal1 = {
   ...TestData.ProposalCorrectMin,
-  proposalId: "20170268",
+  proposalId: faker.string.numeric(8),
   ownerGroup: "group4",
   accessGroups: ["group5"],
 };
 
 const proposal2 = {
   ...TestData.ProposalCorrectComplete,
-  proposalId: "20170269",
+  proposalId: faker.string.numeric(8),
   ownerGroup: "group1",
   accessGroups: ["group3"],
 };
 
 const proposal3 = {
   ...TestData.ProposalCorrectMin,
-  proposalId: "20170270",
+  proposalId: faker.string.numeric(8),
   ownerGroup: "group2",
   accessGroups: ["group3"],
 };
@@ -53,7 +54,7 @@ describe("1400: ProposalAuthorization: Test access to proposal", () => {
   before(() => {
     db.collection("Proposal").deleteMany({});
   });
-  beforeEach(async() => {
+  beforeEach(async () => {
     accessTokenAdminIngestor = await utils.getToken(appUrl, {
       username: "adminIngestor",
       password: TestData.Accounts["adminIngestor"]["password"],

--- a/test/RawDataset.js
+++ b/test/RawDataset.js
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 "use strict";
 
+const { faker } = require("@faker-js/faker");
 var utils = require("./LoginUtils");
 const { TestData } = require("./TestData");
 
@@ -283,9 +284,13 @@ describe("1900: RawDataset: Raw Datasets", () => {
   });
 
   it("01250: adds a new proposal for pattching in the existing dataset", async () => {
+    const newProposal = {
+      ...TestData.ProposalCorrectComplete,
+      proposalId: faker.string.numeric(8),
+    };
     return request(appUrl)
       .post("/api/v3/Proposals")
-      .send(TestData.ProposalCorrectComplete)
+      .send(newProposal)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessProposalToken}` })
       .expect(TestData.EntryCreatedStatusCode)

--- a/test/RawDataset.js
+++ b/test/RawDataset.js
@@ -283,7 +283,7 @@ describe("1900: RawDataset: Raw Datasets", () => {
     );
   });
 
-  it("01250: adds a new proposal for pattching in the existing dataset", async () => {
+  it("0124: adds a new proposal for pattching in the existing dataset", async () => {
     const newProposal = {
       ...TestData.ProposalCorrectComplete,
       proposalId: faker.string.numeric(8),

--- a/test/RawDataset.js
+++ b/test/RawDataset.js
@@ -18,7 +18,7 @@ describe("1900: RawDataset: Raw Datasets", () => {
     db.collection("Dataset").deleteMany({});
     db.collection("Proposals").deleteMany({});
   });
-  beforeEach(async() => {
+  beforeEach(async () => {
     accessProposalToken = await utils.getToken(appUrl, {
       username: "proposalIngestor",
       password: TestData.Accounts["proposalIngestor"]["password"],
@@ -46,6 +46,8 @@ describe("1900: RawDataset: Raw Datasets", () => {
       .then((res) => {
         res.body.should.have.property("ownerGroup").and.be.string;
         res.body.should.have.property("proposalId").and.be.string;
+        // NOTE: Add real proposal in the testdata instead of fixed (non-existing) one
+        TestData.RawCorrect.proposalId = res.body["proposalId"];
         proposalId = encodeURIComponent(res.body["proposalId"]);
       });
   });
@@ -278,6 +280,22 @@ describe("1900: RawDataset: Raw Datasets", () => {
           res.body.should.be.an("array");
         })
     );
+  });
+
+  it("01250: adds a new proposal for pattching in the existing dataset", async () => {
+    return request(appUrl)
+      .post("/api/v3/Proposals")
+      .send(TestData.ProposalCorrectComplete)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessProposalToken}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("ownerGroup").and.be.string;
+        res.body.should.have.property("proposalId").and.be.string;
+        // NOTE: Add real proposal in the testdata instead of fixed (non-existing) one
+        TestData.PatchProposal1.proposalId = res.body["proposalId"];
+      });
   });
 
   it("0125: should update proposal of the dataset", async () => {

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -231,7 +231,7 @@ const TestData = {
     isPublished: false,
     ownerGroup: "p13388",
     accessGroups: [],
-    proposalId: "10.540.16635/20110123",
+    proposalId: "",
     runNumber: "123456",
     instrumentId: "1f016ec4-7a73-11ef-ae3e-439013069377",
     sampleId: "20c32b4e-7a73-11ef-9aec-5b9688aa3791i",
@@ -838,7 +838,7 @@ const TestData = {
   },
 
   PatchProposal1: {
-    proposalId: "10.540.16635/20240124",
+    proposalId: "",
   },
 
   PatchInstrument1: {

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -75,7 +75,7 @@ const TestData = {
   },
 
   ProposalCorrectComplete: {
-    proposalId: "20170267",
+    proposalId: faker.string.numeric(8),
     pi_email: "pi@uni.edu",
     pi_firstname: "principal",
     pi_lastname: "investigator",
@@ -102,7 +102,7 @@ const TestData = {
   },
 
   ProposalWrong_1: {
-    proposalId: "20170267",
+    proposalId: faker.string.numeric(8),
     pi_email: "pi@uni.edu",
     pi_firstname: "principal",
     pi_lastname: "investigator",
@@ -144,11 +144,11 @@ const TestData = {
   RawCorrectMin: {
     ownerGroup: faker.company.name(),
     creationLocation: faker.location.city(),
-    principalInvestigator: faker.internet.userName(),
+    principalInvestigator: faker.internet.username(),
     type: "raw",
     creationTime: faker.date.past(),
     sourceFolder: faker.system.directoryPath(),
-    owner: faker.internet.userName(),
+    owner: faker.internet.username(),
     contactEmail: faker.internet.email(),
     datasetName: faker.string.sample(),
   },
@@ -422,7 +422,7 @@ const TestData = {
     investigator: faker.internet.email(),
     inputDatasets: [faker.string.uuid()],
     usedSoftware: [faker.internet.url()],
-    owner: faker.internet.userName(),
+    owner: faker.internet.username(),
     contactEmail: faker.internet.email(),
     sourceFolder: faker.system.directoryPath(),
     creationTime: faker.date.past(),
@@ -867,12 +867,12 @@ const TestData = {
   ScientificMetadataForElasticSearch: {
     ownerGroup: faker.company.name(),
     creationLocation: faker.location.city(),
-    principalInvestigator: faker.internet.userName(),
+    principalInvestigator: faker.internet.username(),
     type: "raw",
     datasetName: faker.string.sample(),
     creationTime: faker.date.past(),
     sourceFolder: faker.system.directoryPath(),
-    owner: faker.internet.userName(),
+    owner: faker.internet.username(),
     size: faker.number.int({ min: 0, max: 100000000 }),
     proposalId: faker.string.numeric(6),
     contactEmail: faker.internet.email(),


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This PR aims to add the new `parentProposalId` field in the proposal document.

## Motivation
There was a feature requested to add new field on a proposal called parent proposal

## Fixes

* https://jira.ess.eu/browse/SWAP-4298

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [x] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
