### PR TITLE
ci: added test workflow trigger for scitacean

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,24 +39,26 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 
-      # - uses: actions/create-github-app-token@v1
-      #   id: app-token
-      #   with:
-      #     app-id: ${{ secrets.WORKFLOW_DISPATCHER_APP_ID }}
-      #     private-key: ${{ secrets.WORKFLOW_DISPATCHER_APP_PRIVATE_KEY }}
-      #     repositories: SciCatProject/scitacean
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.WORKFLOW_DISPATCHER_APP_ID }}
+          private-key: ${{ secrets.WORKFLOW_DISPATCHER_APP_PRIVATE_KEY }}
+          repositories: scitacean
 
-      # - name: Trigger test workflow in scitacean
-      #   uses: actions/github-script@v6
-      #   with:
-      #     github-token: ${{ steps.app-token.outputs.token }}
-      #     script: |
-      #       github.rest.actions.createWorkflowDispatch({
-      #         owner: 'SciCatProject',
-      #         repo: 'scitacean',
-      #         workflow_id: 'test.yml',
-      #         ref: 'main',
-      #         inputs: {
-      #           "backend-version": "${{ steps.meta.outputs.tags }}"
-      #         }
-      #       })
+      - name: Trigger test workflow in scitacean
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: 'SciCatProject',
+              repo: 'scitacean',
+              workflow_id: 'test.yml',  
+              ref: 'main',
+              inputs: {
+                "backend-version": "latest",
+                "python-version": "3.13",
+                "tox-env": "py313-full"
+              }
+            })

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,3 +38,25 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
           push: true
           tags: ${{ steps.meta.outputs.tags }}
+
+      # - uses: actions/create-github-app-token@v1
+      #   id: app-token
+      #   with:
+      #     app-id: ${{ secrets.WORKFLOW_DISPATCHER_APP_ID }}
+      #     private-key: ${{ secrets.WORKFLOW_DISPATCHER_APP_PRIVATE_KEY }}
+      #     repositories: SciCatProject/scitacean
+
+      # - name: Trigger test workflow in scitacean
+      #   uses: actions/github-script@v6
+      #   with:
+      #     github-token: ${{ steps.app-token.outputs.token }}
+      #     script: |
+      #       github.rest.actions.createWorkflowDispatch({
+      #         owner: 'SciCatProject',
+      #         repo: 'scitacean',
+      #         workflow_id: 'test.yml',
+      #         ref: 'main',
+      #         inputs: {
+      #           "backend-version": "${{ steps.meta.outputs.tags }}"
+      #         }
+      #       })

--- a/.github/workflows/release-and-publish-sdk.yml
+++ b/.github/workflows/release-and-publish-sdk.yml
@@ -92,6 +92,30 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.WORKFLOW_DISPATCHER_APP_ID }}
+          private-key: ${{ secrets.WORKFLOW_DISPATCHER_APP_PRIVATE_KEY }}
+          repositories: scitacean
+
+      - name: Trigger test workflow in scitacean
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: 'SciCatProject',
+              repo: 'scitacean',
+              workflow_id: 'test.yml',  
+              ref: 'main',
+              inputs: {
+                "backend-version": "${{steps.tag_version.outputs.new_tag}}",
+                "python-version": "3.13",
+                "tox-env": "py313-full"
+              }
+            })
+
   start-backend-export-swagger:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-and-publish-sdk.yml
+++ b/.github/workflows/release-and-publish-sdk.yml
@@ -92,28 +92,6 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.WORKFLOW_DISPATCHER_APP_ID }}
-          private-key: ${{ secrets.WORKFLOW_DISPATCHER_APP_PRIVATE_KEY }}
-          repositories: SciCatProject/scitacean
-
-      - name: Trigger test workflow in scitacean
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: 'SciCatProject',
-              repo: 'scitacean',
-              workflow_id: 'test.yml',  
-              ref: 'main',
-              inputs: {
-                "backend-version": "${{ steps.meta.outputs.tags }}"
-              }
-            })
-
   start-backend-export-swagger:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-and-publish-sdk.yml
+++ b/.github/workflows/release-and-publish-sdk.yml
@@ -92,6 +92,28 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
 
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.WORKFLOW_DISPATCHER_APP_ID }}
+          private-key: ${{ secrets.WORKFLOW_DISPATCHER_APP_PRIVATE_KEY }}
+          repositories: SciCatProject/scitacean
+
+      - name: Trigger test workflow in scitacean
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: 'SciCatProject',
+              repo: 'scitacean',
+              workflow_id: 'test.yml',  
+              ref: 'main',
+              inputs: {
+                "backend-version": "${{ steps.meta.outputs.tags }}"
+              }
+            })
+
   start-backend-export-swagger:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/upload-sdk-artifact.yml
+++ b/.github/workflows/upload-sdk-artifact.yml
@@ -67,7 +67,7 @@ jobs:
               ref: 'main',
               inputs: {
                 "backend-version": "latest",
-                "python-version": 3.13,
+                "python-version": "3.13",
                 "tox-env": "py313-full"
               }
             })

--- a/.github/workflows/upload-sdk-artifact.yml
+++ b/.github/workflows/upload-sdk-artifact.yml
@@ -66,7 +66,9 @@ jobs:
               workflow_id: 'test.yml',  
               ref: 'main',
               inputs: {
-                "backend-version": "v4.12.0"
+                "backend-version": "latest"
+                "python-version": 3.13
+                "tox-env": "py313-full"
               }
             })
 

--- a/.github/workflows/upload-sdk-artifact.yml
+++ b/.github/workflows/upload-sdk-artifact.yml
@@ -47,31 +47,6 @@ jobs:
         with:
           name: swagger-schema-${{ github.sha }}
           path: ./swagger-schema.json
-      # TODO: following step needs to be removed after testing.
-
-      - uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ secrets.WORKFLOW_DISPATCHER_APP_ID }}
-          private-key: ${{ secrets.WORKFLOW_DISPATCHER_APP_PRIVATE_KEY }}
-          repositories: scitacean
-
-      - name: Trigger test workflow in scitacean
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ steps.app-token.outputs.token }}
-          script: |
-            github.rest.actions.createWorkflowDispatch({
-              owner: 'SciCatProject',
-              repo: 'scitacean',
-              workflow_id: 'test.yml',  
-              ref: 'main',
-              inputs: {
-                "backend-version": "latest",
-                "python-version": "3.13",
-                "tox-env": "py313-full"
-              }
-            })
 
   generate-and-upload-sdk:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-sdk-artifact.yml
+++ b/.github/workflows/upload-sdk-artifact.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           app-id: ${{ secrets.WORKFLOW_DISPATCHER_APP_ID }}
           private-key: ${{ secrets.WORKFLOW_DISPATCHER_APP_PRIVATE_KEY }}
-          repositories: SciCatProject/scitacean
+          repositories: scitacean
 
       - name: Trigger test workflow in scitacean
         uses: actions/github-script@v6

--- a/.github/workflows/upload-sdk-artifact.yml
+++ b/.github/workflows/upload-sdk-artifact.yml
@@ -66,8 +66,8 @@ jobs:
               workflow_id: 'test.yml',  
               ref: 'main',
               inputs: {
-                "backend-version": "latest"
-                "python-version": 3.13
+                "backend-version": "latest",
+                "python-version": 3.13,
                 "tox-env": "py313-full"
               }
             })

--- a/.github/workflows/upload-sdk-artifact.yml
+++ b/.github/workflows/upload-sdk-artifact.yml
@@ -47,6 +47,28 @@ jobs:
         with:
           name: swagger-schema-${{ github.sha }}
           path: ./swagger-schema.json
+      # TODO: following step needs to be removed after testing
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.WORKFLOW_DISPATCHER_APP_ID }}
+          private-key: ${{ secrets.WORKFLOW_DISPATCHER_APP_PRIVATE_KEY }}
+          repositories: SciCatProject/scitacean
+
+      - name: Trigger test workflow in scitacean
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: 'SciCatProject',
+              repo: 'scitacean',
+              workflow_id: 'test.yml',  
+              ref: 'main',
+              inputs: {
+                "backend-version": "latest"
+              }
+            })
 
   generate-and-upload-sdk:
     runs-on: ubuntu-latest

--- a/.github/workflows/upload-sdk-artifact.yml
+++ b/.github/workflows/upload-sdk-artifact.yml
@@ -66,7 +66,7 @@ jobs:
               workflow_id: 'test.yml',  
               ref: 'main',
               inputs: {
-                "backend-version": "latest"
+                "backend-version": "v4.12.0"
               }
             })
 

--- a/.github/workflows/upload-sdk-artifact.yml
+++ b/.github/workflows/upload-sdk-artifact.yml
@@ -48,6 +48,7 @@ jobs:
           name: swagger-schema-${{ github.sha }}
           path: ./swagger-schema.json
       # TODO: following step needs to be removed after testing.
+
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:

--- a/.github/workflows/upload-sdk-artifact.yml
+++ b/.github/workflows/upload-sdk-artifact.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           name: swagger-schema-${{ github.sha }}
           path: ./swagger-schema.json
-      # TODO: following step needs to be removed after testing
+      # TODO: following step needs to be removed after testing.
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
- Added two test workflow triggers for the scitacean repo.
  - One trigger runs on push to master.
  - The other runs when a new release is created and pushed.
- Both triggers use a GitHub App token to dispatch the test workflow with inputs (backend-version, python-version, tox-env).

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
