### PR TITLE
fix: elasticsearch throws a 500 error when injecting a key-value pair into the scientific metadata field

### DIFF
--- a/src/elastic-search/configuration/datasetFieldMapping.ts
+++ b/src/elastic-search/configuration/datasetFieldMapping.ts
@@ -92,4 +92,22 @@ export const datasetMappings: MappingObject = {
   size: {
     type: "long",
   },
+  runNumber: {
+    type: "keyword",
+    ignore_above: 256,
+  },
+  // NOTE: below fields are for backward compatibility
+  // and should be removed when obsolete dto is removed
+  proposalId: {
+    type: "keyword",
+    ignore_above: 256,
+  },
+  sampleId: {
+    type: "keyword",
+    ignore_above: 256,
+  },
+  instrumentId: {
+    type: "keyword",
+    ignore_above: 256,
+  },
 };

--- a/src/elastic-search/configuration/indexSetting.ts
+++ b/src/elastic-search/configuration/indexSetting.ts
@@ -32,18 +32,6 @@ export const dynamic_template: Record<string, MappingDynamicTemplate>[] = [
       },
     },
   },
-  // NOTE: This is a workaround for the issue where the start_time field is not being
-  // parsed correctly. This is a temporary solution until
-  // we can find a better way to handle date format.
-  {
-    start_time_as_keyword: {
-      path_match: "scientificMetadata.start_time.*",
-      match_mapping_type: "long",
-      mapping: {
-        type: "keyword",
-      },
-    },
-  },
   {
     long_as_double: {
       path_match: "scientificMetadata.*.*",
@@ -71,8 +59,13 @@ export const dynamic_template: Record<string, MappingDynamicTemplate>[] = [
       path_match: "scientificMetadata.*.*",
       match_mapping_type: "string",
       mapping: {
-        type: "keyword",
-        ignore_above: 256,
+        type: "text",
+        fields: {
+          keyword: {
+            type: "keyword",
+            ignore_above: 256,
+          },
+        },
       },
     },
   },

--- a/src/elastic-search/elastic-search.module.ts
+++ b/src/elastic-search/elastic-search.module.ts
@@ -1,6 +1,6 @@
 import { Module, forwardRef } from "@nestjs/common";
 import { CaslModule } from "src/casl/casl.module";
-import { ConfigModule, ConfigService } from "@nestjs/config";
+import { ConfigModule } from "@nestjs/config";
 import { DatasetsModule } from "src/datasets/datasets.module";
 import { ElasticSearchServiceController } from "./elastic-search.controller";
 import { ElasticSearchService } from "./elastic-search.service";
@@ -9,7 +9,7 @@ import { SearchQueryService } from "./providers/query-builder.service";
 @Module({
   imports: [forwardRef(() => DatasetsModule), ConfigModule, CaslModule],
   controllers: [ElasticSearchServiceController],
-  providers: [ElasticSearchService, SearchQueryService, ConfigService],
+  providers: [ElasticSearchService, SearchQueryService],
   exports: [ElasticSearchService, SearchQueryService],
 })
 export class ElasticSearchModule {}

--- a/src/elastic-search/elastic-search.service.ts
+++ b/src/elastic-search/elastic-search.service.ts
@@ -408,8 +408,8 @@ export class ElasticSearchService implements OnModuleInit {
   // *** NOTE: below are helper methods ***
 
   async performBulkOperation(collection: DatasetClass[], index: string) {
-    return await this.esService.helpers.bulk({
-      retries: 3,
+    const result = await this.esService.helpers.bulk({
+      retries: 5,
       wait: 10000,
       datasource: collection,
       onDocument(doc: DatasetClass) {
@@ -427,5 +427,6 @@ export class ElasticSearchService implements OnModuleInit {
         console.debug(`${doc.document.pid}`, doc.error?.reason);
       },
     });
+    return result;
   }
 }

--- a/src/elastic-search/helpers/utils.ts
+++ b/src/elastic-search/helpers/utils.ts
@@ -19,9 +19,16 @@ export const addValueType = (obj: Record<string, unknown>) => {
   for (const [key, value] of Object.entries(obj)) {
     const newKey = transformKey(key);
 
+    const isObjectValueType =
+      typeof value === "object" &&
+      value !== null &&
+      Object.keys(value).length > 0;
     const isNumberValueType =
       typeof (value as Record<string, unknown>)?.value === "number";
 
+    if (!isObjectValueType) {
+      return { [newKey]: value };
+    }
     if (isNumberValueType) {
       (value as Record<string, unknown>)["value_type"] = "number";
     } else {

--- a/src/elastic-search/helpers/utils.ts
+++ b/src/elastic-search/helpers/utils.ts
@@ -26,14 +26,14 @@ export const addValueType = (obj: Record<string, unknown>) => {
     const isNumberValueType =
       typeof (value as Record<string, unknown>)?.value === "number";
 
-    if (!isObjectValueType) {
-      return { [newKey]: value };
+    if (isObjectValueType) {
+      if (isNumberValueType) {
+        (value as Record<string, unknown>)["value_type"] = "number";
+      } else {
+        (value as Record<string, unknown>)["value_type"] = "string";
+      }
     }
-    if (isNumberValueType) {
-      (value as Record<string, unknown>)["value_type"] = "number";
-    } else {
-      (value as Record<string, unknown>)["value_type"] = "string";
-    }
+
     newObj[newKey] = value;
   }
 

--- a/test/ElasticSearch.js
+++ b/test/ElasticSearch.js
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 "use strict";
 
 const { faker } = require("@faker-js/faker");
@@ -19,6 +19,7 @@ const Relation = {
 };
 
 const scientificMetadataFieldName = {
+  keyValue: "with_key_value",
   unitAndValue: "with_unit_and_value_si",
   number: "with_number",
   string: "with_string",
@@ -70,6 +71,7 @@ const scientificMetadata = (values) => {
             .property("scientificMetadata")
             .which.is.an("object")
             .that.has.all.keys(
+              scientificMetadataFieldName.keyValue,
               scientificMetadataFieldName.unitAndValue,
               scientificMetadataFieldName.number,
               scientificMetadataFieldName.string,

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -1082,7 +1082,7 @@ const TestData = {
     proposalId: faker.string.numeric(6),
     contactEmail: faker.internet.email(),
     scientificMetadata: {
-      File_Prefix: "817b_B2_",
+      with_key_value: "some text",
       with_unit_and_value_si: {
         value: 100,
         unit: "meters",

--- a/test/TestData.js
+++ b/test/TestData.js
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 const { faker } = require("@faker-js/faker");
 
 const RawTestAccounts = require("../functionalAccounts.json");
@@ -172,6 +172,7 @@ const TestData = {
     creationLocation: "/SU/XQX/RAMJET",
     dataFormat: "Upchuck pre 2017",
     scientificMetadata: {
+      File_Prefix: "817b_B2_",
       approx_file_size_mb: {
         value: 8500,
         unit: "",
@@ -451,6 +452,7 @@ const TestData = {
     creationLocation: "/SU/XQX/RAMJET",
     dataFormat: "Upchuck pre 2017",
     scientificMetadata: {
+      File_Prefix: "817b_B2_",
       beamlineParameters: {
         Monostripe: "Ru/C",
         "Ring current": {
@@ -1080,6 +1082,7 @@ const TestData = {
     proposalId: faker.string.numeric(6),
     contactEmail: faker.internet.email(),
     scientificMetadata: {
+      File_Prefix: "817b_B2_",
       with_unit_and_value_si: {
         value: 100,
         unit: "meters",


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
fixes https://github.com/SciCatProject/scicat-backend-next/issues/1796

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
