### PR TITLE
fix: improve validate action validation

### DIFF
--- a/src/config/job-config/actions/validateaction/validateaction.service.ts
+++ b/src/config/job-config/actions/validateaction/validateaction.service.ts
@@ -5,7 +5,10 @@ import {
   JobDto,
 } from "../../jobconfig.interface";
 import { ValidateCreateJobAction, ValidateJobAction } from "./validateaction";
-import { isValidateJobActionOptions } from "./validateaction.interface";
+import {
+  isValidateCreateJobActionOptions,
+  isValidateJobActionOptions,
+} from "./validateaction.interface";
 import { DatasetsService } from "src/datasets/datasets.service";
 import { CreateJobDto } from "src/jobs/dto/create-job.dto";
 import { ModuleRef } from "@nestjs/core";
@@ -17,7 +20,7 @@ export class ValidateJobActionCreator implements JobActionCreator<JobDto> {
   public create<Options extends JobActionOptions>(options: Options) {
     if (!isValidateJobActionOptions(options)) {
       throw new Error(
-        `Invalid options for ValidateJobAction: ${JSON.stringify(options)}`,
+        `Invalid options for validate action: ${JSON.stringify(options)}`,
       );
     }
     return new ValidateJobAction(options);
@@ -32,8 +35,10 @@ export class ValidateCreateJobActionCreator
   constructor(private moduleRef: ModuleRef) {}
 
   public create<Options extends JobActionOptions>(options: Options) {
-    if (!isValidateJobActionOptions(options)) {
-      throw new Error("Invalid options for ValidateJobAction.");
+    if (!isValidateCreateJobActionOptions(options)) {
+      throw new Error(
+        "Invalid options for validate action: ${JSON.stringify(options)}",
+      );
     }
     return new ValidateCreateJobAction(this.moduleRef, options);
   }


### PR DESCRIPTION
## Description
Improve the error message when you misconfigure a 'validate' action in a create job.

## Motivation
We ran into this error with a buggy jobConfig.yaml and had trouble tracking it back. This improves the error message.

It also uses `isValidateCreateJobActionOptions` correctly in create jobs. This doesn't actually have an impact, since we don't currently throw errors for extra fields in action configuration (maybe this is a bug?). This means that `isValidateCreateJobActionOptions` and `isValidateJobActionOptions` accept the same objects (all added fields are optional), which is why this "bug" wasn't picked up in testing.

## Fixes
(no issue filed)

## Changes:

## Tests included

- [ ] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes) - N/A
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
