### PR TITLE
RabbitMQ service: fix logging and error handling

### DIFF
--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -6,7 +6,7 @@ import { RabbitMQService } from "./rabbitmq/rabbitmq.service";
 @Module({
   imports: [ConfigModule],
   providers: [
-    MailService, 
+    MailService,
     {
       provide: RabbitMQService,
       useFactory: (configService: ConfigService) => {

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,11 +1,25 @@
 import { Module } from "@nestjs/common";
-import { ConfigModule } from "@nestjs/config";
+import { ConfigModule, ConfigService } from "@nestjs/config";
 import { MailService } from "./mail.service";
 import { RabbitMQService } from "./rabbitmq/rabbitmq.service";
 
 @Module({
   imports: [ConfigModule],
-  providers: [MailService, RabbitMQService],
+  providers: [
+    MailService, 
+    {
+      provide: RabbitMQService,
+      useFactory: (configService: ConfigService) => {
+        const isEnabled =
+          configService.get<string>("rabbitMq.enabled") === "yes";
+        if (isEnabled) {
+          return new RabbitMQService(configService);
+        }
+        return null;
+      },
+      inject: [ConfigService],
+    },
+  ],
   exports: [MailService, RabbitMQService],
 })
 export class CommonModule {}

--- a/src/common/rabbitmq/rabbitmq.service.ts
+++ b/src/common/rabbitmq/rabbitmq.service.ts
@@ -1,12 +1,17 @@
 import amqp, { Connection, Channel } from "amqplib/callback_api";
-import { Injectable, Logger, OnModuleDestroy, OnApplicationShutdown  } from "@nestjs/common";
+import {
+  Injectable,
+  Logger,
+  OnModuleDestroy,
+  OnApplicationShutdown
+} from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
 /**
  * Service for publishing messages to a RabbitMQ queue.
  */
 @Injectable()
-export class RabbitMQService implements OnModuleDestroy, OnApplicationShutdown  {
+export class RabbitMQService implements OnModuleDestroy, OnApplicationShutdown {
   private connectionOptions: amqp.Options.Connect;
   private connection: Connection;
   private channel: Channel;
@@ -92,10 +97,9 @@ export class RabbitMQService implements OnModuleDestroy, OnApplicationShutdown  
         persistent: true,
       });
     } catch (error) {
-      throw new Error(
-        `Could not send message to RabbitMQ queue ${queue}.`,
-        { cause: error },
-      );
+      throw new Error(`Could not send message to RabbitMQ queue ${queue}.`, {
+        cause: error
+      });
     }
   }
 
@@ -116,7 +120,7 @@ export class RabbitMQService implements OnModuleDestroy, OnApplicationShutdown  
     await this.close();
   }
 
-  async onApplicationShutdown(signal?: string): Promise<void> {
+  async onApplicationShutdown(): Promise<void> {
     await this.close();
   }
 }

--- a/src/common/rabbitmq/rabbitmq.service.ts
+++ b/src/common/rabbitmq/rabbitmq.service.ts
@@ -3,7 +3,7 @@ import {
   Injectable,
   Logger,
   OnModuleDestroy,
-  OnApplicationShutdown
+  OnApplicationShutdown,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 
@@ -98,7 +98,7 @@ export class RabbitMQService implements OnModuleDestroy, OnApplicationShutdown {
       });
     } catch (error) {
       throw new Error(`Could not send message to RabbitMQ queue ${queue}.`, {
-        cause: error
+        cause: error,
       });
     }
   }

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.module.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.module.ts
@@ -1,9 +1,10 @@
 import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
 import { CommonModule } from "src/common/common.module";
 import { RabbitMQJobActionCreator } from "./rabbitmqaction.service";
 
 @Module({
-  imports: [CommonModule],
+  imports: [ConfigModule, CommonModule],
   providers: [RabbitMQJobActionCreator],
   exports: [RabbitMQJobActionCreator],
 })

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.service.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.service.ts
@@ -23,7 +23,7 @@ export class RabbitMQJobActionCreator implements JobActionCreator<JobDto> {
     return new RabbitMQJobAction(
       this.configService,
       this.rabbitMQService,
-      options
+      options,
     );
   }
 }

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.service.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import {
   JobActionCreator,
   JobActionOptions,
@@ -10,12 +11,15 @@ import { RabbitMQService } from "src/common/rabbitmq/rabbitmq.service";
 
 @Injectable()
 export class RabbitMQJobActionCreator implements JobActionCreator<JobDto> {
-  constructor(private rabbitMQService: RabbitMQService) {}
+  constructor(
+    private configService: ConfigService,
+    private rabbitMQService: RabbitMQService,
+  ) {}
 
   public create<Options extends JobActionOptions>(options: Options) {
     if (!isRabbitMQJobActionOptions(options)) {
       throw new Error("Invalid options for RabbitMQJobAction.");
     }
-    return new RabbitMQJobAction(this.rabbitMQService, options);
+    return new RabbitMQJobAction(this.configService, this.rabbitMQService, options);
   }
 }

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.service.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.service.ts
@@ -20,6 +20,10 @@ export class RabbitMQJobActionCreator implements JobActionCreator<JobDto> {
     if (!isRabbitMQJobActionOptions(options)) {
       throw new Error("Invalid options for RabbitMQJobAction.");
     }
-    return new RabbitMQJobAction(this.configService, this.rabbitMQService, options);
+    return new RabbitMQJobAction(
+      this.configService,
+      this.rabbitMQService,
+      options
+    );
   }
 }

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.ts
@@ -40,7 +40,7 @@ export class RabbitMQJobAction<T extends JobDto> implements JobAction<T> {
       this.queue,
       this.exchange,
       this.key,
-      JSON.stringify(job)
+      JSON.stringify(job),
     );
   }
 }

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.ts
@@ -23,10 +23,9 @@ export class RabbitMQJobAction<T extends JobDto> implements JobAction<T> {
     private readonly rabbitMQService: RabbitMQService,
     options: RabbitMQJobActionOptions,
   ) {
-    Logger.log(
-      "Initializing RabbitMQJobAction. Params: " + JSON.stringify(options),
-      "RabbitMQJobAction",
-    );
+    if (!this.rabbitMQService.rabbitMqEnabled) {
+      throw new Error("RabbitMQService is not enabled.");
+    }
     this.queue = options.queue;
     this.exchange = options.exchange;
     this.key = options.key;
@@ -37,7 +36,11 @@ export class RabbitMQJobAction<T extends JobDto> implements JobAction<T> {
       "Performing RabbitMQJobAction: " + JSON.stringify(job),
       "RabbitMQJobAction",
     );
-    this.rabbitMQService.connect(this.queue, this.exchange, this.key);
-    this.rabbitMQService.sendMessage(this.queue, JSON.stringify(job));
+    this.rabbitMQService.sendMessage(
+      this.queue,
+      this.exchange,
+      this.key,
+      JSON.stringify(job)
+    );
   }
 }

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.ts
@@ -1,4 +1,5 @@
 import { Logger } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { JobAction, JobDto } from "../../jobconfig.interface";
 import { JobClass } from "../../../../jobs/schemas/job.schema";
 import {
@@ -20,10 +21,13 @@ export class RabbitMQJobAction<T extends JobDto> implements JobAction<T> {
   }
 
   constructor(
+    private readonly configService: ConfigService,
     private readonly rabbitMQService: RabbitMQService,
     options: RabbitMQJobActionOptions,
   ) {
-    if (!this.rabbitMQService.rabbitMqEnabled) {
+    const rabbitMqEnabled =
+      this.configService.get<string>("rabbitMq.enabled") === "yes";
+    if (!rabbitMqEnabled) {
       throw new Error("RabbitMQService is not enabled.");
     }
     this.queue = options.queue;


### PR DESCRIPTION
## Description
The NestJS `RabbitMQService` always gets initialized when the application starts. However, the RabbitMQ connection itself should not get initialized if `RABBITMQ_ENABLED=no` in the `.env` file. The following changes will initialize the connection only when `RABBITMQ_ENABLED=yes`, while also printing the relevant logs. Then, will also throw relevant errors in the case that we are unable to connect to the queue or send a message to it. 

On the other hand, if based on the `jobConfig` definition, we wish that a job will use the `RabbitMQJobAction`, then in the action's constructor we check that the service is enabled. If not, we throw an error.

## Motivation
Addressing @sbliven 's latest comments after merging PR https://github.com/SciCatProject/scicat-backend-next/pull/1575