### PR TITLE
fix: added api response to get dataset

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -1305,6 +1305,10 @@ export class DatasetsController {
     isArray: false,
     description: "Return dataset with pid specified",
   })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: "Dataset not found",
+  })
   async findById(@Req() request: Request, @Param("pid") id: string) {
     const dataset = this.convertCurrentToObsoleteSchema(
       await this.checkPermissionsForDatasetObsolete(request, id),


### PR DESCRIPTION
## Description
This PR adds the 404 Not found code to the swagger API for GET Datasets/{id}. Which is returned when the dataset is not found.

## Motivation
We wanted provide more details in the swagger API so it is clear the behavior of the endpoint

## Changes:
* Updated Dataset controller (V3)

## Tests included
- [x] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [X] swagger documentation updated (required for API changes)
- [ ] official documentation updated

