### PR TITLE
feat: add `datasetlifecycle.storageLocation` property

### DIFF
--- a/src/datasets/schemas/lifecycle.schema.ts
+++ b/src/datasets/schemas/lifecycle.schema.ts
@@ -159,6 +159,15 @@ export class LifecycleClass {
   })
   @Prop({ type: Boolean, default: false, required: false })
   retrieveIntegrityCheck?: boolean;
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      "Location of the data on the archive system. Allowed values are facility-specific and may be validated when submitting scicat jobs relating to this dataset. Facilities with a single storage location can leave this field empty.",
+  })
+  @Prop({ type: String, required: false })
+  storageLocation?: string;
 }
 
 export const LifecycleSchema = SchemaFactory.createForClass(LifecycleClass);


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
Adds `datasetlifecycle.storageLocation` to the dataset schema.

## Motivation
<!-- Background on use case, changes needed -->
Most sites have a single storage location for all data, so they don't need this feature. However with this it is possible to configure storage at several different sites. 

Sites that use this should also add validation to their job configuration to ensure that archive and retrieve jobs only apply to a single storageLocation.

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Support multiple storage locations for datasets (#1405)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* add `datasetlifecycle.storageLocation` property

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
