### PR TITLE
chore: allow unauthenticated users to access dataset origdatablock endpoint

### DIFF
--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -442,74 +442,85 @@ export class CaslAbilityFactory {
     const { can, cannot, build } = new AbilityBuilder(
       createMongoAbility<PossibleAbilities, Conditions>,
     );
-    if (user.currentGroups.some((g) => this.accessGroups?.delete.includes(g))) {
-      /*
+    if (!user) {
+      /**
+      /*  unauthenticated users
+      **/
+      can(Action.OrigdatablockRead, OrigDatablock);
+    } else {
+      if (
+        user.currentGroups.some((g) => this.accessGroups?.delete.includes(g))
+      ) {
+        /*
       / user that belongs to any of the group listed in DELETE_GROUPS
       */
 
-      can(Action.OrigdatablockDelete, OrigDatablock);
-    } else {
-      /*
+        can(Action.OrigdatablockDelete, OrigDatablock);
+      } else {
+        /*
       /  user that does not belong to any of the group listed in DELETE_GROUPS
       */
 
-      cannot(Action.OrigdatablockDelete, OrigDatablock);
-    }
+        cannot(Action.OrigdatablockDelete, OrigDatablock);
+      }
 
-    if (user.currentGroups.some((g) => this.accessGroups?.admin.includes(g))) {
-      /*
+      if (
+        user.currentGroups.some((g) => this.accessGroups?.admin.includes(g))
+      ) {
+        /*
       / user that belongs to any of the group listed in ADMIN_GROUPS
       */
 
-      can(Action.OrigdatablockRead, OrigDatablock);
-      can(Action.OrigdatablockCreate, OrigDatablock);
-      can(Action.OrigdatablockUpdate, OrigDatablock);
-    } else if (
-      user.currentGroups.some((g) =>
-        this.accessGroups?.createDatasetPrivileged.includes(g),
-      )
-    ) {
-      /**
+        can(Action.OrigdatablockRead, OrigDatablock);
+        can(Action.OrigdatablockCreate, OrigDatablock);
+        can(Action.OrigdatablockUpdate, OrigDatablock);
+      } else if (
+        user.currentGroups.some((g) =>
+          this.accessGroups?.createDatasetPrivileged.includes(g),
+        )
+      ) {
+        /**
       /*  users belonging to CREATE_DATASET_PRIVILEGED_GROUPS
       **/
 
-      can(Action.OrigdatablockRead, OrigDatablock);
-      can(Action.OrigdatablockCreate, OrigDatablock);
-      can(Action.OrigdatablockUpdate, OrigDatablock);
-    } else if (
-      user.currentGroups.some((g) =>
-        this.accessGroups?.createDatasetWithPid.includes(g),
-      ) ||
-      this.accessGroups?.createDatasetWithPid.includes("#all")
-    ) {
-      /**
+        can(Action.OrigdatablockRead, OrigDatablock);
+        can(Action.OrigdatablockCreate, OrigDatablock);
+        can(Action.OrigdatablockUpdate, OrigDatablock);
+      } else if (
+        user.currentGroups.some((g) =>
+          this.accessGroups?.createDatasetWithPid.includes(g),
+        ) ||
+        this.accessGroups?.createDatasetWithPid.includes("#all")
+      ) {
+        /**
       /*  users belonging to CREATE_DATASET_WITH_PID_GROUPS
       **/
 
-      can(Action.OrigdatablockRead, OrigDatablock);
-      can(Action.OrigdatablockCreate, OrigDatablock);
-      can(Action.OrigdatablockUpdate, OrigDatablock);
-    } else if (
-      user.currentGroups.some((g) =>
-        this.accessGroups?.createDataset.includes(g),
-      ) ||
-      this.accessGroups?.createDataset.includes("#all")
-    ) {
-      /**
+        can(Action.OrigdatablockRead, OrigDatablock);
+        can(Action.OrigdatablockCreate, OrigDatablock);
+        can(Action.OrigdatablockUpdate, OrigDatablock);
+      } else if (
+        user.currentGroups.some((g) =>
+          this.accessGroups?.createDataset.includes(g),
+        ) ||
+        this.accessGroups?.createDataset.includes("#all")
+      ) {
+        /**
       /*  users belonging to CREATE_DATASET_GROUPS
       **/
 
-      can(Action.OrigdatablockRead, OrigDatablock);
-      can(Action.OrigdatablockCreate, OrigDatablock);
-      can(Action.OrigdatablockUpdate, OrigDatablock);
-    } else if (user) {
-      /**
+        can(Action.OrigdatablockRead, OrigDatablock);
+        can(Action.OrigdatablockCreate, OrigDatablock);
+        can(Action.OrigdatablockUpdate, OrigDatablock);
+      } else if (user) {
+        /**
       /*  authenticated users
       **/
 
-      can(Action.OrigdatablockRead, OrigDatablock);
-      cannot(Action.OrigdatablockCreate, OrigDatablock);
-      cannot(Action.OrigdatablockUpdate, OrigDatablock);
+        can(Action.OrigdatablockRead, OrigDatablock);
+        cannot(Action.OrigdatablockCreate, OrigDatablock);
+        cannot(Action.OrigdatablockUpdate, OrigDatablock);
+      }
     }
     return build({
       detectSubjectType: (item) =>
@@ -1192,11 +1203,11 @@ export class CaslAbilityFactory {
       /*  unauthenticated users
       **/
 
-      can(Action.OrigdatablockReadManyPublic, SampleClass);
-      can(Action.OrigdatablockReadOnePublic, SampleClass, {
+      can(Action.OrigdatablockReadManyPublic, OrigDatablock);
+      can(Action.OrigdatablockReadOnePublic, OrigDatablock, {
         isPublished: true,
       });
-      can(Action.DatasetOrigdatablockReadPublic, SampleClass, {
+      can(Action.DatasetOrigdatablockReadPublic, OrigDatablock, {
         isPublished: true,
       });
     } else {

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -125,7 +125,7 @@ export class CaslAbilityFactory {
       cannot(Action.DatasetAttachmentDelete, DatasetClass);
       // -
       cannot(Action.DatasetOrigdatablockCreate, DatasetClass);
-      cannot(Action.DatasetOrigdatablockRead, DatasetClass);
+      can(Action.DatasetOrigdatablockRead, DatasetClass);
       cannot(Action.DatasetOrigdatablockUpdate, DatasetClass);
       // -
       cannot(Action.DatasetDatablockCreate, DatasetClass);

--- a/test/DatasetAuthorization.js
+++ b/test/DatasetAuthorization.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 "use strict";
 
 const utils = require("./LoginUtils");
@@ -560,6 +559,25 @@ describe("0300: DatasetAuthorization: Test access to dataset", () => {
       .then((res) => {
         res.body.should.be.an("array").to.have.lengthOf(1);
       });
+  });
+
+  it("0375: access public dataset origdatablocks as unauthenticated user", async () => {
+    return request(appUrl)
+      .get("/api/v3/Datasets/" + encodedDatasetPid1 + "/origdatablocks")
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(TestData.SuccessfulGetStatusCode)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(1);
+      });
+  });
+
+  it("0376: access dataset 3 origdatablocks as unauthenticated user, which should fail as forbidden", async () => {
+    return request(appUrl)
+      .get("/api/v3/Datasets/" + encodedDatasetPid3 + "/origdatablocks")
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(TestData.AccessForbiddenStatusCode);
   });
 
   it("0380: access dataset 1 datablocks as User 3", async () => {


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This PR fixes an issue where unauthenticated users could not read public originaldatablocks from the `dataset/:id/originaldatablock` endpoint.

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
