### PR TITLE
fix: use one login function in tests and minor changes to test names

### DIFF
--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -94,7 +94,7 @@ describe("1110: Jobs: Test New Job Model: possible real configurations", () => {
     db.collection("Job").deleteMany({});
   });
 
-  it("0010: adds dataset 1 as Admin Ingestor", async () => {
+  it("0010: Add dataset 1 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset1)
@@ -111,7 +111,7 @@ describe("1110: Jobs: Test New Job Model: possible real configurations", () => {
       });
   });
 
-  it("0020: adds dataset 2 as Admin Ingestor", async () => {
+  it("0020: Add dataset 2 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset2)
@@ -128,7 +128,7 @@ describe("1110: Jobs: Test New Job Model: possible real configurations", () => {
       });
   });
 
-  it("0030: adds dataset 3 as Admin Ingestor", async () => {
+  it("0030: Add dataset 3 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset3)

--- a/test/JobsAll.js
+++ b/test/JobsAll.js
@@ -102,7 +102,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
     db.collection("Job").deleteMany({});
   });
 
-  it("0010: adds dataset 1 as Admin Ingestor", async () => {
+  it("0010: Add dataset 1 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset1)
@@ -119,7 +119,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       });
   });
 
-  it("0020: adds dataset 2 as Admin Ingestor", async () => {
+  it("0020: Add dataset 2 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset2)
@@ -136,7 +136,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       });
   });
 
-  it("0030: adds dataset 3 as Admin Ingestor", async () => {
+  it("0030: Add dataset 3 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset3)
@@ -644,7 +644,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       });
   });
 
-  it("0220: Adds a new job as unauthenticated user in '#all' configuration", async () => {
+  it("0220: Add a new job as unauthenticated user in '#all' configuration", async () => {
     const newJob = {
       ...jobAll,
       jobParams: {
@@ -668,7 +668,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       });
   });
 
-  it("0230: Adds a new job as unauthenticated user for another user in '#all' configuration, which should fail as bad request", async () => {
+  it("0230: Add a new job as unauthenticated user for another user in '#all' configuration, which should fail as bad request", async () => {
     const newJob = {
       ...jobAll,
       ownerGroup: "group1",
@@ -691,7 +691,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       });
   });
 
-  it("0240: Adds a status update to a job as a user from ADMIN_GROUPS for his/her job in '#all' configuration", async () => {
+  it("0240: Add a status update to a job as a user from ADMIN_GROUPS for his/her job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAdmin}`)
       .send({
@@ -704,7 +704,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0250: Adds a Status update to a job as a user from ADMIN_GROUPS for another user's job in '#all' configuration", async () => {
+  it("0250: Add a Status update to a job as a user from ADMIN_GROUPS for another user's job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -717,7 +717,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0260: Adds a Status update to a job as a user from ADMIN_GROUPS for another group's job in '#all' configuration", async () => {
+  it("0260: Add a Status update to a job as a user from ADMIN_GROUPS for another group's job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -730,7 +730,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0270: Adds a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#all' configuration", async () => {
+  it("0270: Add a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -743,7 +743,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0280: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in '#all' configuration", async () => {
+  it("0280: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -756,7 +756,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0290: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in '#all' configuration", async () => {
+  it("0290: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -769,7 +769,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0300: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in '#all' configuration", async () => {
+  it("0300: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -782,7 +782,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0310: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in '#all' configuration", async () => {
+  it("0310: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -795,7 +795,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0320: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in '#all' configuration", async () => {
+  it("0320: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -808,7 +808,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0330: Adds a Status update to a job as a normal user for his/her job in '#all' configuration", async () => {
+  it("0330: Add a Status update to a job as a normal user for his/her job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -821,7 +821,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0340: Adds a Status update to a job as a normal user for another user's job in '#all' configuration", async () => {
+  it("0340: Add a Status update to a job as a normal user for another user's job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -834,7 +834,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0350: Adds a Status update to a job as a normal user for his/her group in '#all' configuration", async () => {
+  it("0350: Add a Status update to a job as a normal user for his/her group in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -847,7 +847,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0360: Adds a Status update to a job as a normal user for another user's group in '#all' configuration", async () => {
+  it("0360: Add a Status update to a job as a normal user for another user's group in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -860,7 +860,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0370: Adds a Status update to a job as a normal user for anonymous user's group in '#all' configuration", async () => {
+  it("0370: Add a Status update to a job as a normal user for anonymous user's group in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -873,7 +873,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0380: Adds a Status update to a job as unauthenticated user for anonymous job in '#all' configuration", async () => {
+  it("0380: Add a Status update to a job as unauthenticated user for anonymous job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -885,7 +885,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0390: Adds a Status update to a job as unauthenticated user for another group's job in '#all' configuration, which should fail as forbidden", async () => {
+  it("0390: Add a Status update to a job as unauthenticated user for another group's job in '#all' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -897,7 +897,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0400: Adds a Status update to a job as unauthenticated user for another user's job in '#all' configuration, which should fail as forbidden", async () => {
+  it("0400: Add a Status update to a job as unauthenticated user for another user's job in '#all' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -909,7 +909,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0410: Adds a status update to a job as a user from ADMIN_GROUPS for his/her job in '#all' configuration with non-existing jobId, which should fail as bad request", async () => {
+  it("0410: Add a status update to a job as a user from ADMIN_GROUPS for his/her job in '#all' configuration with non-existing jobId, which should fail as bad request", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/badJobId`)
       .send({
@@ -1215,7 +1215,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       });
   });
 
-  it("0640: Get admin's job as normal, which should be forbidden", async () => {
+  it("0640: Get admin's job as normal user, which should be forbidden", async () => {
     return request(appUrl)
       .get(`/api/v4/Jobs/${encodedJobOwnedByAdmin}`)
       .set("Accept", "application/json")

--- a/test/JobsAll.js
+++ b/test/JobsAll.js
@@ -704,7 +704,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0250: Add a Status update to a job as a user from ADMIN_GROUPS for another user's job in '#all' configuration", async () => {
+  it("0250: Add a status update to a job as a user from ADMIN_GROUPS for another user's job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -717,7 +717,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0260: Add a Status update to a job as a user from ADMIN_GROUPS for another group's job in '#all' configuration", async () => {
+  it("0260: Add a status update to a job as a user from ADMIN_GROUPS for another group's job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -730,7 +730,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0270: Add a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#all' configuration", async () => {
+  it("0270: Add a status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -743,7 +743,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0280: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in '#all' configuration", async () => {
+  it("0280: Add a status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -756,7 +756,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0290: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in '#all' configuration", async () => {
+  it("0290: Add a status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -769,7 +769,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0300: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in '#all' configuration", async () => {
+  it("0300: Add a status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -782,7 +782,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0310: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in '#all' configuration", async () => {
+  it("0310: Add a status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -795,7 +795,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0320: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in '#all' configuration", async () => {
+  it("0320: Add a status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -808,7 +808,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0330: Add a Status update to a job as a normal user for his/her job in '#all' configuration", async () => {
+  it("0330: Add a status update to a job as a normal user for his/her job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -821,7 +821,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0340: Add a Status update to a job as a normal user for another user's job in '#all' configuration", async () => {
+  it("0340: Add a status update to a job as a normal user for another user's job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -834,7 +834,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0350: Add a Status update to a job as a normal user for his/her group in '#all' configuration", async () => {
+  it("0350: Add a status update to a job as a normal user for his/her group in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -847,7 +847,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0360: Add a Status update to a job as a normal user for another user's group in '#all' configuration", async () => {
+  it("0360: Add a status update to a job as a normal user for another user's group in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -860,7 +860,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0370: Add a Status update to a job as a normal user for anonymous user's group in '#all' configuration", async () => {
+  it("0370: Add a status update to a job as a normal user for anonymous user's group in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -873,7 +873,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0380: Add a Status update to a job as unauthenticated user for anonymous job in '#all' configuration", async () => {
+  it("0380: Add a status update to a job as unauthenticated user for anonymous job in '#all' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -885,7 +885,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0390: Add a Status update to a job as unauthenticated user for another group's job in '#all' configuration, which should fail as forbidden", async () => {
+  it("0390: Add a status update to a job as unauthenticated user for another group's job in '#all' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -897,7 +897,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
       .expect("Content-Type", /json/);
   });
 
-  it("0400: Add a Status update to a job as unauthenticated user for another user's job in '#all' configuration, which should fail as forbidden", async () => {
+  it("0400: Add a status update to a job as unauthenticated user for another user's job in '#all' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({

--- a/test/JobsAuthenticated.js
+++ b/test/JobsAuthenticated.js
@@ -68,7 +68,7 @@ describe("1130: Jobs: Test New Job Model Authorization for authenticated_access 
     db.collection("Job").deleteMany({});
   });
 
-  it("0010: adds dataset 1 as Admin Ingestor", async () => {
+  it("0010: Add dataset 1 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset1)
@@ -85,7 +85,7 @@ describe("1130: Jobs: Test New Job Model Authorization for authenticated_access 
       });
   });
 
-  it("0020: adds dataset 2 as Admin Ingestor", async () => {
+  it("0020: Add dataset 2 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset2)
@@ -102,7 +102,7 @@ describe("1130: Jobs: Test New Job Model Authorization for authenticated_access 
       });
   });
 
-  it("0030: adds dataset 3 as Admin Ingestor", async () => {
+  it("0030: Add dataset 3 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset3)

--- a/test/JobsDatasetAccess.js
+++ b/test/JobsDatasetAccess.js
@@ -83,7 +83,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
     db.collection("Job").deleteMany({});
   });
 
-  it("0010: adds dataset 1 as Admin Ingestor", async () => {
+  it("0010: Add dataset 1 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset1)
@@ -100,7 +100,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       });
   });
 
-  it("0020: adds dataset 2 as Admin Ingestor", async () => {
+  it("0020: Add dataset 2 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset2)
@@ -117,7 +117,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       });
   });
 
-  it("0030: adds dataset 3 as Admin Ingestor", async () => {
+  it("0030: Add dataset 3 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset3)
@@ -342,7 +342,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       });
   });
 
-  it("0110: Adds a new job as user1 for user5.1 ownerUser and group5 ownerGroup for #datasetAccess, which should fail", async () => {
+  it("0110: Add a new job as user1 for user5.1 ownerUser and group5 ownerGroup for #datasetAccess, which should fail", async () => {
     const newJob = {
       ...jobDatasetAccess,
       ownerUser: "user5.1",
@@ -425,7 +425,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       });
   });
 
-  it("0140: Adds a status update to a job as a user from ADMIN_GROUPS for his/her job in '#jobOwnerGroup' configuration", async () => {
+  it("0140: Add a status update to a job as a user from ADMIN_GROUPS for his/her job in '#jobOwnerGroup' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAdmin}`)
       .send({
@@ -438,7 +438,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0150: Adds a Status update to a job as a user from ADMIN_GROUPS for another group's job in '#jobOwnerGroup' configuration", async () => {
+  it("0150: Add a Status update to a job as a user from ADMIN_GROUPS for another group's job in '#jobOwnerGroup' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -451,7 +451,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0160: Adds a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#jobOwnerGroup' configuration", async () => {
+  it("0160: Add a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#jobOwnerGroup' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -464,7 +464,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0170: Adds a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#jobOwnerGroup' configuration", async () => {
+  it("0170: Add a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#jobOwnerGroup' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -477,7 +477,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0180: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in '#jobOwnerGroup' configuration", async () => {
+  it("0180: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in '#jobOwnerGroup' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -490,7 +490,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0190: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
+  it("0190: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -503,7 +503,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0200: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in '#jobOwnerGroup' configuration", async () => {
+  it("0200: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in '#jobOwnerGroup' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -516,7 +516,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0210: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
+  it("0210: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -529,7 +529,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0220: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
+  it("0220: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -542,7 +542,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0230: Adds a Status update to a job as a normal user for his/her job in '#jobOwnerGroup' configuration", async () => {
+  it("0230: Add a Status update to a job as a normal user for his/her job in '#jobOwnerGroup' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -555,7 +555,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0240: Adds a Status update to a job as a normal user for another user's job in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
+  it("0240: Add a Status update to a job as a normal user for another user's job in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -568,7 +568,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0250: Adds a Status update to a job as a normal user for his/her group in '#jobOwnerGroup' configuration", async () => {
+  it("0250: Add a Status update to a job as a normal user for his/her group in '#jobOwnerGroup' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -581,7 +581,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0260: Adds a Status update to a job as a normal user for another user's group in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
+  it("0260: Add a Status update to a job as a normal user for another user's group in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -594,7 +594,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0270: Adds a Status update to a job as a normal user for anonymous user's group in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
+  it("0270: Add a Status update to a job as a normal user for anonymous user's group in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -607,7 +607,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
       .expect("Content-Type", /json/);
   });
 
-  it("0280: Adds a Status update to a job as unauthenticated user for anonymous user's group in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
+  it("0280: Add a Status update to a job as unauthenticated user for anonymous user's group in '#jobOwnerGroup' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({

--- a/test/JobsDatasetOwner.js
+++ b/test/JobsDatasetOwner.js
@@ -101,7 +101,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
     db.collection("Job").deleteMany({});
   });
 
-  it("0010: adds dataset 1 as Admin Ingestor", async () => {
+  it("0010: Add dataset 1 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset1)
@@ -118,7 +118,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       });
   });
 
-  it("0020: adds dataset 2 as Admin Ingestor", async () => {
+  it("0020: Add dataset 2 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset2)
@@ -135,7 +135,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       });
   });
 
-  it("0030: adds dataset 3 as Admin Ingestor", async () => {
+  it("0030: Add dataset 3 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset3)
@@ -528,7 +528,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       });
   });
 
-  it("0170: Adds a status update to a job as a user from ADMIN_GROUPS for his/her job in '#jobOwnerUser' configuration", async () => {
+  it("0170: Add a status update to a job as a user from ADMIN_GROUPS for his/her job in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAdmin}`)
       .send({
@@ -541,7 +541,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0180: Adds a Status update to a job as a user from ADMIN_GROUPS for another group's job in '#jobOwnerUser' configuration", async () => {
+  it("0180: Add a Status update to a job as a user from ADMIN_GROUPS for another group's job in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -554,7 +554,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0190: Adds a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#jobOwnerUser' configuration", async () => {
+  it("0190: Add a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -567,7 +567,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0200: Adds a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#jobOwnerUser' configuration", async () => {
+  it("0200: Add a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -580,7 +580,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0210: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in '#jobOwnerUser' configuration", async () => {
+  it("0210: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -593,7 +593,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0220: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0220: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -606,7 +606,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0230: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in '#jobOwnerUser' configuration", async () => {
+  it("0230: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -619,7 +619,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0240: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0240: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -632,7 +632,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0250: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0250: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -645,7 +645,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0260: Adds a Status update to a job as a normal user  for his/her job in '#jobOwnerUser' configuration", async () => {
+  it("0260: Add a Status update to a job as a normal user  for his/her job in '#jobOwnerUser' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -658,7 +658,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0270: Adds a Status update to a job as a normal user for another user's job in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0270: Add a Status update to a job as a normal user for another user's job in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -671,7 +671,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0280: Adds a Status update to a job as a normal user for his/her group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0280: Add a Status update to a job as a normal user for his/her group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -684,7 +684,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0290: Adds a Status update to a job as a normal user for another user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0290: Add a Status update to a job as a normal user for another user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -697,7 +697,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0300: Adds a Status update to a job as a normal user for anonymous user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0300: Add a Status update to a job as a normal user for anonymous user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -710,7 +710,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
       .expect("Content-Type", /json/);
   });
 
-  it("0310: Adds a Status update to a job as unauthenticated user for anonymous user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
+  it("0310: Add a Status update to a job as unauthenticated user for anonymous user's group in '#jobOwnerUser' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({

--- a/test/JobsDatasetPublic.js
+++ b/test/JobsDatasetPublic.js
@@ -70,7 +70,7 @@ describe("1160: Jobs: Test New Job Model Authorization for public_access jobs ty
     db.collection("Job").deleteMany({});
   });
 
-  it("0010: adds dataset 1 as Admin Ingestor", async () => {
+  it("0010: Add dataset 1 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset1)
@@ -87,7 +87,7 @@ describe("1160: Jobs: Test New Job Model Authorization for public_access jobs ty
       });
   });
 
-  it("0020: adds dataset 2 as Admin Ingestor", async () => {
+  it("0020: Add dataset 2 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset2)
@@ -104,7 +104,7 @@ describe("1160: Jobs: Test New Job Model Authorization for public_access jobs ty
       });
   });
 
-  it("0030: adds dataset 3 as Admin Ingestor", async () => {
+  it("0030: Add dataset 3 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset3)

--- a/test/JobsSpecificGroup.js
+++ b/test/JobsSpecificGroup.js
@@ -102,7 +102,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
     db.collection("Job").deleteMany({});
   });
 
-  it("0010: adds dataset 1 as Admin Ingestor", async () => {
+  it("0010: Add dataset 1 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset1)
@@ -119,7 +119,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       });
   });
 
-  it("0020: adds dataset 2 as Admin Ingestor", async () => {
+  it("0020: Add dataset 2 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset2)
@@ -136,7 +136,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       });
   });
 
-  it("0030: adds dataset 3 as Admin Ingestor", async () => {
+  it("0030: Add dataset 3 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset3)
@@ -472,7 +472,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       });
   });
 
-  it("0150: Adds a new job as user3 for himself/herself in #@group5 configuration, which should fail as forbidden", async () => {
+  it("0150: Add a new job as user3 for himself/herself in #@group5 configuration, which should fail as forbidden", async () => {
     const newJob = {
       ...jobGroup5,
       ownerUser: "user3",
@@ -498,7 +498,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       });
   });
 
-  it("0160: Adds a status update to a job as a user from ADMIN_GROUPS for his/her job in '@group5' configuration", async () => {
+  it("0160: Add a status update to a job as a user from ADMIN_GROUPS for his/her job in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAdmin}`)
       .send({
@@ -511,7 +511,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0170: Adds a Status update to a job as a user from ADMIN_GROUPS for another group's job in '@group5' configuration", async () => {
+  it("0170: Add a Status update to a job as a user from ADMIN_GROUPS for another group's job in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -524,7 +524,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0180: Adds a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '@group5' configuration", async () => {
+  it("0180: Add a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -537,7 +537,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0190: Adds a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '@group5' configuration", async () => {
+  it("0190: Add a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -550,7 +550,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0200: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in '@group5' configuration", async () => {
+  it("0200: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -563,7 +563,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0210: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in '@group5' configuration, which should fail as forbidden", async () => {
+  it("0210: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in '@group5' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -576,7 +576,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0220: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in '@group5' configuration", async () => {
+  it("0220: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -589,7 +589,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0230: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in '@group5' configuration, which should fail as forbidden", async () => {
+  it("0230: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in '@group5' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -602,7 +602,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0240: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in '@group5' configuration, which should fail as forbidden", async () => {
+  it("0240: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in '@group5' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -615,7 +615,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0250: Adds a Status update to a job as user5.1 for his/her job in '@group5' configuration", async () => {
+  it("0250: Add a Status update to a job as user5.1 for his/her job in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -628,7 +628,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0260: Adds a Status update to a job as user5.1 for another user's job in '@group5' configuration", async () => {
+  it("0260: Add a Status update to a job as user5.1 for another user's job in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -641,7 +641,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0270: Adds a Status update to a job as user5.1 for his/her group in '@group5' configuration", async () => {
+  it("0270: Add a Status update to a job as user5.1 for his/her group in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -654,7 +654,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0280: Adds a Status update to a job as user5.1 for another user's group in '@group5' configuration", async () => {
+  it("0280: Add a Status update to a job as user5.1 for another user's group in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -667,7 +667,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0290: Adds a Status update to a job as user5.1 for anonymous user's group in '@group5' configuration", async () => {
+  it("0290: Add a Status update to a job as user5.1 for anonymous user's group in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -680,7 +680,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0300: Adds a Status update to a job as user5.2 for his/her job in '@group5' configuration", async () => {
+  it("0300: Add a Status update to a job as user5.2 for his/her job in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser52}`)
       .send({
@@ -693,7 +693,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0310: Adds a Status update to a job as user5.2 for user's 5.1 in same group job in '@group5' configuration", async () => {
+  it("0310: Add a Status update to a job as user5.2 for user's 5.1 in same group job in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -706,7 +706,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0320: Adds a Status update to a job as user5.2 for another user in his/her group job in '@group5' configuration", async () => {
+  it("0320: Add a Status update to a job as user5.2 for another user in his/her group job in '@group5' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -719,7 +719,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0330: Adds a Status update to a job as user3 for his/her job in '@group5' configuration, which should fail as forbidden", async () => {
+  it("0330: Add a Status update to a job as user3 for his/her job in '@group5' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser3}`)
       .send({
@@ -732,7 +732,7 @@ describe("1170: Jobs: Test New Job Model Authorization for group_access type: co
       .expect("Content-Type", /json/);
   });
 
-  it("0340: Adds a Status update to a job as user3 for user's 5.1 job in '@group5' configuration, which should fail as forbidden", async () => {
+  it("0340: Add a Status update to a job as user3 for user's 5.1 job in '@group5' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({

--- a/test/JobsSpecificUser.js
+++ b/test/JobsSpecificUser.js
@@ -90,7 +90,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
     db.collection("Job").deleteMany({});
   });
 
-  it("0010: adds dataset 1 as Admin Ingestor", async () => {
+  it("0010: Add dataset 1 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset1)
@@ -107,7 +107,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       });
   });
 
-  it("0020: adds dataset 2 as Admin Ingestor", async () => {
+  it("0020: Add dataset 2 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset2)
@@ -124,7 +124,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       });
   });
 
-  it("0030: adds dataset 3 as Admin Ingestor", async () => {
+  it("0030: Add dataset 3 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset3)
@@ -373,7 +373,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       });
   });
 
-  it("0120: Adds a new job as user5.1 himself/herself in '#USER5.1' configuration", async () => {
+  it("0120: Add a new job as user5.1 himself/herself in '#USER5.1' configuration", async () => {
     const newJob = {
       ...jobUser51,
       ownerUser: "user5.1",
@@ -403,7 +403,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       });
   });
 
-  it("0130: Adds a new job as user5.1 for no ownerUser and group5 ownerGroup in #USER5.1 configuration", async () => {
+  it("0130: Add a new job as user5.1 for no ownerUser and group5 ownerGroup in #USER5.1 configuration", async () => {
     const newJob = {
       ...jobUser51,
       ownerGroup: "group5",
@@ -430,7 +430,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       });
   });
 
-  it("0140: Adds a new job as user5.2 for himself/herself in #USER5.1, which should fail as forbidden", async () => {
+  it("0140: Add a new job as user5.2 for himself/herself in #USER5.1, which should fail as forbidden", async () => {
     const newJob = {
       ...jobUser51,
       ownerUser: "user5.2",
@@ -456,7 +456,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       });
   });
 
-  it("0150: Adds a Status update to a job as a user from ADMIN_GROUPS for his/her job in 'USER5.1' configuration", async () => {
+  it("0150: Add a Status update to a job as a user from ADMIN_GROUPS for his/her job in 'USER5.1' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAdmin}`)
       .send({
@@ -469,7 +469,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0160: Adds a Status update to a job as a user from ADMIN_GROUPS for another group's job in 'USER5.1' configuration", async () => {
+  it("0160: Add a Status update to a job as a user from ADMIN_GROUPS for another group's job in 'USER5.1' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -482,7 +482,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0170: Adds a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in 'USER5.1' configuration", async () => {
+  it("0170: Add a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in 'USER5.1' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -495,7 +495,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0180: Adds a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in 'USER5.1' configuration", async () => {
+  it("0180: Add a Status update to a job as a user from ADMIN_GROUPS for anonymous user's job in 'USER5.1' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -508,7 +508,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0190: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in 'USER5.1' configuration", async () => {
+  it("0190: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her job in 'USER5.1' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -521,7 +521,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0200: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in 'USER5.1' configuration, which should fail as forbidden", async () => {
+  it("0200: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's job in 'USER5.1' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -534,7 +534,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0210: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in 'USER5.1' configuration", async () => {
+  it("0210: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for his/her group in 'USER5.1' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup1}`)
       .send({
@@ -547,7 +547,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0220: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in 'USER5.1' configuration, which should fail as forbidden", async () => {
+  it("0220: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for another user's group in 'USER5.1' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -560,7 +560,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0230: Adds a Status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in 'USER5.1' configuration, which should fail as forbidden", async () => {
+  it("0230: Add a Status update to a job as a user from UPDATE_JOB_GROUPS for anonymous user's group in 'USER5.1' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -573,7 +573,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0240: Adds a Status update to a job as user5.1 for his/her job in 'USER5.1' configuration", async () => {
+  it("0240: Add a Status update to a job as user5.1 for his/her job in 'USER5.1' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -586,7 +586,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0250: Adds a Status update to a job as user5.1 for another user's job in 'USER5.1' configuration", async () => {
+  it("0250: Add a Status update to a job as user5.1 for another user's job in 'USER5.1' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser1}`)
       .send({
@@ -599,7 +599,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0260: Adds a Status update to a job as user5.1 for his/her group in 'USER5.1' configuration", async () => {
+  it("0260: Add a Status update to a job as user5.1 for his/her group in 'USER5.1' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({
@@ -612,7 +612,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0270: Adds a Status update to a job as user5.1 for another user's group in 'USER5.1' configuration", async () => {
+  it("0270: Add a Status update to a job as user5.1 for another user's group in 'USER5.1' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -625,7 +625,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0280: Adds a Status update to a job as user5.1 for anonymous user's group in 'USER5.1' configuration", async () => {
+  it("0280: Add a Status update to a job as user5.1 for anonymous user's group in 'USER5.1' configuration", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByAnonym}`)
       .send({
@@ -638,7 +638,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0290: Adds a Status update to a job as user5.2 for his/her job in 'USER5.1' configuration, which should fail as forbidden", async () => {
+  it("0290: Add a Status update to a job as user5.2 for his/her job in 'USER5.1' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser52}`)
       .send({
@@ -651,7 +651,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0300: Adds a Status update to a job as user5.2 for user's 5.1 in same group job in 'USER5.1' configuration, which should fail as forbidden", async () => {
+  it("0300: Add a Status update to a job as user5.2 for user's 5.1 in same group job in 'USER5.1' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByUser51}`)
       .send({
@@ -664,7 +664,7 @@ describe("1180: Jobs: Test New Job Model Authorization for user_access type: con
       .expect("Content-Type", /json/);
   });
 
-  it("0310: Adds a Status update to a job as user5.2 for another user in his/her group job in 'USER5.1' configuration, which should fail as forbidden", async () => {
+  it("0310: Add a Status update to a job as user5.2 for another user in his/her group job in 'USER5.1' configuration, which should fail as forbidden", async () => {
     return request(appUrl)
       .patch(`/api/v4/Jobs/${encodedJobOwnedByGroup5}`)
       .send({

--- a/test/LoginUtils.js
+++ b/test/LoginUtils.js
@@ -1,36 +1,35 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 var request = require("supertest");
 
-exports.getToken = function (appUrl, user) {
+function loginWithPassword(appUrl, user) {
   return new Promise((resolve, reject) => {
     request(appUrl)
-      .post("/api/v3/auth/Login?include=user")
+      .post("/api/v3/auth/Login")
       .send(user)
       .set("Accept", "application/json")
       .end((err, res) => {
         if (err) {
           reject(err);
         } else {
-          resolve(res.body.id);
+          resolve(res.body);
         }
       });
   });
 };
 
-exports.getIdAndToken = function (appUrl, user) {
-  return new Promise((resolve, reject) => {
-    request(appUrl)
-      .post("/api/v3/auth/Login?include=user")
-      .send(user)
-      .set("Accept", "application/json")
-      .end((err, res) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve({ userId: res.body.userId, token: res.body.id });
-        }
-      });
-  });
+exports.getToken = async function (appUrl, user) {  
+  const responseBody = await loginWithPassword(appUrl, user);
+  return responseBody.id;
+};
+
+exports.getIdAndToken = async function (appUrl, user) {
+  const responseBody = await loginWithPassword(appUrl, user);
+  return { userId: responseBody.userId, token: responseBody.id }
+};
+
+exports.getTokenAndEmail = async function (appUrl, user) {
+  const responseBody = await loginWithPassword(appUrl, user);
+  return { token: responseBody.id, userEmail: responseBody.user.email}
 };
 
 exports.getTokenAD = function (appUrl, user, cb) {
@@ -45,20 +44,4 @@ exports.getTokenAD = function (appUrl, user, cb) {
         cb(res.body.access_token);
       }
     });
-};
-
-exports.getTokenAndEmail = function (appUrl, user) {
-  return new Promise((resolve, reject) => {
-    request(appUrl)
-      .post("/api/v3/auth/Login?include=user")
-      .send(user)
-      .set("Accept", "application/json")
-      .end((err, res) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve({token: res.body.id, userEmail: res.body.user.email});
-        }
-      });
-  });
 };


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Adresses issue #1779 and creates a one function for logging in with username and password that returns a whole response body. Other functions extract required information from it. 

## Motivation
<!-- Background on use case, changes needed -->
We had three very similar functions

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
