### PR TITLE
refactor(proposal): use openapi plugin

### DIFF
--- a/nest-cli.json
+++ b/nest-cli.json
@@ -5,7 +5,12 @@
     "plugins": [{
       "name": "@nestjs/swagger",
       "options": {
-        "dtoFileNameSuffix": [".dto.ts", "sample.schema.ts"],
+        "dtoFileNameSuffix": [
+          ".dto.ts",
+          "sample.schema.ts",
+          "proposal.schema.ts",
+          "measurement-period.schema.ts"
+        ],
         "introspectComments": true
       }
     }]

--- a/src/proposals/dto/create-measurement-period.dto.ts
+++ b/src/proposals/dto/create-measurement-period.dto.ts
@@ -1,4 +1,3 @@
-import { ApiProperty } from "@nestjs/swagger";
 import { IsDateString, IsOptional, IsString } from "class-validator";
 
 export class CreateMeasurementPeriodDto {

--- a/src/proposals/dto/create-measurement-period.dto.ts
+++ b/src/proposals/dto/create-measurement-period.dto.ts
@@ -2,36 +2,27 @@ import { ApiProperty } from "@nestjs/swagger";
 import { IsDateString, IsOptional, IsString } from "class-validator";
 
 export class CreateMeasurementPeriodDto {
-  @ApiProperty({
-    type: String,
-    required: true,
-    description:
-      "Instrument or beamline identifier where measurement was pursued, e.g. /PSI/SLS/TOMCAT",
-  })
+  /**
+   * Instrument or beamline identifier where measurement was pursued, e.g. /PSI/SLS/TOMCAT
+   */
   @IsString()
   readonly instrument: string;
 
-  @ApiProperty({
-    type: Date,
-    description:
-      "Time when measurement period started, format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
-  })
+  /**
+   * Time when measurement period started, format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.
+   */
   @IsDateString()
   readonly start: Date;
 
-  @ApiProperty({
-    type: Date,
-    description:
-      "Time when measurement period ended, format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
-  })
+  /**
+   * Time when measurement period ended, format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.
+   */
   @IsDateString()
   readonly end: Date;
 
-  @ApiProperty({
-    type: String,
-    description:
-      "Additional information relevant for this measurement period, e.g. if different accounts were used for data taking.",
-  })
+  /**
+   * Additional information relevant for this measurement period, e.g. if different accounts were used for data taking.
+   */
   @IsOptional()
   @IsString()
   readonly comment?: string;

--- a/src/proposals/dto/create-proposal.dto.ts
+++ b/src/proposals/dto/create-proposal.dto.ts
@@ -1,4 +1,3 @@
-import { ApiProperty } from "@nestjs/swagger";
 import { IsString } from "class-validator";
 import { UpdateProposalDto } from "./update-proposal.dto";
 

--- a/src/proposals/dto/create-proposal.dto.ts
+++ b/src/proposals/dto/create-proposal.dto.ts
@@ -3,12 +3,9 @@ import { IsString } from "class-validator";
 import { UpdateProposalDto } from "./update-proposal.dto";
 
 export class CreateProposalDto extends UpdateProposalDto {
-  @ApiProperty({
-    type: String,
-    required: true,
-    description:
-      "Globally unique identifier of a proposal, eg. PID-prefix/internal-proposal-number. PID prefix is auto prepended.",
-  })
+  /**
+   * Globally unique identifier of a proposal, eg. PID-prefix/internal-proposal-number. PID prefix is auto prepended.
+   */
   @IsString()
   readonly proposalId: string;
 }

--- a/src/proposals/dto/update-proposal.dto.ts
+++ b/src/proposals/dto/update-proposal.dto.ts
@@ -14,132 +14,100 @@ import { CreateMeasurementPeriodDto } from "./create-measurement-period.dto";
 
 @ApiTags("proposals")
 export class UpdateProposalDto extends OwnableDto {
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Email of principal investigator.",
-  })
+  /**
+   * Email of principal investigator.
+   */
   @IsOptional()
   @IsEmail()
   readonly pi_email?: string;
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "First name of principal investigator.",
-  })
+  /**
+   * First name of principal investigator.
+   */
   @IsOptional()
   @IsString()
   readonly pi_firstname?: string;
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Last name of principal investigator.",
-  })
+  /**
+   * Last name of principal investigator.
+   */
   @IsOptional()
   @IsString()
   readonly pi_lastname?: string;
 
-  @ApiProperty({
-    type: String,
-    required: true,
-    description: "Email of main proposer.",
-  })
+  /**
+   * Email of main proposer.
+   */
   @IsEmail()
   readonly email: string;
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "First name of main proposer.",
-  })
+  /**
+   * First name of main proposer.
+   */
   @IsOptional()
   @IsString()
   readonly firstname?: string;
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Last name of main proposer.",
-  })
+  /**
+   * Last name of main proposer.
+   */
   @IsOptional()
   @IsString()
   readonly lastname?: string;
 
-  @ApiProperty({
-    type: String,
-    required: true,
-    description: "The title of the proposal.",
-  })
+  /**
+   * The title of the proposal.
+   */
   @IsString()
   readonly title: string;
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "The proposal abstract.",
-  })
+  /**
+   * The proposal abstract.
+   */
   @IsOptional()
   @IsString()
   readonly abstract?: string;
 
-  @ApiProperty({
-    type: Date,
-    required: false,
-    description: "The date when the data collection starts.",
-  })
+  /**
+   * The date when the data collection starts.
+   */
   @IsOptional()
   @IsDateString()
   readonly startTime?: Date;
 
-  @ApiProperty({
-    type: Date,
-    required: false,
-    description: "The date when data collection finishes.",
-  })
+  /**
+   * The date when data collection finishes.
+   */
   @IsOptional()
   @IsDateString()
   readonly endTime?: Date;
 
-  @ApiProperty({
-    type: CreateMeasurementPeriodDto,
-    isArray: true,
-    required: false,
-    description:
-      "Embedded information used inside proposals to define which type of experiment has to be pursued, where (at which instrument) and when.",
-  })
+  /**
+   * Embedded information used inside proposals to define which type of experiment has to be pursued, where (at which instrument) and when.
+   */
   @IsArray()
   @IsOptional()
   @ValidateNested({ each: true })
   @Type(() => CreateMeasurementPeriodDto)
   readonly MeasurementPeriodList?: CreateMeasurementPeriodDto[];
 
-  @ApiProperty({
-    type: Object,
-    required: false,
-    default: {},
-    description: "JSON object containing the proposal metadata.",
-  })
+  /**
+   * JSON object containing the proposal metadata.
+   */
   @IsOptional()
   @IsObject()
-  readonly metadata?: Record<string, unknown>;
+  readonly metadata?: Record<string, unknown> = {};
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Parent proposal id.",
-  })
+  /**
+   * Parent proposal id.
+   */
   @IsOptional()
   @IsString()
   readonly parentProposalId?: string;
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description:
-      "Characterize type of proposal, use some of the configured values",
-  })
+  /**
+   * Characterize type of proposal, use some of the configured values
+   */
   @IsOptional()
   @IsString()
   readonly type?: string;

--- a/src/proposals/dto/update-proposal.dto.ts
+++ b/src/proposals/dto/update-proposal.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty, ApiTags, PartialType } from "@nestjs/swagger";
+import { ApiTags, PartialType } from "@nestjs/swagger";
 import { Type } from "class-transformer";
 import {
   IsArray,

--- a/src/proposals/schemas/measurement-period.schema.ts
+++ b/src/proposals/schemas/measurement-period.schema.ts
@@ -1,5 +1,4 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
-import { ApiProperty } from "@nestjs/swagger";
 import { Document } from "mongoose";
 import { QueryableClass } from "src/common/schemas/queryable.schema";
 

--- a/src/proposals/schemas/measurement-period.schema.ts
+++ b/src/proposals/schemas/measurement-period.schema.ts
@@ -7,36 +7,27 @@ export type MeasurementPeriodDocument = MeasurementPeriodClass & Document;
 
 @Schema()
 export class MeasurementPeriodClass extends QueryableClass {
-  @ApiProperty({
-    type: String,
-    required: true,
-    description:
-      "Instrument or beamline identifier where measurement was pursued, e.g. /PSI/SLS/TOMCAT",
-  })
+  /**
+   * Instrument or beamline identifier where measurement was pursued, e.g. /PSI/SLS/TOMCAT
+   */
   @Prop({ type: String, required: true, index: true })
   instrument: string;
 
-  @ApiProperty({
-    type: Date,
-    description:
-      "Time when measurement period started, format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
-  })
+  /**
+   * Time when measurement period started, format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.
+   */
   @Prop({ type: Date, index: true })
   start: Date;
 
-  @ApiProperty({
-    type: Date,
-    description:
-      "Time when measurement period ended, format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.",
-  })
+  /**
+   * Time when measurement period ended, format according to chapter 5.6 internet date/time format in RFC 3339. Local times without timezone/offset info are automatically transformed to UTC using the timezone of the API server.
+   */
   @Prop({ type: Date, index: true })
   end: Date;
 
-  @ApiProperty({
-    type: String,
-    description:
-      "Additional information relevant for this measurement period, e.g. if different accounts were used for data taking.",
-  })
+  /**
+   * Additional information relevant for this measurement period, e.g. if different accounts were used for data taking.
+   */
   @Prop({ type: String })
   comment: string;
 }

--- a/src/proposals/schemas/proposal.schema.ts
+++ b/src/proposals/schemas/proposal.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiHideProperty, ApiProperty } from "@nestjs/swagger";
 import { Document, Schema as MongooseSchema } from "mongoose";
 
 import { OwnableClass } from "src/common/schemas/ownable.schema";
@@ -21,12 +21,9 @@ export type ProposalDocument = ProposalClass & Document;
   minimize: false,
 })
 export class ProposalClass extends OwnableClass {
-  @ApiProperty({
-    type: String,
-    required: true,
-    description:
-      "Globally unique identifier of a proposal, eg. PID-prefix/internal-proposal-number. PID prefix is auto prepended.",
-  })
+  /**
+   * Globally unique identifier of a proposal, eg. PID-prefix/internal-proposal-number. PID prefix is auto prepended.
+   */
   @Prop({
     type: String,
     unique: true,
@@ -34,16 +31,15 @@ export class ProposalClass extends OwnableClass {
   })
   proposalId: string;
 
+  @ApiHideProperty()
   @Prop({
     type: String,
   })
   _id: string;
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Email of principal investigator.",
-  })
+  /**
+   * Email of principal investigator.
+   */
   @Prop({
     type: String,
     required: false,
@@ -51,112 +47,90 @@ export class ProposalClass extends OwnableClass {
   })
   pi_email?: string;
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "First name of principal investigator.",
-  })
+  /**
+   * First name of principal investigator.
+   */
   @Prop({
     type: String,
     required: false,
   })
   pi_firstname?: string;
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Last name of principal investigator.",
-  })
+  /**
+   * Last name of principal investigator.
+   */
   @Prop({
     type: String,
     required: false,
   })
   pi_lastname?: string;
 
-  @ApiProperty({
-    type: String,
-    required: true,
-    description: "Email of main proposer.",
-  })
+  /**
+   * Email of main proposer.
+   */
   @Prop({
     type: String,
     required: true,
   })
   email: string;
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "First name of main proposer.",
-  })
+  /**
+   * First name of main proposer.
+   */
   @Prop({
     type: String,
     required: false,
   })
   firstname?: string;
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Last name of main proposer.",
-  })
+  /**
+   * Last name of main proposer.
+   */
   @Prop({
     type: String,
     required: false,
   })
   lastname?: string;
 
-  @ApiProperty({
-    type: String,
-    required: true,
-    description: "The title of the proposal.",
-  })
+  /**
+   * The title of the proposal.
+   */
   @Prop({
     type: String,
     required: true,
   })
   title: string;
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "The proposal abstract.",
-  })
+  /**
+   * The proposal abstract.
+   */
   @Prop({
     type: String,
     required: false,
   })
   abstract?: string;
 
-  @ApiProperty({
-    type: Date,
-    required: false,
-    description: "The date when the data collection starts.",
-  })
+  /**
+   * The date when the data collection starts.
+   */
   @Prop({
     type: Date,
     required: false,
   })
   startTime?: Date;
 
-  @ApiProperty({
-    type: Date,
-    required: false,
-    description: "The date when data collection finishes.",
-  })
+  /**
+   * The date when data collection finishes.
+   */
   @Prop({
     type: Date,
     required: false,
   })
   endTime?: Date;
 
-  @ApiProperty({
-    type: MeasurementPeriodClass,
-    isArray: true,
-    required: false,
-    description:
-      "Embedded information used inside proposals to define which type of experiment has to be pursued, where (at which instrument) and when.",
-  })
+  /**
+   * Embedded information used inside proposals to define which type of experiment has to be pursued, where (at which instrument) and when.
+   */
   @Prop({
     type: [MeasurementPeriodSchema],
     required: false,

--- a/src/proposals/schemas/proposal.schema.ts
+++ b/src/proposals/schemas/proposal.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
-import { ApiHideProperty, ApiProperty } from "@nestjs/swagger";
+import { ApiHideProperty } from "@nestjs/swagger";
 import { Document, Schema as MongooseSchema } from "mongoose";
 
 import { OwnableClass } from "src/common/schemas/ownable.schema";
@@ -137,43 +137,30 @@ export class ProposalClass extends OwnableClass {
   })
   MeasurementPeriodList?: MeasurementPeriodClass[];
 
-  @ApiProperty({
-    type: MongooseSchema.Types.Mixed,
-    required: false,
-    default: {},
-    description: "JSON object containing the proposal metadata.",
-  })
+  /**
+   * JSON object containing the proposal metadata.
+   */
   @Prop({ type: MongooseSchema.Types.Mixed, required: false, default: {} })
-  metadata?: Record<string, unknown>;
+  metadata?: Record<string, unknown> = {};
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Parent proposal id",
-    default: null,
-    nullable: true,
-  })
+  /**
+   * Parent proposal id
+   */
   @Prop({
     type: String,
-    required: false,
     default: null,
     ref: "Proposal",
   })
-  parentProposalId: string;
+  parentProposalId: string | null = null;
 
-  @ApiProperty({
-    type: String,
-    required: true,
-    default: DEFAULT_PROPOSAL_TYPE,
-    description:
-      "Characterize type of proposal, use some of the configured values",
-  })
+  /**
+   * Characterize type of proposal, use some of the configured values
+   */
   @Prop({
     type: String,
-    required: true,
     default: DEFAULT_PROPOSAL_TYPE,
   })
-  type: string;
+  type: string = DEFAULT_PROPOSAL_TYPE;
 }
 
 export const ProposalSchema = SchemaFactory.createForClass(ProposalClass);


### PR DESCRIPTION
## Description
Use openapi plugin in proposal module

## Motivation
Less clutter in code and less risk for inconstensies between openapi spec and the actual behaviour.

## Fixes
Related to #1590 

## Changes:
Removed all `@ApiProperty` decorators in proposal module.

The first commit doesn't change the openapi spec. The second commit, which touches three fields, does make some changes which we can discuss.

## Tests included

- [ ] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated
