### PR TITLE
fix: remove rabbitmq from test jobconfig

### DIFF
--- a/test/config/jobconfig.yaml
+++ b/test/config/jobconfig.yaml
@@ -104,13 +104,3 @@ jobs:
                       type: array
                       items:
                         type: string
-  - jobType: rabbitmq
-    create:
-      auth: "#all"
-      actions:
-        - actionType: rabbitmq
-          queue: testQueue
-          exchange: testExchange
-          key: testKey
-    update:
-      auth: "#all"


### PR DESCRIPTION
## Description
<!-- Short description of the pull request -->
Running the mocha tests fails if rabbitmq isn't available.
RabbitMQ is tested from unit tests not mocha, so we can just remove it from the test jobconfig file.

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Remove RabbitMQ dependency from mocha tests

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
