### PR TITLE
fix: handle obsolete where filter fields mapping to current schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,6 @@ OIDC_USERQUERY_OPERATOR=<"or"|"and">
 OIDC_USERQUERY_FILTER="username:username, email:email"
 
 ELASTICSEARCH_ENABLED=<"yes"|"no">
-APP_PORT=3003
 STACK_VERSION="8.8.2"
 CLUSTER_NAME="es-cluster"
 MEM_LIMIT="4G"

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -178,10 +178,11 @@ export class DatasetsController {
       DatasetClass,
     );
 
+    if (!mergedFilters.where) {
+      mergedFilters.where = {};
+    }
+
     if (!canViewAny) {
-      if (!mergedFilters.where) {
-        mergedFilters.where = {};
-      }
       if (canViewAccess) {
         mergedFilters.where["$or"] = [
           { ownerGroup: { $in: user.currentGroups } },
@@ -195,6 +196,10 @@ export class DatasetsController {
         mergedFilters.where = { isPublished: true };
       }
     }
+
+    mergedFilters.where = this.convertObsoleteWhereFilterToCurrentSchema(
+      mergedFilters.where,
+    );
 
     return mergedFilters;
   }
@@ -396,6 +401,27 @@ export class DatasetsController {
     return dataset;
   }
 
+  convertObsoleteWhereFilterToCurrentSchema(
+    whereFilter: Record<string, unknown>,
+  ): IFilters<DatasetDocument, IDatasetFields> {
+    if ("proposalId" in whereFilter) {
+      whereFilter.proposalIds = whereFilter.proposalId;
+      delete whereFilter.proposalId;
+    }
+    if ("sampleId" in whereFilter) {
+      whereFilter.sampleIds = whereFilter.sampleId;
+      delete whereFilter.sampleId;
+    }
+    if ("instrumentId" in whereFilter) {
+      whereFilter.instrumentIds = whereFilter.instrumentId;
+      delete whereFilter.instrumentId;
+    }
+    if ("principalInvestigator" in whereFilter) {
+      whereFilter.investigator = whereFilter.principalInvestigator;
+      delete whereFilter.instrumentId;
+    }
+    return whereFilter;
+  }
   convertObsoleteToCurrentSchema(
     inputObsoleteDataset:
       | CreateRawDatasetObsoleteDto

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -418,7 +418,7 @@ export class DatasetsController {
     }
     if ("principalInvestigator" in whereFilter) {
       whereFilter.investigator = whereFilter.principalInvestigator;
-      delete whereFilter.instrumentId;
+      delete whereFilter.principalInvestigator;
     }
     return whereFilter;
   }


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This PR adds a new function, convertObsoleteWhereFilterToCurrentSchema, to handle mapping obsolete filter fields (e.g., proposalId → proposalIds, sampleId → sampleIds) to their current schema equivalents. 

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
