### PR TITLE
fix: delete_job_groups instance authorization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,7 +155,7 @@ jobs:
           ACCESS_GROUPS_STATIC_VALUES: "ess"
           CREATE_JOB_GROUPS: group1,group2
           UPDATE_JOB_GROUPS: group1
-          DELETE_JOB_GROUPS: "archivemanager"
+          DELETE_JOB_GROUPS: "archivemanager,admin"
           PROPOSAL_GROUPS: "proposalingestor"
           SAMPLE_PRIVILEGED_GROUPS: "sampleingestor"
           SAMPLE_GROUPS: "group1"

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -459,8 +459,8 @@ export class CaslAbilityFactory {
          * authenticated users belonging to any of the group listed in DELETE_JOB_GROUPS
          */
         can(Action.JobDelete, JobClass);
-      } else{
-        cannot(Action.JobDelete, JobClass)
+      } else {
+        cannot(Action.JobDelete, JobClass);
       }
     }
 

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -389,16 +389,6 @@ export class CaslAbilityFactory {
         can(Action.JobRead, JobClass);
         can(Action.JobCreate, JobClass);
         can(Action.JobStatusUpdate, JobClass);
-        cannot(Action.JobDelete, JobClass);
-      } else if (
-        user.currentGroups.some((g) =>
-          configuration().deleteJobGroups.includes(g),
-        )
-      ) {
-        /**
-         * authenticated users belonging to any of the group listed in DELETE_JOB_GROUPS
-         */
-        can(Action.JobDelete, JobClass);
       } else {
         const jobUserAuthorizationValues = [
           ...user.currentGroups.map((g) => "@" + g),
@@ -459,7 +449,18 @@ export class CaslAbilityFactory {
             can(Action.JobStatusUpdate, JobClass);
           }
         }
-        cannot(Action.JobDelete, JobClass);
+      }
+      if (
+        user.currentGroups.some((g) =>
+          configuration().deleteJobGroups.includes(g),
+        )
+      ) {
+        /**
+         * authenticated users belonging to any of the group listed in DELETE_JOB_GROUPS
+         */
+        can(Action.JobDelete, JobClass);
+      } else{
+        cannot(Action.JobDelete, JobClass)
       }
     }
 

--- a/src/casl/guards/policies.guard.ts
+++ b/src/casl/guards/policies.guard.ts
@@ -35,7 +35,6 @@ export class PoliciesGuard implements CanActivate {
   private execPolicyHandler(handler: PolicyHandler, ability: AppAbility) {
     if (typeof handler === "function") {
       const res = handler(ability);
-      //console.log("PoliciesGuard:execPolicyHandler ", res);
       return res;
     }
     return handler.handle(ability);

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -4085,18 +4085,18 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect("Content-Type", /json/);
   });
 
-  it("1920: Delete job 1 as Admin, which should fail", async () => {
+  it("1920: Delete job 1 as Admin", async () => {
     return request(appUrl)
-      .delete("/api/v3/jobs/" + encodedJobIdUser1)
+      .delete("/api/v3/jobs/" + encodedJobIdUser2)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenAdmin}` })
-      .expect(TestData.DeleteForbiddenStatusCode)
+      .expect(TestData.SuccessfulDeleteStatusCode)
       .expect("Content-Type", /json/);
   });
 
   it("1930: Delete job 1 as CREATE_JOB_GROUPS user, which should fail", async () => {
     return request(appUrl)
-      .delete("/api/v3/jobs/" + encodedJobIdUser1)
+      .delete("/api/v3/jobs/" + encodedJobIdUser3)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenUser1}` })
       .expect(TestData.DeleteForbiddenStatusCode)
@@ -4105,7 +4105,7 @@ describe("1100: Jobs: Test New Job Model", () => {
 
   it("1940: Delete job 1 as normal user, which should fail", async () => {
     return request(appUrl)
-      .delete("/api/v3/jobs/" + encodedJobIdUser1)
+      .delete("/api/v3/jobs/" + encodedJobIdUser3)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenUser51}` })
       .expect(TestData.DeleteForbiddenStatusCode)
@@ -4130,7 +4130,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(63);
+        res.body.should.be.an("array").to.have.lengthOf(62);
       });
   });
 
@@ -4160,7 +4160,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(36);
+        res.body.should.be.an("array").to.have.lengthOf(35);
       });
   });
 
@@ -4237,7 +4237,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(14);
+        res.body.should.be.an("array").to.have.lengthOf(13);
       });
   });
 
@@ -4326,7 +4326,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 36 }] });
+        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 35 }] });
       });
   });
 
@@ -4401,7 +4401,7 @@ describe("1100: Jobs: Test New Job Model", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 14 }] });
+        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 13 }] });
       });
   });
 


### PR DESCRIPTION
## Description
When in .env delete-job-group was set to admin, flowing the authorization logic, admin should be able to delete a job. Instead, this user would get denied access. 

## Motivation
fix this

## Fixes
user can delete a job based on delete-job-group

## Changes:
* In casl, the endpoint authorization lines for JobDelete are separated into their own if/else clauses
* added admin to delete_job_group in tests workflow
* 1920 test shour return a successful status code
* test for getting are adapted to minus one deleted test. 

## Tests included

- [x] Included for each change/fix?
- [x] Passing? 

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated
