### PR TITLE
revert: build(deps): bump @nestjs/swagger from 7.4.2 to 8.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@nestjs/mongoose": "^10.0.0",
         "@nestjs/passport": "^10.0.0",
         "@nestjs/platform-express": "^10.3.8",
-        "@nestjs/swagger": "^8.0.7",
+        "@nestjs/swagger": "^7.1.7",
         "@nestjs/terminus": "^10.1.1",
         "@user-office-software/duo-logger": "^2.1.1",
         "@user-office-software/duo-message-broker": "^1.4.0",
@@ -2379,10 +2379,9 @@
       }
     },
     "node_modules/@nestjs/mapped-types": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.6.tgz",
-      "integrity": "sha512-84ze+CPfp1OWdpRi1/lOu59hOhTz38eVzJvRKrg9ykRFwDz+XleKfMsG0gUqNZYFa6v53XYzeD+xItt8uDW7NQ==",
-      "license": "MIT",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.0.5.tgz",
+      "integrity": "sha512-bSJv4pd6EY99NX9CjBIyn4TVDoSit82DUZlL4I3bqNfy5Gt+gXTa86i3I/i0iIV9P4hntcGM5GyO+FhZAhxtyg==",
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0",
         "class-transformer": "^0.4.0 || ^0.5.0",
@@ -2466,17 +2465,16 @@
       "dev": true
     },
     "node_modules/@nestjs/swagger": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-8.0.7.tgz",
-      "integrity": "sha512-zaTMCEZ/CxX7QYF110nTqJsn7eCXp4VI9kv7+AdUcIlBmhhgJpggBw2Mx2p6xVjyz1EoWXGfxxWKnxEyaQwFlg==",
-      "license": "MIT",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-7.4.2.tgz",
+      "integrity": "sha512-Mu6TEn1M/owIvAx2B4DUQObQXqo2028R2s9rSZ/hJEgBK95+doTwS0DjmVA2wTeZTyVtXOoN7CsoM5pONBzvKQ==",
       "dependencies": {
         "@microsoft/tsdoc": "^0.15.0",
-        "@nestjs/mapped-types": "2.0.6",
+        "@nestjs/mapped-types": "2.0.5",
         "js-yaml": "4.1.0",
         "lodash": "4.17.21",
         "path-to-regexp": "3.3.0",
-        "swagger-ui-dist": "5.18.2"
+        "swagger-ui-dist": "5.17.14"
       },
       "peerDependencies": {
         "@fastify/static": "^6.0.0 || ^7.0.0",
@@ -2718,13 +2716,6 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
-    },
-    "node_modules/@scarf/scarf": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
-      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0"
     },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.11.0",
@@ -13001,13 +12992,9 @@
       }
     },
     "node_modules/swagger-ui-dist": {
-      "version": "5.18.2",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.18.2.tgz",
-      "integrity": "sha512-J+y4mCw/zXh1FOj5wGJvnAajq6XgHOyywsa9yITmwxIlJbMqITq3gYRZHaeqLVH/eV/HOPphE6NjF+nbSNC5Zw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@scarf/scarf": "=1.4.0"
-      }
+      "version": "5.17.14",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.17.14.tgz",
+      "integrity": "sha512-CVbSfaLpstV65OnSjbXfVd6Sta3q3F7Cj/yYuvHMp1P90LztOLs6PfUnKEVAeiIVQt9u2SaPwv0LiH/OyMjHRw=="
     },
     "node_modules/swagger-ui-express": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@nestjs/mongoose": "^10.0.0",
     "@nestjs/passport": "^10.0.0",
     "@nestjs/platform-express": "^10.3.8",
-    "@nestjs/swagger": "^8.0.7",
+    "@nestjs/swagger": "^7.1.7",
     "@nestjs/terminus": "^10.1.1",
     "@user-office-software/duo-logger": "^2.1.1",
     "@user-office-software/duo-message-broker": "^1.4.0",

--- a/src/users/schemas/user-settings.schema.ts
+++ b/src/users/schemas/user-settings.schema.ts
@@ -51,7 +51,6 @@ export class UserSettings {
   @ApiProperty({
     type: "object",
     default: {},
-    additionalProperties: true,
     description:
       "A customizable object for storing the user's external settings, which can contain various nested properties and configurations.",
   })


### PR DESCRIPTION
Reverts SciCatProject/scicat-backend-next#1505
Swagger 8.0.0 automatically appends V3 suffix to all the API methods. 
We will keep swagger version with 7.4.2 until we can find a way to remove V3 suffix