### PR TITLE
fix: use partialupdatedatasetdto in patch v4 endpoint

### DIFF
--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -678,7 +678,7 @@ export class DatasetsV4Controller {
     description:
       "Fields that needs to be updated in the dataset. Only the fields that needs to be updated have to be passed in.",
     required: true,
-    type: UpdateDatasetDto,
+    type: PartialUpdateDatasetDto,
   })
   @ApiResponse({
     status: HttpStatus.OK,


### PR DESCRIPTION
## Description
Changing to PartialUpdateDatasetDto from UpdateDatasetDto for the patch datasets v4 endpoint.

## Motivation
It should be possible to update any fields. The body of this endpoint takes a PartialUpdateDatasetDto, that needs to be reflected in the @ApiBody for the SDK to work.

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated
