### PR TITLE
fix: update schema validation from oneOf to anyOf for dataset creation and updates

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @/quotes */
 import {
   Body,
   Controller,
@@ -567,7 +566,7 @@ export class DatasetsController {
     description: "Input fields for the dataset to be created",
     required: true,
     schema: {
-      oneOf: [
+      anyOf: [
         { $ref: getSchemaPath(CreateRawDatasetObsoleteDto) },
         { $ref: getSchemaPath(CreateDerivedDatasetObsoleteDto) },
         { $ref: getSchemaPath(CreateDatasetDto) },
@@ -731,7 +730,7 @@ export class DatasetsController {
     description: "Input fields for the dataset that needs to be validated",
     required: true,
     schema: {
-      oneOf: [
+      anyOf: [
         { $ref: getSchemaPath(CreateRawDatasetObsoleteDto) },
         { $ref: getSchemaPath(CreateDerivedDatasetObsoleteDto) },
         { $ref: getSchemaPath(CreateDatasetDto) },
@@ -1245,7 +1244,7 @@ export class DatasetsController {
       "Fields that needs to be updated in the dataset. Only the fields that needs to be updated have to be passed in.",
     required: true,
     schema: {
-      oneOf: [
+      anyOf: [
         { $ref: getSchemaPath(PartialUpdateRawDatasetObsoleteDto) },
         { $ref: getSchemaPath(PartialUpdateDerivedDatasetObsoleteDto) },
         { $ref: getSchemaPath(PartialUpdateDatasetDto) },
@@ -1357,7 +1356,7 @@ export class DatasetsController {
       "Dataset object that needs to be updated. The whole dataset object with updated fields have to be passed in.",
     required: true,
     schema: {
-      oneOf: [
+      anyOf: [
         { $ref: getSchemaPath(UpdateRawDatasetObsoleteDto) },
         { $ref: getSchemaPath(UpdateDerivedDatasetObsoleteDto) },
         { $ref: getSchemaPath(UpdateDatasetDto) },


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This PR aims to fix the python SDK issue  https://github.com/SciCatProject/scicat-backend-next/issues/1533 raised by @emigun

## Motivation
Based on the official [documentation](https://swagger.io/docs/specification/v3_0/data-models/oneof-anyof-allof-not/) it is suggested to use anyOf to validate when there's one or more fields are shared across the combined schemas.

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
