### PR TITLE
fix: use limit after skip for mongodb aggregate

### DIFF
--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -147,9 +147,9 @@ export class DatasetsService {
       pipeline.push({ $sort: sort });
     }
 
-    pipeline.push({ $limit: limits.limit || 10 });
-
     pipeline.push({ $skip: limits.skip || 0 });
+
+    pipeline.push({ $limit: limits.limit || 10 });
 
     this.addLookupFields(pipeline, filter.include);
 

--- a/test/DatasetV4.js
+++ b/test/DatasetV4.js
@@ -412,7 +412,7 @@ describe("2500: Datasets v4 tests", () => {
         .expect("Content-Type", /json/)
         .then((res) => {
           res.body.should.be.a("array");
-          res.body.should.have.length(0);
+          res.body.should.have.length(1);
 
           JSON.stringify(responseBody).should.not.be.equal(
             JSON.stringify(res.body),

--- a/test/DatasetV4Public.js
+++ b/test/DatasetV4Public.js
@@ -141,7 +141,7 @@ describe("2600: Datasets v4 public endpoints tests", () => {
         .expect("Content-Type", /json/)
         .then((res) => {
           res.body.should.be.a("array");
-          res.body.should.have.length(0);
+          res.body.should.have.length(1);
 
           JSON.stringify(responseBody).should.not.be.equal(
             JSON.stringify(res.body),

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -553,7 +553,7 @@ const TestData = {
       "https://gitlab.psi.ch/ANALYSIS/csaxs/commit/7d5888bfffc440bb613bc7fa50adc0097853446c",
     ],
     jobParameters: {
-      nscans: 10,
+      nscans: 11,
     },
     jobLogData: "Output of log file...",
     owner: "Egon Meier",
@@ -583,7 +583,7 @@ const TestData = {
       "https://gitlab.psi.ch/ANALYSIS/csaxs/commit/7d5888bfffc440bb613bc7fa50adc0097853446c",
     ],
     jobParameters: {
-      nscans: 10,
+      nscans: 12,
     },
     jobLogData: "Output of log file...",
     owner: "Egon Meier",
@@ -609,7 +609,7 @@ const TestData = {
   DerivedWrong: {
     investigator: "egon.meier@web.de",
     jobParameters: {
-      nscans: 10,
+      nscans: 13,
     },
     jobLogData: "Output of log file...",
     owner: "Egon Meier",
@@ -673,7 +673,7 @@ const TestData = {
     creationTime: "2017-01-31T09:20:19.562Z",
     keywords: ["Test", "Derived", "Science", "Math"],
     description: "Some fancy description",
-    datasetName: "Test derived dataset",
+    datasetName: "Test custom dataset",
     isPublished: false,
     ownerGroup: "p34123",
     accessGroups: [],


### PR DESCRIPTION
## Description
Limit needs to be after skip for MongoDb aggregate.

## Motivation
With limit before skip it doesn't work as intended. Say you use limit: 10 and skip:10, then you would always get an empty result back because the skip is done after limit.

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
