### PR TITLE
Jobs RabbitMQ Action connection info should come from ConfigService

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ PUBLIC_URL_PREFIX="https://doi.esss.se/detail/"
 PORT=3000
 RABBITMQ_ENABLED=<"yes"|"no">
 RABBITMQ_HOSTNAME="localhost"
+RABBITMQ_PORT=5672
 RABBITMQ_USERNAME="rabbitmq"
 RABBITMQ_PASSWORD="rabbitmq"
 REGISTER_DOI_URI="https://mds.test.datacite.org/doi"

--- a/jobConfig.example.yaml
+++ b/jobConfig.example.yaml
@@ -10,10 +10,6 @@ jobs:
           headers:
             accept: application/json
         - actionType: rabbitmq
-          hostname: rabbitmq
-          port: 5672
-          username: guest
-          password: guest
           exchange: jobs.write
           queue: client.jobs.write
           key: jobqueue
@@ -29,10 +25,6 @@ jobs:
       auth: archivemanager
       actions:
         - actionType: rabbitmq
-          hostname: rabbitmq
-          port: 5672
-          username: guest
-          password: guest
           exchange: jobs.write
           queue: client.jobs.write
           key: jobqueue

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@user-office-software/duo-logger": "^2.1.1",
         "@user-office-software/duo-message-broker": "^1.4.0",
         "ajv": "^8.12.0",
+        "amqplib": "^0.10.5",
         "bcrypt": "^5.1.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
@@ -2448,6 +2449,72 @@
         }
       }
     },
+    "node_modules/@nestjs/microservices": {
+      "version": "10.4.15",
+      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-10.4.15.tgz",
+      "integrity": "sha512-t6hTvWnykF+C0mrCKJzhkyRQ8pChxrHn6Vc+mi0OViwJXzsQdRmy/m2xfQ9aeSC8B4MmGUvkK7UdH9fYbJW7gQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "iterare": "1.2.1",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@grpc/grpc-js": "*",
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0",
+        "@nestjs/websockets": "^10.0.0",
+        "amqp-connection-manager": "*",
+        "amqplib": "*",
+        "cache-manager": "*",
+        "ioredis": "*",
+        "kafkajs": "*",
+        "mqtt": "*",
+        "nats": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@grpc/grpc-js": {
+          "optional": true
+        },
+        "@nestjs/websockets": {
+          "optional": true
+        },
+        "amqp-connection-manager": {
+          "optional": true
+        },
+        "amqplib": {
+          "optional": true
+        },
+        "cache-manager": {
+          "optional": true
+        },
+        "ioredis": {
+          "optional": true
+        },
+        "kafkajs": {
+          "optional": true
+        },
+        "mqtt": {
+          "optional": true
+        },
+        "nats": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/microservices/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@nestjs/mongoose": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/mongoose/-/mongoose-10.1.0.tgz",
@@ -3990,13 +4057,12 @@
       }
     },
     "node_modules/amqplib": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.3.tgz",
-      "integrity": "sha512-UHmuSa7n8vVW/a5HGh2nFPqAEr8+cD4dEZ6u9GjP91nHfr1a54RyAKyra7Sb5NH7NBKOUlyQSMXIp0qAixKexw==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.5.tgz",
+      "integrity": "sha512-Dx5zmy0Ur+Q7LPPdhz+jx5IzmJBoHd15tOeAfQ8SuvEtyPJ20hBemhOBA4b1WeORCRa0ENM/kHCzmem1w/zHvQ==",
       "dependencies": {
         "@acuminous/bitsyntax": "^0.1.2",
         "buffer-more-ints": "~1.0.0",
-        "readable-stream": "1.x >=1.1.9",
         "url-parse": "~1.5.10"
       },
       "engines": {
@@ -8204,11 +8270,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -12081,17 +12142,6 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
-    "node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -12969,11 +13019,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@user-office-software/duo-logger": "^2.1.1",
     "@user-office-software/duo-message-broker": "^1.4.0",
     "ajv": "^8.12.0",
+    "amqplib": "^0.10.5",
     "bcrypt": "^5.1.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,8 +1,11 @@
 import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
 import { MailService } from "./mail.service";
+import { RabbitMQService } from "./rabbitmq/rabbitmq.service";
 
 @Module({
-  providers: [MailService],
-  exports: [MailService],
+  imports: [ConfigModule],
+  providers: [MailService, RabbitMQService],
+  exports: [MailService, RabbitMQService],
 })
 export class CommonModule {}

--- a/src/common/rabbitmq/rabbitmq.module.ts
+++ b/src/common/rabbitmq/rabbitmq.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from "@nestjs/config";
+import { RabbitMQService } from './rabbitmq.service';
+
+@Module({
+  imports: [ConfigModule],
+  providers: [RabbitMQService],
+  exports: [RabbitMQService],
+})
+export class RabbitMQModule {}

--- a/src/common/rabbitmq/rabbitmq.module.ts
+++ b/src/common/rabbitmq/rabbitmq.module.ts
@@ -1,6 +1,6 @@
-import { Module } from '@nestjs/common';
+import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
-import { RabbitMQService } from './rabbitmq.service';
+import { RabbitMQService } from "./rabbitmq.service";
 
 @Module({
   imports: [ConfigModule],

--- a/src/common/rabbitmq/rabbitmq.service.ts
+++ b/src/common/rabbitmq/rabbitmq.service.ts
@@ -1,0 +1,123 @@
+import amqp, { Connection, Channel } from "amqplib/callback_api";
+import { Injectable, Logger, OnModuleDestroy } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+
+/**
+ * Service for publishing messages to a RabbitMQ queue.
+ */
+@Injectable()
+export class RabbitMQService implements OnModuleDestroy {
+  private connectionOptions: amqp.Options.Connect;
+  private connection: Connection;
+  private channel: Channel;
+
+  constructor(private configService: ConfigService) {
+    Logger.log("Initializing RabbitMQService.", "RabbitMQService");
+
+    const rabbitMqEnabled =
+      (this.configService.get<string>("rabbitMq.enabled") === "yes");
+
+    if (rabbitMqEnabled) {
+      const hostname = this.configService.get<string>("rabbitMq.hostname");
+      const port = this.configService.get<number>("rabbitMq.port");
+      const username = this.configService.get<string>("rabbitMq.username");
+      const password = this.configService.get<string>("rabbitMq.password");
+
+      if (!hostname || !port || !username || !password) {
+        Logger.error(
+          "RabbitMQ is enabled but missing one or more config variables.",
+          "RabbitMQService",
+        );
+      } else {
+        this.connectionOptions = {
+          protocol: "amqp",
+          hostname: hostname,
+          port: port,
+          username: username,
+          password: password,
+        };
+
+        amqp.connect(
+          this.connectionOptions,
+          (connectionError: Error, connection: Connection) => {
+            if (connectionError) {
+              Logger.error(
+                "Connection error in RabbitMQService: " +
+                  JSON.stringify(connectionError.message),
+                "RabbitMQService",
+              );
+              return;
+            }
+            this.connection = connection;
+    
+            this.connection.createChannel(
+              (channelError: Error, channel: Channel) => {
+                if (channelError) {
+                  Logger.error(
+                    "Channel error in RabbitMQService: " +
+                      JSON.stringify(channelError.message),
+                    "RabbitMQService",
+                  );
+                  return;
+                }
+                this.channel = channel;
+                Logger.log(this.channel);
+              }
+            );
+          },
+        );
+      }
+    } else {
+      Logger.error("RabbitMQ is not enabled.", "RabbitMQService");
+    }
+  }
+
+  connect(
+    queue: string,
+    exchange: string,
+    key: string,
+  ) {
+    try {
+      this.channel.assertQueue(queue, { durable: true });
+      this.channel.assertExchange(exchange, "topic", {
+        durable: true,
+      });
+      this.channel.bindQueue(queue, exchange, key);
+    } catch (error) {
+      Logger.error(
+        `Could not connect to RabbitMQ queue ${queue} with exchange ${exchange} and key ${key}.`,
+        "RabbitMQService",
+      );
+      Logger.error(error);
+    }
+  }
+
+  sendMessage(
+    queue: string,
+    message: string,
+  ) {
+    try {
+      this.channel.sendToQueue(queue, Buffer.from(message), {
+        persistent: true
+      });
+    } catch (error) {
+      Logger.error(
+        `Could not send message to RabbitMQ queue ${queue}.`,
+        "RabbitMQService",
+      );
+    }
+  }
+
+  onModuleDestroy() {
+    if (this.channel) {
+      this.channel.close(() => {
+        Logger.log("RabbitMQ channel closed.", "RabbitMQService");
+      });
+    }
+    if (this.connection) {
+      this.connection.close(() => {
+        Logger.log("RabbitMQ connection closed.", "RabbitMQService");
+      });
+    }
+  }
+}

--- a/src/common/rabbitmq/rabbitmq.service.ts
+++ b/src/common/rabbitmq/rabbitmq.service.ts
@@ -15,7 +15,7 @@ export class RabbitMQService implements OnModuleDestroy {
     Logger.log("Initializing RabbitMQService.", "RabbitMQService");
 
     const rabbitMqEnabled =
-      (this.configService.get<string>("rabbitMq.enabled") === "yes");
+      this.configService.get<string>("rabbitMq.enabled") === "yes";
 
     if (rabbitMqEnabled) {
       const hostname = this.configService.get<string>("rabbitMq.hostname");
@@ -49,7 +49,7 @@ export class RabbitMQService implements OnModuleDestroy {
               return;
             }
             this.connection = connection;
-    
+
             this.connection.createChannel(
               (channelError: Error, channel: Channel) => {
                 if (channelError) {
@@ -62,7 +62,7 @@ export class RabbitMQService implements OnModuleDestroy {
                 }
                 this.channel = channel;
                 Logger.log(this.channel);
-              }
+              },
             );
           },
         );
@@ -72,11 +72,7 @@ export class RabbitMQService implements OnModuleDestroy {
     }
   }
 
-  connect(
-    queue: string,
-    exchange: string,
-    key: string,
-  ) {
+  connect(queue: string, exchange: string, key: string) {
     try {
       this.channel.assertQueue(queue, { durable: true });
       this.channel.assertExchange(exchange, "topic", {
@@ -92,13 +88,10 @@ export class RabbitMQService implements OnModuleDestroy {
     }
   }
 
-  sendMessage(
-    queue: string,
-    message: string,
-  ) {
+  sendMessage(queue: string, message: string) {
     try {
       this.channel.sendToQueue(queue, Buffer.from(message), {
-        persistent: true
+        persistent: true,
       });
     } catch (error) {
       Logger.error(

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -185,6 +185,7 @@ const configuration = () => {
     rabbitMq: {
       enabled: process.env.RABBITMQ_ENABLED ?? "no",
       hostname: process.env.RABBITMQ_HOSTNAME,
+      port: process.env.RABBITMQ_PORT,
       username: process.env.RABBITMQ_USERNAME,
       password: process.env.RABBITMQ_PASSWORD,
     },

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.interface.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.interface.ts
@@ -4,10 +4,6 @@ export const actionType = "rabbitmq";
 
 export interface RabbitMQJobActionOptions extends JobActionOptions {
   actionType: typeof actionType;
-  hostname: string;
-  port: number;
-  username: string;
-  password: string;
   exchange: string;
   queue: string;
   key: string;
@@ -26,10 +22,6 @@ export function isRabbitMQJobActionOptions(
   const opts = options as RabbitMQJobActionOptions;
   return (
     opts.actionType === actionType &&
-    typeof opts.hostname === "string" &&
-    typeof opts.port === "number" &&
-    typeof opts.username === "string" &&
-    typeof opts.password === "string" &&
     typeof opts.exchange === "string" &&
     typeof opts.queue === "string" &&
     typeof opts.key === "string"

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.module.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.module.ts
@@ -1,9 +1,13 @@
 import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
 import { RabbitMQJobActionCreator } from "./rabbitmqaction.service";
 import { CommonModule } from "src/common/common.module";
 
 @Module({
-  imports: [CommonModule],
+  imports: [
+    CommonModule,
+    ConfigModule,
+  ],
   providers: [RabbitMQJobActionCreator],
   exports: [RabbitMQJobActionCreator],
 })

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.module.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.module.ts
@@ -1,10 +1,9 @@
 import { Module } from "@nestjs/common";
-import { ConfigModule } from "@nestjs/config";
-import { RabbitMQJobActionCreator } from "./rabbitmqaction.service";
 import { CommonModule } from "src/common/common.module";
+import { RabbitMQJobActionCreator } from "./rabbitmqaction.service";
 
 @Module({
-  imports: [CommonModule, ConfigModule],
+  imports: [CommonModule],
   providers: [RabbitMQJobActionCreator],
   exports: [RabbitMQJobActionCreator],
 })

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.module.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.module.ts
@@ -4,10 +4,7 @@ import { RabbitMQJobActionCreator } from "./rabbitmqaction.service";
 import { CommonModule } from "src/common/common.module";
 
 @Module({
-  imports: [
-    CommonModule,
-    ConfigModule,
-  ],
+  imports: [CommonModule, ConfigModule],
   providers: [RabbitMQJobActionCreator],
   exports: [RabbitMQJobActionCreator],
 })

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.service.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.service.ts
@@ -6,15 +6,16 @@ import {
 } from "../../jobconfig.interface";
 import { isRabbitMQJobActionOptions } from "./rabbitmqaction.interface";
 import { RabbitMQJobAction } from "./rabbitmqaction";
+import { ConfigService } from "@nestjs/config";
 
 @Injectable()
 export class RabbitMQJobActionCreator implements JobActionCreator<JobDto> {
-  constructor() {}
+  constructor(private configService: ConfigService) {}
 
   public create<Options extends JobActionOptions>(options: Options) {
     if (!isRabbitMQJobActionOptions(options)) {
       throw new Error("Invalid options for RabbitMQJobAction.");
     }
-    return new RabbitMQJobAction(options);
+    return new RabbitMQJobAction(this.configService, options);
   }
 }

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.service.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.service.ts
@@ -6,16 +6,16 @@ import {
 } from "../../jobconfig.interface";
 import { isRabbitMQJobActionOptions } from "./rabbitmqaction.interface";
 import { RabbitMQJobAction } from "./rabbitmqaction";
-import { ConfigService } from "@nestjs/config";
+import { RabbitMQService } from "src/common/rabbitmq/rabbitmq.service";
 
 @Injectable()
 export class RabbitMQJobActionCreator implements JobActionCreator<JobDto> {
-  constructor(private configService: ConfigService) {}
+  constructor(private rabbitMQService: RabbitMQService) {}
 
   public create<Options extends JobActionOptions>(options: Options) {
     if (!isRabbitMQJobActionOptions(options)) {
       throw new Error("Invalid options for RabbitMQJobAction.");
     }
-    return new RabbitMQJobAction(this.configService, options);
+    return new RabbitMQJobAction(this.rabbitMQService, options);
   }
 }

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.ts
@@ -1,69 +1,35 @@
 import { Logger } from "@nestjs/common";
-import amqp, { Connection } from "amqplib/callback_api";
 import { JobAction, JobDto } from "../../jobconfig.interface";
 import { JobClass } from "../../../../jobs/schemas/job.schema";
 import {
   actionType,
   RabbitMQJobActionOptions,
 } from "./rabbitmqaction.interface";
-import { ConfigService } from "@nestjs/config";
+import { RabbitMQService } from "src/common/rabbitmq/rabbitmq.service";
 
 /**
  * Publish a message in a RabbitMQ queue
  */
 export class RabbitMQJobAction<T extends JobDto> implements JobAction<T> {
-  private connection: amqp.Options.Connect;
-  private binding: RabbitMQJobActionOptions;
-  private rabbitMqReady = false;
+  private queue: string;
+  private exchange: string;
+  private key: string;
 
   getActionType(): string {
     return actionType;
   }
 
   constructor(
-    private configService: ConfigService,
+    private readonly rabbitMQService: RabbitMQService,
     options: RabbitMQJobActionOptions,
   ) {
     Logger.log(
       "Initializing RabbitMQJobAction. Params: " + JSON.stringify(options),
       "RabbitMQJobAction",
     );
-
-    const rabbitMqEnabled =
-      this.configService.get<string>("rabbitMq.enabled") === "yes"
-        ? true
-        : false;
-
-    if (rabbitMqEnabled) {
-      const hostname = this.configService.get<string>("rabbitMq.hostname");
-      const port = this.configService.get<number>("rabbitMq.port");
-      const username = this.configService.get<string>("rabbitMq.username");
-      const password = this.configService.get<string>("rabbitMq.password");
-
-      if (!hostname || !port || !username || !password) {
-        Logger.error(
-          "RabbitMQ is enabled but missing one or more config variables.",
-          "RabbitMQJobAction",
-        );
-      } else {
-        this.connection = {
-          protocol: "amqp",
-          hostname: hostname,
-          port: port,
-          username: username,
-          password: password,
-        };
-        this.binding = {
-          actionType: actionType,
-          exchange: options.exchange,
-          queue: options.queue,
-          key: options.key,
-        };
-        this.rabbitMqReady = true;
-      }
-    } else {
-      Logger.error("RabbitMQ is not enabled.", "RabbitMQJobAction");
-    }
+    this.queue = options.queue;
+    this.exchange = options.exchange;
+    this.key = options.key;
   }
 
   async performJob(job: JobClass) {
@@ -71,55 +37,7 @@ export class RabbitMQJobAction<T extends JobDto> implements JobAction<T> {
       "Performing RabbitMQJobAction: " + JSON.stringify(job),
       "RabbitMQJobAction",
     );
-
-    if (this.rabbitMqReady) {
-      amqp.connect(
-        this.connection,
-        (connectionError: Error, connection: Connection) => {
-          if (connectionError) {
-            Logger.error(
-              "Connection error in RabbitMQJobAction: " +
-                JSON.stringify(connectionError.message),
-              "RabbitMQJobAction",
-            );
-            return;
-          }
-
-          connection.createChannel((channelError: Error, channel) => {
-            if (channelError) {
-              Logger.error(
-                "Channel error in RabbitMQJobAction: " +
-                  JSON.stringify(channelError.message),
-                "RabbitMQJobAction",
-              );
-              return;
-            }
-
-            channel.assertQueue(this.binding.queue, { durable: true });
-            channel.assertExchange(this.binding.exchange, "topic", {
-              durable: true,
-            });
-            channel.bindQueue(
-              this.binding.queue,
-              this.binding.exchange,
-              this.binding.key,
-            );
-            channel.sendToQueue(
-              this.binding.queue,
-              Buffer.from(JSON.stringify(job)),
-            );
-
-            channel.close(() => {
-              connection.close();
-            });
-          });
-        },
-      );
-    } else {
-      Logger.error(
-        "RabbitMQ is either not enabled or not configured properly.",
-        "RabbitMQJobAction",
-      );
-    }
+    this.rabbitMQService.connect(this.queue, this.exchange, this.key);
+    this.rabbitMQService.sendMessage(this.queue, JSON.stringify(job));
   }
 }

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.ts
@@ -14,7 +14,7 @@ import { ConfigService } from "@nestjs/config";
 export class RabbitMQJobAction<T extends JobDto> implements JobAction<T> {
   private connection: amqp.Options.Connect;
   private binding: RabbitMQJobActionOptions;
-  private rabbitMqReady: boolean = false;
+  private rabbitMqReady = false;
 
   getActionType(): string {
     return actionType;
@@ -30,9 +30,9 @@ export class RabbitMQJobAction<T extends JobDto> implements JobAction<T> {
     );
 
     const rabbitMqEnabled =
-    this.configService.get<string>("rabbitMq.enabled") === "yes"
-      ? true
-      : false;
+      this.configService.get<string>("rabbitMq.enabled") === "yes"
+        ? true
+        : false;
 
     if (rabbitMqEnabled) {
       const hostname = this.configService.get<string>("rabbitMq.hostname");
@@ -45,8 +45,7 @@ export class RabbitMQJobAction<T extends JobDto> implements JobAction<T> {
           "RabbitMQ is enabled but missing one or more config variables.",
           "RabbitMQJobAction",
         );
-      }
-      else {
+      } else {
         this.connection = {
           protocol: "amqp",
           hostname: hostname,
@@ -62,12 +61,8 @@ export class RabbitMQJobAction<T extends JobDto> implements JobAction<T> {
         };
         this.rabbitMqReady = true;
       }
-    }
-    else {
-      Logger.error(
-        "RabbitMQ is not enabled.",
-        "RabbitMQJobAction",
-      );
+    } else {
+      Logger.error("RabbitMQ is not enabled.", "RabbitMQJobAction");
     }
   }
 
@@ -89,7 +84,7 @@ export class RabbitMQJobAction<T extends JobDto> implements JobAction<T> {
             );
             return;
           }
-  
+
           connection.createChannel((channelError: Error, channel) => {
             if (channelError) {
               Logger.error(
@@ -99,7 +94,7 @@ export class RabbitMQJobAction<T extends JobDto> implements JobAction<T> {
               );
               return;
             }
-  
+
             channel.assertQueue(this.binding.queue, { durable: true });
             channel.assertExchange(this.binding.exchange, "topic", {
               durable: true,
@@ -113,15 +108,14 @@ export class RabbitMQJobAction<T extends JobDto> implements JobAction<T> {
               this.binding.queue,
               Buffer.from(JSON.stringify(job)),
             );
-  
+
             channel.close(() => {
               connection.close();
             });
           });
         },
       );
-    }
-    else {
+    } else {
       Logger.error(
         "RabbitMQ is either not enabled or not configured properly.",
         "RabbitMQJobAction",


### PR DESCRIPTION
## Description
Previously, all information needed to set up the Jobs RabbitMQ action would come from `jobConfig`.
A better approach is to split this information: connection config info should be in  `.env` file, and only the queue info in the `jobConfig` file.

## Motivation
Extract the info from `ConfigService` after the NestJS refactor.

## Changes
While NestJs offers a RabbitMQ microservice, unfortunately it does not cover all necessary options needed for Jobs. More specifically, we are configurating `exchange` and `key`, which is not offered by that library. So instead, we stick to using the `amqplib` library as before, but only request `queue`, `exchange` and `key` to be defined in `jobConfig`. Which means that the `.env` file should now look like this example for RabbitMQ Job Action to be set up properly:
```
RABBITMQ_ENABLED="yes"
RABBITMQ_HOSTNAME="rabbitmq"
RABBITMQ_PORT=5672
RABBITMQ_USERNAME="guest"
RABBITMQ_PASSWORD="guest"
```
And the job action definition in the `jobConfig` file, should look like this:
```
    - actionType: rabbitmq
      exchange: myexchange
      queue: myqueue
      key: mykey
```

Note: make sure you have a running RabbitMQ instance for testing this. For example, with `scicat-ci`: https://github.com/despadam/scicat-ci/commit/969959057ea13fa1fb8b01ba4c791f015ab3850f

---
To make sure that messages are being sent, you can connect to the RabbitMQ admin page (http://localhost:15672/ by default) with the username and password provided in the `.env` file. There, after a job creation or update, you will see that the queue has been created and messages are incoming:
![image](https://github.com/user-attachments/assets/cfb7ce91-a0df-45b5-b1bb-abb5802ea786)
You can also explore the queue contents, as seen here:
![image](https://github.com/user-attachments/assets/57606314-8845-419d-87f7-d8243f52f6d9)