### PR TITLE
feat: add support for dyanmic redirect url for oidc login and improve session management

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `ACCESS_GROUPS_STATIC_VALUES` | string | Yes | Comma-separated list of access groups automatically assigned to all users. Example: "scicat, user". | |
 | `ACCESS_GROUPS_OIDCPAYLOAD_ENABLED` | string | Yes | Flag to enable/disable fetching access groups directly from OIDC response. Requires specifying a field via `OIDC_ACCESS_GROUPS_PROPERTY` to extract access groups. | false |
 | `DOI_PREFIX` | string | | The facility DOI prefix, with trailing slash. | |
-| `EXPRESS_SESSION_SECRET` | string | No | Secret used to set up express session. | |
+| `EXPRESS_SESSION_SECRET` | string | No | Secret used to set up express session. Required if using OIDC authentication | |
 | `HTTP_MAX_REDIRECTS` | number | Yes | Max redirects for HTTP requests. | 5 |
 | `HTTP_TIMEOUT` | number | Yes | Timeout for HTTP requests in ms. | 5000 |
 | `JWT_SECRET` | string | | The secret for your JWT token, used for authorization. | |
@@ -140,7 +140,7 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `OIDC_CLIENT_SECRET` | string | Yes | Secret to provide to the OIDC service to obtain the user token. Example: Aa1JIw3kv3mQlGFWhRrE3gOdkH6xreAwro. | |
 | `OIDC_CALLBACK_URL` | string | Yes | SciCat callback URL to redirect to after a successful login. Example: http://myscicat/api/v3/oidc/callback. | |
 | `OIDC_SCOPE` | string | Yes | Space-separated list of info returned by the OIDC service. Example: "openid profile email". | |
-| `OIDC_SUCCESS_URL` | string | Yes | SciCat Frontend auth-callback URL. Required to pass user credentials to SciCat Frontend after OIDC login. Example: https://myscicatfrontend/auth-callback. | |
+| `OIDC_SUCCESS_URL` | string | Yes | SciCat Frontend auth-callback URL. Required to pass user credentials to SciCat Frontend after OIDC login. Example: https://myscicatfrontend/auth-callback. Must be `frontend-base-url/auth-callback` or `frontend-base-url/login` for the official SciCat frontend. | |
 | `OIDC_RETURN_URL` | string | Yes | The path segment within the SciCat Frontend to redirect to, passed as query param in `OIDC_SUCCESS_URL` and handled by frontend. Example: /datasets. | |
 | `OIDC_FRONTEND_CLIENTS` | string | Yes | Comma separated list of additional frontend OIDC clients for this backend. Example: scilog,maxiv. Their success and return URLs can be configured by setting `OIDC_${CLIENT}_SUCCESS_URL` (E.g. `OIDC_SCILOG_SUCCESS_URL`) and `OIDC_${CLIENT}_RETURN_URL` | |
 | `OIDC_ACCESS_GROUPS` | string | Yes | Functionality is still unclear. | |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `ACCESS_GROUPS_STATIC_VALUES` | string | Yes | Comma-separated list of access groups automatically assigned to all users. Example: "scicat, user". | |
 | `ACCESS_GROUPS_OIDCPAYLOAD_ENABLED` | string | Yes | Flag to enable/disable fetching access groups directly from OIDC response. Requires specifying a field via `OIDC_ACCESS_GROUPS_PROPERTY` to extract access groups. | false |
 | `DOI_PREFIX` | string | | The facility DOI prefix, with trailing slash. | |
-| `EXPRESS_SESSION_SECRET` | string | Yes | Secret used to set up express session. | |
+| `EXPRESS_SESSION_SECRET` | string | No | Secret used to set up express session. | |
 | `HTTP_MAX_REDIRECTS` | number | Yes | Max redirects for HTTP requests. | 5 |
 | `HTTP_TIMEOUT` | number | Yes | Timeout for HTTP requests in ms. | 5000 |
 | `JWT_SECRET` | string | | The secret for your JWT token, used for authorization. | |
@@ -141,6 +141,8 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `OIDC_CALLBACK_URL` | string | Yes | SciCat callback URL to redirect to after a successful login. Example: http://myscicat/api/v3/oidc/callback. | |
 | `OIDC_SCOPE` | string | Yes | Space-separated list of info returned by the OIDC service. Example: "openid profile email". | |
 | `OIDC_SUCCESS_URL` | string | Yes | SciCat Frontend auth-callback URL. Required to pass user credentials to SciCat Frontend after OIDC login. Example: https://myscicatfrontend/auth-callback. | |
+| `OIDC_RETURN_URL` | string | Yes | The path segment within the SciCat Frontend to redirect to, passed as query param in `OIDC_SUCCESS_URL` and handled by frontend. Example: /datasets. | |
+| `OIDC_FRONTEND_CLIENTS` | string | Yes | Comma separated list of additional frontend OIDC clients for this backend. Example: scilog,maxiv. Their success and return URLs can be configured by setting `OIDC_${CLIENT}_SUCCESS_URL` (E.g. `OIDC_SCILOG_SUCCESS_URL`) and `OIDC_${CLIENT}_RETURN_URL` | |
 | `OIDC_ACCESS_GROUPS` | string | Yes | Functionality is still unclear. | |
 | `OIDC_ACCESS_GROUPS_PROPERTY` | string | Yes | Target field to get the access groups value from OIDC response. | |
 | `OIDC_USERINFO_MAPPING_FIELD_USERNAME` | string | Yes | Comma-separated list of fields from the OIDC response to use as the user's profile username. Example: `OIDC_USERINFO_MAPPING_FIELD_USERNAME="iss, sub"`. | "preferred_username" \|\| "name" |

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -2,10 +2,18 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { AuthController } from "./auth.controller";
 import { AuthService } from "./auth.service";
 import { ConfigService } from "@nestjs/config";
+import configuration, { type OidcConfig } from "src/config/configuration";
+import { Response } from "express";
+import { Session } from "express-session";
 
 class AuthServiceMock {
   login() {
-    return { username: "Test User", email: "testUser@gmail.com" };
+    return {
+      username: "Test User",
+      email: "testUser@gmail.com",
+      access_token: "xyz",
+      userId: "abc",
+    };
   }
 
   adLogin() {
@@ -17,6 +25,18 @@ class AuthServiceMock {
   }
 }
 
+const config: Partial<ReturnType<typeof configuration>> = {
+  oidc: {
+    frontendClients: ["scicat"],
+    clientConfig: {
+      scicat: {
+        successURL: "https://scicatbackend.com/",
+      },
+      maxiv: {}, //simulate unset config
+    },
+  } as unknown as OidcConfig,
+};
+
 describe("AuthController", () => {
   let controller: AuthController;
 
@@ -24,7 +44,10 @@ describe("AuthController", () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [AuthController],
       providers: [
-        ConfigService,
+        {
+          provide: ConfigService,
+          useValue: new ConfigService(config),
+        },
         { provide: AuthService, useClass: AuthServiceMock },
       ],
     }).compile();
@@ -34,5 +57,59 @@ describe("AuthController", () => {
 
   it("should be defined", () => {
     expect(controller).toBeDefined();
+  });
+
+  it("should redirect to successURL for the client from config", async () => {
+    const mockResponse: Response = {
+      req: {
+        session: {
+          client: "scicat",
+          returnURL: "/datasets123",
+        } as unknown as Session,
+      },
+      redirect: jest.fn<void, [string]>(),
+    } as unknown as Response;
+
+    await controller.loginCallback(mockResponse);
+
+    expect(mockResponse.redirect).toBeCalled();
+    const redirectedUrl = (
+      mockResponse.redirect as unknown as jest.Mock<void, [string]>
+    ).mock.calls[0][0];
+    console.log("redirectedURL is", redirectedUrl);
+    const url = new URL(redirectedUrl);
+    expect(url.origin).toEqual<string>(
+      new URL(config.oidc!.clientConfig["scicat"].successURL as string).origin,
+    );
+    expect(url.searchParams.get("access-token")).toEqual<string>("xyz");
+    expect(url.searchParams.get("user-id")).toEqual<string>("abc");
+    expect(url.searchParams.get("returnUrl")).toEqual<string>("/datasets123");
+  });
+
+  it("should redirect to successURL from session if config is unset", async () => {
+    const mockResponse: Response = {
+      req: {
+        session: {
+          client: "maxiv",
+          successURL: "https://custom-scicat-frontend.com/",
+        } as unknown as Session,
+      },
+      redirect: jest.fn<void, [string]>(),
+    } as unknown as Response;
+
+    await controller.loginCallback(mockResponse);
+
+    expect(mockResponse.redirect).toBeCalled();
+    const redirectedUrl = (
+      mockResponse.redirect as unknown as jest.Mock<void, [string]>
+    ).mock.calls[0][0];
+    const url = new URL(redirectedUrl);
+    expect(url.origin).toEqual<string>(
+      new URL("https://custom-scicat-frontend.com/").origin,
+    );
+    expect(url.searchParams.get("access-token")).toEqual<string>("xyz");
+    expect(url.searchParams.get("user-id")).toEqual<string>("abc");
+    // Default returnUrl since returnUrl config is also unset
+    expect(url.searchParams.get("returnUrl")).toEqual<string>("/datasets");
   });
 });

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -112,4 +112,19 @@ describe("AuthController", () => {
     // Default returnUrl since returnUrl config is also unset
     expect(url.searchParams.get("returnUrl")).toEqual<string>("/datasets");
   });
+
+  it("should throw exception if both config and session.successURL are unset", async () => {
+    const mockResponse: Response = {
+      req: {
+        session: {
+          client: "maxiv",
+        } as unknown as Session,
+      },
+      redirect: jest.fn<void, [string]>(),
+    } as unknown as Response;
+    // Because the new URL(...) constructor fails for empty string
+    await expect(controller.loginCallback(mockResponse)).rejects.toThrow(
+      "Invalid URL",
+    );
+  });
 });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -6,6 +6,7 @@ import {
   Res,
   Req,
   HttpCode,
+  Query,
 } from "@nestjs/common";
 import { LocalAuthGuard } from "./guards/local-auth.guard";
 import { AuthService } from "./auth.service";
@@ -16,6 +17,7 @@ import {
   ApiOperation,
   ApiResponse,
   ApiTags,
+  ApiQuery,
 } from "@nestjs/swagger";
 import { CredentialsDto } from "./dto/credentials.dto";
 import { LdapAuthGuard } from "./guards/ldap.guard";
@@ -79,6 +81,11 @@ export class AuthController {
   @AllowAny()
   @UseGuards(OidcAuthGuard)
   @Get("oidc")
+  @ApiQuery({
+    name: "successURL",
+    description: "The URL to redirect to in case of successful login",
+    required: false,
+  })
   async oidcLogin() {
     // this function is invoked when the oidc is set as an auth method. It's behaviour comes from the oidc strategy
   }
@@ -89,9 +96,9 @@ export class AuthController {
   async loginCallback(@Res() res: Response) {
     const token = await this.authService.login(res.req.user as User);
     const url = new URL(
+      res.req.session.successURL ||
       this.configService.get<OidcConfig>("oidc")?.successURL ||
-        res.req.headers["referer"] ||
-        "",
+      "",
     );
     url.searchParams.append("access-token", token.access_token as string);
     url.searchParams.append("user-id", token.userId as string);

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -24,18 +24,13 @@ import { AllowAny } from "./decorators/allow-any.decorator";
 import { User } from "src/users/schemas/user.schema";
 import { OidcAuthGuard } from "./guards/oidc.guard";
 import { Request, Response } from "express";
-import { ConfigService } from "@nestjs/config";
-import { OidcConfig } from "src/config/configuration";
 import { ReturnedAuthLoginDto } from "./dto/returnedLogin.dto";
 
 @ApiBearerAuth()
 @ApiTags("auth")
 @Controller("auth")
 export class AuthController {
-  constructor(
-    private authService: AuthService,
-    private configService: ConfigService,
-  ) {}
+  constructor(private authService: AuthService) {}
 
   @ApiBody({ type: CredentialsDto })
   @AllowAny()
@@ -101,23 +96,10 @@ export class AuthController {
   @Get("oidc/callback")
   async loginCallback(@Res() res: Response) {
     const token = await this.authService.login(res.req.user as User);
-    const url = new URL(
-      this.configService.get<OidcConfig>("oidc")?.clientConfig[
-        res.req.session.client!
-      ].successURL ||
-        res.req.session.successURL || // only for MAXIV. The value is HTTP Referer of /oidc request. Recommended deprecating.
-        "",
-    );
+    const url = new URL(res.req.session.successURL!);
     url.searchParams.append("access-token", token.access_token as string);
     url.searchParams.append("user-id", token.userId as string);
-    url.searchParams.append(
-      "returnUrl",
-      res.req.session.returnURL ||
-        this.configService.get<OidcConfig>("oidc")?.clientConfig[
-          res.req.session.client!
-        ].returnURL ||
-        "/datasets",
-    );
+    url.searchParams.append("returnUrl", res.req.session.returnURL!);
     delete res.req.session.client;
     delete res.req.session.successURL;
     delete res.req.session.returnURL;

--- a/src/auth/guards/oidc.guard.spec.ts
+++ b/src/auth/guards/oidc.guard.spec.ts
@@ -1,0 +1,52 @@
+import { ConfigService } from "@nestjs/config";
+import { Test, TestingModule } from "@nestjs/testing";
+import configuration, { type OidcConfig } from "src/config/configuration";
+import { OidcAuthGuard } from "./oidc.guard";
+import { ExecutionContext } from "@nestjs/common";
+import { Request } from "express";
+
+const config: Partial<ReturnType<typeof configuration>> = {
+  oidc: {
+    frontendClients: ["scicat"],
+  } as unknown as OidcConfig,
+};
+
+describe("OidcAuthGuard", () => {
+  let oidcAuthGuard: OidcAuthGuard;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        OidcAuthGuard,
+        {
+          provide: ConfigService,
+          useValue: new ConfigService(config),
+        },
+      ],
+    }).compile();
+
+    oidcAuthGuard = module.get(OidcAuthGuard);
+  });
+
+  it("should be defined", () => {
+    expect(oidcAuthGuard).toBeDefined();
+  });
+
+  it("should validate and store request params in session", () => {
+    const mockRequest: Request = {
+      query: { client: "scicat", returnURL: "/datasets123" },
+      session: {}, // Initially empty session
+      headers: {},
+    } as unknown as Request;
+    const mockExecutionContext: ExecutionContext = {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+    } as ExecutionContext;
+
+    oidcAuthGuard.getRequest(mockExecutionContext);
+
+    expect(mockRequest.session.client).toBe("scicat");
+    expect(mockRequest.session.returnURL).toBe("/datasets123");
+  });
+});

--- a/src/auth/guards/oidc.guard.spec.ts
+++ b/src/auth/guards/oidc.guard.spec.ts
@@ -2,14 +2,21 @@ import { ConfigService } from "@nestjs/config";
 import { Test, TestingModule } from "@nestjs/testing";
 import configuration, { type OidcConfig } from "src/config/configuration";
 import { OidcAuthGuard } from "./oidc.guard";
-import { ExecutionContext } from "@nestjs/common";
+import { ExecutionContext, HttpException } from "@nestjs/common";
 import { Request } from "express";
 
 const config: Partial<ReturnType<typeof configuration>> = {
   oidc: {
-    frontendClients: ["scicat"],
+    frontendClients: ["scicat", "scilog", "maxiv"],
     clientConfig: {
-      scicat: {},
+      scicat: {
+        successURL: "https://scicat-frontend.com/",
+        returnURL: "/datasets",
+      },
+      scilog: {
+        successURL: "https://scilog-frontend.com/",
+      },
+      maxiv: {},
     },
   } as unknown as OidcConfig,
 };
@@ -37,6 +44,7 @@ describe("OidcAuthGuard", () => {
 
   it("should validate and store request params in session", () => {
     const mockRequest: Request = {
+      path: "/api/v3/auth/oidc",
       query: { client: "scicat", returnURL: "/datasets123" },
       session: {}, // Initially empty session
       headers: {},
@@ -50,11 +58,14 @@ describe("OidcAuthGuard", () => {
     oidcAuthGuard.getRequest(mockExecutionContext);
 
     expect(mockRequest.session.client).toBe("scicat");
+
+    // prefers returnURL from query params over config
     expect(mockRequest.session.returnURL).toBe("/datasets123");
   });
 
   it("should set default client if client is not provided in query", () => {
     const mockRequest: Request = {
+      path: "/api/v3/auth/oidc",
       query: { returnURL: "/datasets123" },
       session: {}, // Initially empty session
       headers: {},
@@ -70,9 +81,63 @@ describe("OidcAuthGuard", () => {
     expect(mockRequest.session.client).toBe("scicat");
   });
 
-  it("should set successURL from referer header if OIDC_SUCCESS_URL config is unset", () => {
+  it("should throw exception if client is unknown", () => {
     const mockRequest: Request = {
+      path: "/api/v3/auth/oidc",
+      query: { client: "unregistered_client" },
+      session: {}, // Initially empty session
+      headers: {},
+    } as unknown as Request;
+    const mockExecutionContext: ExecutionContext = {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+    } as ExecutionContext;
+    expect(() => oidcAuthGuard.getRequest(mockExecutionContext)).toThrow(
+      HttpException,
+    );
+  });
+
+  it("should set proper successURL in session for the default client", () => {
+    const mockRequest: Request = {
+      path: "/api/v3/auth/oidc",
       query: {},
+      session: {}, // Initially empty session
+      headers: {},
+    } as unknown as Request;
+    const mockExecutionContext: ExecutionContext = {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+    } as ExecutionContext;
+
+    oidcAuthGuard.getRequest(mockExecutionContext);
+
+    expect(mockRequest.session.successURL).toBe("https://scicat-frontend.com/");
+  });
+
+  it("should set proper successURL in session for the non-default client", () => {
+    const mockRequest: Request = {
+      path: "/api/v3/auth/oidc",
+      query: { client: "scilog" },
+      session: {}, // Initially empty session
+      headers: {},
+    } as unknown as Request;
+    const mockExecutionContext: ExecutionContext = {
+      switchToHttp: () => ({
+        getRequest: () => mockRequest,
+      }),
+    } as ExecutionContext;
+
+    oidcAuthGuard.getRequest(mockExecutionContext);
+
+    expect(mockRequest.session.successURL).toBe("https://scilog-frontend.com/");
+  });
+
+  it("should set successURL from referer header if OIDC_${CLIENT}_SUCCESS_URL config is unset", () => {
+    const mockRequest: Request = {
+      path: "/api/v3/auth/oidc",
+      query: { client: "maxiv" },
       session: {}, // Initially empty session
       headers: { referer: "https//custom-scicat-frontend.com" },
     } as unknown as Request;

--- a/src/auth/guards/oidc.guard.ts
+++ b/src/auth/guards/oidc.guard.ts
@@ -40,7 +40,10 @@ export class OidcAuthGuard extends AuthGuard("oidc") {
     if (returnURL && typeof returnURL === "string") {
       request.session.returnURL = returnURL;
     }
-    if (request.headers.referer) {
+    if (
+      !oidcConfig?.clientConfig[client].successURL &&
+      request.headers.referer
+    ) {
       // For MAX IV, recommend deprecating and using config based successURL
       request.session.successURL = request.headers.referer;
     }

--- a/src/auth/guards/oidc.guard.ts
+++ b/src/auth/guards/oidc.guard.ts
@@ -1,24 +1,52 @@
-import { ExecutionContext, Injectable } from "@nestjs/common";
+import { ExecutionContext, HttpException, HttpStatus, Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { AuthGuard } from "@nestjs/passport";
+import { Request } from "express";
+import { OidcConfig } from "src/config/configuration";
+
+declare module "express-session" {
+  interface SessionData {
+    successURL?: string;
+  }
+}
+
 
 @Injectable()
 export class OidcAuthGuard extends AuthGuard("oidc") {
-  constructor(private referer: Record<string, string>) {
-    referer = {};
+  constructor(private configService: ConfigService) {
     super();
   }
 
   getRequest(context: ExecutionContext) {
-    const request = context.switchToHttp().getRequest();
-    const cookie: string = request.headers["cookie"]
-      .split(";")
-      .find((c: string) => c.startsWith("connect.sid="));
-    if (request.headers["referer"]) {
-      this.referer[cookie] = request.headers["referer"];
-    } else {
-      request.headers["referer"] = this.referer[cookie];
-      delete this.referer[cookie];
+    const request = context.switchToHttp().getRequest<Request>();
+    const successURL = request.query.successURL;
+    const sessionID = request.sessionID;
+    console.log("oidc.guard.ts: ", sessionID, successURL)
+    if (successURL && typeof successURL === "string") {
+      if (!this.isValidSuccessURL(successURL)) {
+        throw new HttpException("Invalid successURL", HttpStatus.UNAUTHORIZED);
+      }
+      request.session.successURL = successURL;
+    }
+    else if (request.headers.referer) {
+      request.session.successURL = request.headers.referer;
     }
     return request;
   }
+
+  isValidSuccessURL(successURL : string) : boolean {
+    const oidcConfig = this.configService.get<OidcConfig>("oidc");
+    const allowedSuccessURLs = oidcConfig?.additionalSucessURLs;
+    try {
+      if (!allowedSuccessURLs) return false;
+      const successURLOrigin = new URL(successURL).origin;
+      console.log(successURL, successURLOrigin, allowedSuccessURLs);
+      return allowedSuccessURLs.some((url) => new URL(url).origin === successURLOrigin); 
+    }
+    catch (err) {
+      console.log("Error occured", err)
+      return false;
+    }
+  }
 }
+

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -1,0 +1,67 @@
+import configuration from "./configuration";
+
+describe("configuration", () => {
+  beforeEach(() => {
+    process.env = {};
+  });
+
+  it("should generate clientConfig with default client 'scicat'", () => {
+    process.env.OIDC_SUCCESS_URL = "https://default-success-url.com";
+    process.env.OIDC_RETURN_URL = "/datasets";
+
+    const config = configuration();
+
+    expect(config.oidc.clientConfig).toEqual({
+      scicat: {
+        successURL: "https://default-success-url.com",
+        returnURL: "/datasets",
+      },
+    });
+  });
+
+  it("should generate clientConfig with additional clients from environment variables", () => {
+    process.env.OIDC_FRONTEND_CLIENTS = "client1,client2";
+    process.env.OIDC_CLIENT1_SUCCESS_URL = "https://client1-success-url.com";
+    process.env.OIDC_CLIENT1_RETURN_URL = "/client1-homepage";
+    process.env.OIDC_CLIENT2_SUCCESS_URL = "https://client2-success-url.com";
+    process.env.OIDC_CLIENT2_RETURN_URL = "/client2-homepage";
+
+    const config = configuration();
+
+    expect(config.oidc.clientConfig).toEqual({
+      scicat: {
+        successURL: undefined,
+        returnURL: undefined,
+      },
+      client1: {
+        successURL: "https://client1-success-url.com",
+        returnURL: "/client1-homepage",
+      },
+      client2: {
+        successURL: "https://client2-success-url.com",
+        returnURL: "/client2-homepage",
+      },
+    });
+  });
+
+  it("should deduplicate 'scicat' client if included in OIDC_FRONTEND_CLIENTS", () => {
+    process.env.OIDC_FRONTEND_CLIENTS = "scicat,client1";
+    process.env.OIDC_SUCCESS_URL = "https://default-success-url.com";
+    process.env.OIDC_RETURN_URL = "/datasets";
+    process.env.OIDC_CLIENT1_SUCCESS_URL = "https://client1-success-url.com";
+    process.env.OIDC_CLIENT1_RETURN_URL = "/client1-homepage";
+
+    const config = configuration();
+
+    expect(config.oidc.clientConfig).toEqual({
+      scicat: {
+        successURL: "https://default-success-url.com",
+        returnURL: "/datasets",
+      },
+      client1: {
+        successURL: "https://client1-success-url.com",
+        returnURL: "/client1-homepage",
+      },
+    });
+  });
+});

--- a/src/config/configuration.spec.ts
+++ b/src/config/configuration.spec.ts
@@ -64,4 +64,13 @@ describe("configuration", () => {
       },
     });
   });
+
+  it("should throw error if client is defined but no OIDC_${CLIENT}_SUCCESS_URL is set", () => {
+    process.env.OIDC_FRONTEND_CLIENTS = "client1";
+    process.env.OIDC_SUCCESS_URL = "https://default-success-url.com";
+
+    expect(configuration).toThrowError(
+      "Frontend client client1 is defined in OIDC_FRONTEND_CLIENTS but OIDC_CLIENT1_SUCCESS_URL is unset",
+    );
+  });
 });

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -145,6 +145,7 @@ const configuration = () => {
       callbackURL: process.env.OIDC_CALLBACK_URL, // Example: http://localhost:3000/api/v3/oidc/callback
       scope: process.env.OIDC_SCOPE, // Example: "openid profile email"
       successURL: process.env.OIDC_SUCCESS_URL, // Example: http://localhost:3000/explorer
+      additionalSucessURLs: process.env.OIDC_ADDITIONAL_SUCCESS_URLS?.split(","), // Additionally allowed success URLs (only origins) e.g. http://localhost:4200,http://frontend2.scicat/
       accessGroups: process.env.OIDC_ACCESS_GROUPS, // Example: None
       accessGroupProperty: process.env.OIDC_ACCESS_GROUPS_PROPERTY, // Example: groups
       autoLogout: process.env.OIDC_AUTO_LOGOUT || false,

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -88,6 +88,18 @@ const configuration = () => {
     (config, client) => {
       const isDefault = client === "scicat";
       if (isDefault) {
+        const successURL = process.env.OIDC_SUCCESS_URL;
+        if (
+          successURL &&
+          !(
+            new URL(successURL).pathname === "/login" ||
+            new URL(successURL).pathname == "/auth-callback"
+          )
+        ) {
+          throw new Error(
+            `OIDC_SUCCESS_URL must be <frontend-base-url>/login or <frontend-base-url>/auth-callback for the default client scicat but found ${successURL}`,
+          );
+        }
         config[client] = {
           successURL: process.env.OIDC_SUCCESS_URL,
           returnURL: process.env.OIDC_RETURN_URL,

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -87,19 +87,26 @@ const configuration = () => {
   const clientConfig = oidcFrontendClients.reduce(
     (config, client) => {
       const isDefault = client === "scicat";
+      if (isDefault) {
+        config[client] = {
+          successURL: process.env.OIDC_SUCCESS_URL,
+          returnURL: process.env.OIDC_RETURN_URL,
+        };
+        return config;
+      }
+      if (!process.env[`OIDC_${client.toUpperCase()}_SUCCESS_URL`]) {
+        throw new Error(
+          `Frontend client ${client} is defined in OIDC_FRONTEND_CLIENTS but OIDC_${client.toUpperCase()}_SUCCESS_URL is unset`,
+        );
+      }
+      if (!process.env[`OIDC_${client.toUpperCase()}_RETURN_URL`]) {
+        console.warn(
+          `OIDC_${client.toUpperCase()}_RETURN_URL is unset. Will default to /datasets or dynamically provided returnURL in /oidc`,
+        );
+      }
       config[client] = {
-        successURL:
-          process.env[
-            isDefault
-              ? "OIDC_SUCCESS_URL"
-              : `OIDC_${client.toUpperCase()}_SUCCESS_URL`
-          ],
-        returnURL:
-          process.env[
-            isDefault
-              ? "OIDC_RETURN_URL"
-              : `OIDC_${client.toUpperCase()}_RETURN_URL`
-          ],
+        successURL: process.env[`OIDC_${client.toUpperCase()}_SUCCESS_URL`],
+        returnURL: process.env[`OIDC_${client.toUpperCase()}_RETURN_URL`],
       };
       return config;
     },


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
This PR enables support for frontends to specify a successURL and returnURL during OIDC login. This is required to support custom frontends (e.g. scilog at PSI), but also improves security and user experience compared to the existing approach.

## Motivation
<!-- Background on use case, changes needed -->
We clarify some potentially confusing terminology:
- `successURL`: the URL of the frontend to pass the access-token (and userId etc) to (e.g. `https://discovery.development.psi.ch/auth-callback`, `http://localhost/login`)
- `returnURL`: the url, or `route` that the frontend should redirect the user to after successful login. (e.g. `/datasets` or `/datasets/pid123/datafiles`)

Previously, in case of OIDC login, the successURL was statically set in the config (`OIDC_SUCCESS_URL`), OR if the config was unset, was extracted from the `Referer` header of the requester of /oidc.
The `Referer` approach is inherently unsafe, as blindly trusting this header can result in passing the access-token to an arbitrary origin.
This PR addresses this by allowing multiple successURLs to be defined in config. For each `${CLIENT}`, one is able to define `OIDC_${CLIENT}_SUCCESS_URL`. In turn, the client parameter can be passed as a query param to /oidc. To preserve backwards compatibility, if the client parameter is not passed, it defaults to "scicat" and uses the `OIDC_SUCCESS_URL` value as before.
Moreover, we keep support for the Referer approach for backwards compatibility, but recommend deprecating it and using this new client specific config instead.

Previously, In SciCat frontend, after successful OIDC login, the user was always redirected back to /datasets page (or any statically configured path set in `OIDC_RETURN_URL`. A much better user experience is: if a user clicks on Login from `/datasets/pid123/datafiles` page, she is redirected to the same page on successful login. To support this, we enable passing `returnUrl` as query param in /oidc. This is then saved in the session, and /oidc/callback controller adds it to the query params when redirecting to the client specific SUCCESS_URL (e.g. https://discovery.development.psi.ch/auth-callback?returnUrl=/datasets/pid123/datafiles), so that the frontend can use it to redirect to returnUrl. 
A corresponding change in scicat frontend is made to add the `returnUrl` query param in the login component: https://github.com/SciCatProject/frontend/pull/1753



## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->
- Add `client` specific success and return URLs to the config
- Add `client` and `returnURL` as query parameters to /oidc controller
- Update OidcAuthGuard to use express-session in the recommended way (https://docs.nestjs.com/techniques/session), instead of custom Map as before
- Update /oidc/callback controller to use values from the session to support dynamic success/returnUrl

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [x] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
