### PR TITLE
fix: datasets fullquery output dto

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -890,7 +890,7 @@ export class DatasetsController {
     @Req() request: Request,
     @Headers() headers: Record<string, string>,
     @Query(new FilterPipe()) queryFilter: { filter?: string },
-  ) {
+  ): Promise<OutputDatasetObsoleteDto[]> {
     const mergedFilters = replaceLikeOperator(
       this.updateMergedFiltersForList(
         request,
@@ -944,7 +944,7 @@ export class DatasetsController {
         }),
       );
     }
-    return outputDatasets;
+    return outputDatasets as OutputDatasetObsoleteDto[];
   }
 
   // GET /datasets/fullquery
@@ -979,7 +979,7 @@ export class DatasetsController {
   async fullquery(
     @Req() request: Request,
     @Query() filters: { fields?: string; limits?: string },
-  ) {
+  ): Promise<OutputDatasetObsoleteDto[]> {
     const user: JWTUser = request.user as JWTUser;
     const fields: IDatasetFields = JSON.parse(filters.fields ?? "{}");
 

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -1008,9 +1008,16 @@ export class DatasetsController {
       limits: JSON.parse(filters.limits ?? "{}"),
     };
 
-    const results = await this.datasetsService.fullquery(parsedFilters);
+    const datasets = await this.datasetsService.fullquery(parsedFilters);
+    let outputDatasets: OutputDatasetObsoleteDto[] = [];
 
-    return results as OutputDatasetObsoleteDto[];
+    if (datasets && datasets.length > 0) {
+      outputDatasets = datasets.map((dataset) =>
+        this.convertCurrentToObsoleteSchema(dataset),
+      );
+    }
+
+    return outputDatasets as OutputDatasetObsoleteDto[];
   }
 
   // GET /fullfacets


### PR DESCRIPTION
## Description
This PR fixes the dto issues in output by `datasets/fullQuery`. Now the list of datasets abides to the `OutputObsoleteDatasetDto`.

## Motivation
Thanks to our collaborators, we discovered that `datasets/fullQuery` was returning the datasets according to the internal database schema and not following the `OutputObsoleteDatasetDto`.

## Fixes
- datasets.controller.ts

## Tests included
- [x] Included for each change/fix? Not needed
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [x] swagger documentation updated (required for API changes)
- [ ] official documentation updated
