### PR TITLE
fix: permission for ownerUser to read jobs

### DIFF
--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -1454,7 +1454,7 @@ export class CaslAbilityFactory {
 
           can(Action.JobCreateOwner, JobClass, {
             ownerGroup: { $in: user.currentGroups },
-          });       
+          });
         } else {
           /**
            * authenticated users not belonging to any special group
@@ -1470,7 +1470,6 @@ export class CaslAbilityFactory {
               String(v).includes("#dataset"),
             ),
           ];
-   
 
           if (
             jobCreateInstanceAuthorizationValues.some(

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -1437,6 +1437,12 @@ export class CaslAbilityFactory {
           ...user.currentGroups.map((g) => "@" + g),
           user.username,
         ];
+        can(Action.JobReadAccess, JobClass, {
+          ownerGroup: { $in: user.currentGroups },
+        });
+        can(Action.JobReadAccess, JobClass, {
+          ownerUser: user.username,
+        });
         if (
           user.currentGroups.some((g) =>
             this.accessGroups?.createJob.includes(g),
@@ -1448,10 +1454,7 @@ export class CaslAbilityFactory {
 
           can(Action.JobCreateOwner, JobClass, {
             ownerGroup: { $in: user.currentGroups },
-          });
-          can(Action.JobReadAccess, JobClass, {
-            ownerGroup: { $in: user.currentGroups },
-          });
+          });       
         } else {
           /**
            * authenticated users not belonging to any special group
@@ -1467,11 +1470,8 @@ export class CaslAbilityFactory {
               String(v).includes("#dataset"),
             ),
           ];
+   
 
-          can(Action.JobReadAccess, JobClass, {
-            ownerGroup: { $in: user.currentGroups },
-            ownerUser: user.username,
-          });
           if (
             jobCreateInstanceAuthorizationValues.some(
               (a) => jobConfiguration.create.auth === a,

--- a/test/JobsAll.js
+++ b/test/JobsAll.js
@@ -9,6 +9,8 @@ let accessTokenAdminIngestor = null,
   accessTokenAdmin = null,
   accessTokenArchiveManager = null;
 
+let adminEmail = null;
+
 let datasetPid1 = null,
   datasetPid2 = null,
 
@@ -78,6 +80,11 @@ describe("1120: Jobs: Test New Job Model Authorization for #all jobs", () => {
     });
 
     accessTokenAdmin = await utils.getToken(appUrl, {
+      username: "admin",
+      password: TestData.Accounts["admin"]["password"],
+    });
+
+    adminEmail = await utils.getEmail(appUrl, {
       username: "admin",
       password: TestData.Accounts["admin"]["password"],
     });
@@ -231,7 +238,7 @@ describe("1120: Jobs: Test New Job Model Authorization for #all jobs", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("contactEmail").and.be.equal("admin@scicat.project");
+        res.body.should.have.property("contactEmail").and.be.equal(adminEmail);
         res.body.should.have.property("statusCode").to.be.equal("jobCreated");
       });
   });
@@ -319,7 +326,7 @@ describe("1120: Jobs: Test New Job Model Authorization for #all jobs", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("contactEmail").to.be.equal("admin@scicat.project");
+        res.body.should.have.property("contactEmail").to.be.equal(adminEmail);
         res.body.should.have.property("statusCode").to.be.equal("jobCreated");
         jobId3 = res.body["id"];
         encodedJobOwnedByGroup1 = encodeURIComponent(jobId3);
@@ -1082,7 +1089,7 @@ describe("1120: Jobs: Test New Job Model Authorization for #all jobs", () => {
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(0);
+        res.body.should.be.an("array").to.have.lengthOf(2);
       });
   });
 
@@ -1173,7 +1180,7 @@ describe("1120: Jobs: Test New Job Model Authorization for #all jobs", () => {
     return request(appUrl)
       .get(`/api/v3/Jobs/${encodedJobOwnedByGroup1}`)
       .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {

--- a/test/JobsAll.js
+++ b/test/JobsAll.js
@@ -59,40 +59,42 @@ describe("1120: Jobs: Test New Job Model Authorization for #all jobs", () => {
   });
 
   beforeEach(async () => {
-    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+    const loginResponseAdminIngestor = await utils.getTokenAndEmail(appUrl, {
       username: "adminIngestor",
       password: TestData.Accounts["adminIngestor"]["password"],
     });
+    accessTokenAdminIngestor = loginResponseAdminIngestor.token;
 
-    accessTokenUser1 = await utils.getToken(appUrl, {
+    const loginResponseUser1 = await utils.getTokenAndEmail(appUrl, {
       username: "user1",
       password: TestData.Accounts["user1"]["password"],
     });
+    accessTokenUser1 = loginResponseUser1.token;
 
-    accessTokenUser51 = await utils.getToken(appUrl, {
+    const loginResponseUser51 = await utils.getTokenAndEmail(appUrl, {
       username: "user5.1",
       password: TestData.Accounts["user5.1"]["password"],
     });
+    accessTokenUser51 = loginResponseUser51.token;
 
-    accessTokenUser52 = await utils.getToken(appUrl, {
+    const loginResponseUser52 = await utils.getTokenAndEmail(appUrl, {
       username: "user5.2",
       password: TestData.Accounts["user5.2"]["password"],
     });
-
-    accessTokenAdmin = await utils.getToken(appUrl, {
+    accessTokenUser52 = loginResponseUser52.token;
+    
+    const loginResponseAdmin = await utils.getTokenAndEmail(appUrl, {
       username: "admin",
       password: TestData.Accounts["admin"]["password"],
     });
+    accessTokenAdmin = loginResponseAdmin.token;
+    adminEmail = loginResponseAdmin.userEmail;
 
-    adminEmail = await utils.getEmail(appUrl, {
-      username: "admin",
-      password: TestData.Accounts["admin"]["password"],
-    });
-
-    accessTokenArchiveManager = await utils.getToken(appUrl, {
+    const loginResponseArchiveManager = await utils.getTokenAndEmail(appUrl, {
       username: "archiveManager",
       password: TestData.Accounts["archiveManager"]["password"],
     });
+    accessTokenArchiveManager = loginResponseArchiveManager.token;
   });
 
   after(() => { 

--- a/test/JobsDatasetOwner.js
+++ b/test/JobsDatasetOwner.js
@@ -25,12 +25,11 @@ let datasetPid1 = null,
   encodedJobOwnedByGroup5 = null,
   jobId6 = null,
   encodedJobOwnedByAnonym = null;
-  encodedJobOwnedByGroup13 = null;
-  encodedJobOwnedByGroup12 = null;
-  encodedJobOwnedByGroup11 = null;
+  jobId7 = null,
+  jobId8 = null,
+  jobId12 = null;
+  jobId21 = null;
   jobId31 = null;
-  jobId32 = null;
-  jobId33 = null;
 
 
 const dataset1 = {
@@ -357,6 +356,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
         res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        jobId7 = res.body["id"];
       });
   });
 
@@ -385,6 +385,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
         res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        jobId8 = res.body["id"];
       });
   });
 
@@ -466,8 +467,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
         res.body.should.have.property("ownerUser").and.be.equal("user1");
         res.body.should.have.property("ownerGroup").and.be.equal("group2");
         res.body.should.have.property("statusCode").to.be.equal("jobCreated");
-        jobId31 = res.body["id"];
-        encodedJobOwnedByGroup11 = encodeURIComponent(jobId31);
+        jobId12 = res.body["id"];
       });
   });
 
@@ -495,8 +495,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
         res.body.should.have.property("ownerUser").and.be.equal("user2");
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("statusCode").to.be.equal("jobCreated");
-        jobId32 = res.body["id"];
-        encodedJobOwnedByGroup12 = encodeURIComponent(jobId32);
+        jobId21 = res.body["id"];
       });
   });
 
@@ -525,8 +524,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
         res.body.should.have.property("ownerUser").and.be.equal("user3");
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("statusCode").to.be.equal("jobCreated");
-        jobId33 = res.body["id"];
-        encodedJobOwnedByGroup13 = encodeURIComponent(jobId33);
+        jobId31 = res.body["id"];
       });
   });
 
@@ -735,6 +733,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.be.an("array").to.have.lengthOf(7);
+        res.body.map(job => job.id).should.include.members([jobId2, jobId3, jobId12, jobId31, jobId21, jobId7, jobId8]);
       });
   });
   it("0330: Access jobs as user2 ", async () => {
@@ -747,6 +746,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.be.an("array").to.have.lengthOf(2);
+        res.body.map(job => job.id).should.include.members([jobId12, jobId21]);
       });
   });
   it("0340: Access jobs as user3", async () => {
@@ -759,6 +759,20 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.be.an("array").to.have.lengthOf(1);
+        res.body.map(job => job.id).should.include.members([jobId31]);
+      });
+  });
+  it("0340: Access jobs as user5", async () => {
+    return request(appUrl)
+      .get(`/api/v3/Jobs/`)
+      .send({})
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser51}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(2);
+        res.body.map(job => job.id).should.include.members([jobId4, jobId5]);
       });
   });
 });

--- a/test/JobsDatasetOwner.js
+++ b/test/JobsDatasetOwner.js
@@ -4,6 +4,8 @@ const { TestData } = require("./TestData");
 
 let accessTokenAdminIngestor = null,
   accessTokenUser1 = null,
+  accessTokenUser2 = null,
+  accessTokenUser3 = null,
   accessTokenUser51 = null,
   accessTokenAdmin = null;
 
@@ -23,6 +25,13 @@ let datasetPid1 = null,
   encodedJobOwnedByGroup5 = null,
   jobId6 = null,
   encodedJobOwnedByAnonym = null;
+  encodedJobOwnedByGroup13 = null;
+  encodedJobOwnedByGroup12 = null;
+  encodedJobOwnedByGroup11 = null;
+  jobId31 = null;
+  jobId32 = null;
+  jobId33 = null;
+
 
 const dataset1 = {
   ...TestData.RawCorrect,
@@ -64,6 +73,16 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
     accessTokenUser1 = await utils.getToken(appUrl, {
       username: "user1",
       password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenUser2 = await utils.getToken(appUrl, {
+      username: "user2",
+      password: TestData.Accounts["user2"]["password"],
+    }); 
+
+    accessTokenUser3 = await utils.getToken(appUrl, {
+      username: "user3",
+      password: TestData.Accounts["user3"]["password"],
     });
 
     accessTokenUser51 = await utils.getToken(appUrl, {
@@ -423,7 +442,95 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       });
   });
 
-  it("0140: Adds a status update to a job as a user from ADMIN_GROUPS for his/her job in '#jobOwnerUser' configuration", async () => {
+  it("0140: Add a new job as a user from ADMIN_GROUPS for group2 and user1 in '#datasetOwner' configuration", async () => {
+    const newJob = {
+      ...jobDatasetOwner,
+      ownerUser: "user1",
+      ownerGroup: "group2",
+      jobParams: {
+        datasetList: [
+          { pid: datasetPid2, files: [] },
+        ],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("type").and.be.string;
+        res.body.should.have.property("ownerUser").and.be.equal("user1");
+        res.body.should.have.property("ownerGroup").and.be.equal("group2");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        jobId31 = res.body["id"];
+        encodedJobOwnedByGroup11 = encodeURIComponent(jobId31);
+      });
+  });
+
+  it("0150: Add a new job as a user from ADMIN_GROUPS for group1 and user2 in '#datasetOwner' configuration", async () => {
+    const newJob = {
+      ...jobDatasetOwner,
+      ownerUser: "user2",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [
+          { pid: datasetPid2, files: [] },
+        ],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("type").and.be.string;
+        res.body.should.have.property("ownerUser").and.be.equal("user2");
+        res.body.should.have.property("ownerGroup").and.be.equal("group1");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        jobId32 = res.body["id"];
+        encodedJobOwnedByGroup12 = encodeURIComponent(jobId32);
+      });
+  });
+
+  it("0160: Add a new job as a user from ADMIN_GROUPS for group1 and user3 in '#datasetOwner' configuration", async () => {
+    const newJob = {
+      ...jobDatasetOwner,
+      ownerUser: "user3",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [
+          { pid: datasetPid1, files: [] },
+          { pid: datasetPid3, files: [] },
+        ],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("type").and.be.string;
+        res.body.should.have.property("ownerUser").and.be.equal("user3");
+        res.body.should.have.property("ownerGroup").and.be.equal("group1");
+        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        jobId33 = res.body["id"];
+        encodedJobOwnedByGroup13 = encodeURIComponent(jobId33);
+      });
+  });
+
+  it("0170: Adds a status update to a job as a user from ADMIN_GROUPS for his/her job in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByAdmin}`)
       .send({
@@ -436,7 +543,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0150: Adds a Status update to a job as a user from ADMIN_GROUPS for another group's job in '#jobOwnerUser' configuration", async () => {
+  it("0180: Adds a Status update to a job as a user from ADMIN_GROUPS for another group's job in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -449,7 +556,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0160: Adds a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#jobOwnerUser' configuration", async () => {
+  it("0190: Adds a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -462,7 +569,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0170: Adds a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#jobOwnerUser' configuration", async () => {
+  it("0200: Adds a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -475,7 +582,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0180: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in '#jobOwnerUser' configuration", async () => {
+  it("0210: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -488,7 +595,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0190: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0220: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -501,7 +608,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0200: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in '#jobOwnerUser' configuration", async () => {
+  it("0230: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -514,7 +621,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0210: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0240: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -527,7 +634,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0220: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0250: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -540,7 +647,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0230: Adds a Status update to a job as a normal user  for his/her job in '#jobOwnerUser' configuration", async () => {
+  it("0260: Adds a Status update to a job as a normal user  for his/her job in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -553,7 +660,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0240: Adds a Status update to a job as a normal user for another user's job in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0270: Adds a Status update to a job as a normal user for another user's job in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -566,7 +673,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0250: Adds a Status update to a job as a normal user for his/her group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0280: Adds a Status update to a job as a normal user for his/her group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -579,7 +686,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0260: Adds a Status update to a job as a normal user for another user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0290: Adds a Status update to a job as a normal user for another user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -592,7 +699,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0270: Adds a Status update to a job as a normal user for anonymous user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0300: Adds a Status update to a job as a normal user for anonymous user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -605,7 +712,7 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
-  it("0280: Adds a Status update to a job as unauthenticated user for anonymous user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0310: Adds a Status update to a job as unauthenticated user for anonymous user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v3/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -617,4 +724,41 @@ describe("1150: Jobs: Test New Job Model Authorization for #datasetOwner jobs co
       .expect("Content-Type", /json/);
   });
 
+
+  it("0320: Access jobs as a User1 ", async () => {
+    return request(appUrl)
+      .get(`/api/v3/Jobs/`)
+      .send({})
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(7);
+      });
+  });
+  it("0330: Access jobs as user2 ", async () => {
+    return request(appUrl)
+      .get(`/api/v3/Jobs/`)
+      .send({})
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser2}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(2);
+      });
+  });
+  it("0340: Access jobs as user3", async () => {
+    return request(appUrl)
+      .get(`/api/v3/Jobs/`)
+      .send({})
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser3}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(1);
+      });
+  });
 });

--- a/test/JobsSpecificGroup.js
+++ b/test/JobsSpecificGroup.js
@@ -760,15 +760,15 @@ describe("1170: Jobs: Test New Job Model Authorization for configuration set to 
       });
   });
 
-  it("0360: Get job of another user in his/her group as normal user, which should be forbidden", async () => {
+  it("0360: Get job of another user in his/her group as normal user", async () => {
     return request(appUrl)
         .get(`/api/v3/Jobs/${encodedJobOwnedByUser52}`)
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
-        .expect(TestData.AccessForbiddenStatusCode)
+        .expect(TestData.SuccessfulGetStatusCode)
         .expect("Content-Type", /json/)
         .then((res) => {
-          res.body.should.not.have.property("ownerUser");
+          res.body.should.have.property("ownerUser").and.be.equal("user5.2");
         });
   });
 
@@ -777,10 +777,10 @@ describe("1170: Jobs: Test New Job Model Authorization for configuration set to 
         .get(`/api/v3/Jobs/${encodedJobOwnedByGroup5}`)
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser51}` })
-        .expect(TestData.AccessForbiddenStatusCode)
+        .expect(TestData.SuccessfulGetStatusCode)
         .expect("Content-Type", /json/)
         .then((res) => {
-          res.body.should.not.have.property("ownerUser");
+          res.body.should.have.property("ownerGroup").and.be.equal("group5");
         });
   });
 
@@ -799,7 +799,7 @@ describe("1170: Jobs: Test New Job Model Authorization for configuration set to 
       });
   });
 
-  it("0390: Fullquery jobs as another normal user (user5.2)", async () => { // 0760
+  it("0390: Fullquery jobs as another normal user (user5.2)", async () => {
     return request(appUrl)
       .get(`/api/v3/Jobs/fullquery`)
       .send({})
@@ -808,7 +808,7 @@ describe("1170: Jobs: Test New Job Model Authorization for configuration set to 
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").to.have.lengthOf(1);
+        res.body.should.be.an("array").to.have.lengthOf(4);
       });
   });
 
@@ -850,7 +850,7 @@ describe("1170: Jobs: Test New Job Model Authorization for configuration set to 
       .expect(TestData.SuccessfulGetStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 1 }] });
+        res.body.should.be.an("array").that.deep.contains({ all: [{ totalSets: 4 }] });
       });
   });
 });

--- a/test/LoginUtils.js
+++ b/test/LoginUtils.js
@@ -47,8 +47,7 @@ exports.getTokenAD = function (appUrl, user, cb) {
     });
 };
 
-
-exports.getEmail = function (appUrl, user) {
+exports.getTokenAndEmail = function (appUrl, user) {
   return new Promise((resolve, reject) => {
     request(appUrl)
       .post("/api/v3/auth/Login?include=user")
@@ -58,7 +57,7 @@ exports.getEmail = function (appUrl, user) {
         if (err) {
           reject(err);
         } else {
-          resolve(res.body.user.email);
+          resolve({token: res.body.id, userEmail: res.body.user.email});
         }
       });
   });

--- a/test/LoginUtils.js
+++ b/test/LoginUtils.js
@@ -46,3 +46,20 @@ exports.getTokenAD = function (appUrl, user, cb) {
       }
     });
 };
+
+
+exports.getEmail = function (appUrl, user) {
+  return new Promise((resolve, reject) => {
+    request(appUrl)
+      .post("/api/v3/auth/Login?include=user")
+      .send(user)
+      .set("Accept", "application/json")
+      .end((err, res) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(res.body.user.email);
+        }
+      });
+  });
+};


### PR DESCRIPTION


<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
As the DTO enables user to provide both ownerUser and OwnerGroup, anyone who falls under the specified fields should be able to read the job.
## Motivation
Owner user was not getting access, only the ownerGroup.
## Fixes
Casl was fixed and explicitly allows for a user specified in ownerUser to access the job and for a group specified in ownerGroup to get access to the job.



## Changes:
Tests are added to check this rules.
Test utils introduced new function to get an email of the user, which is used to compare in the contactEmail field in certain tests. 
## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [x] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
