### PR TITLE
fix: ensure RabbitMQ job action is disabled by default

### DIFF
--- a/src/config/job-config/actions/corejobactioncreators.module.ts
+++ b/src/config/job-config/actions/corejobactioncreators.module.ts
@@ -1,4 +1,5 @@
 import { Module } from "@nestjs/common";
+import { ConditionalModule } from "@nestjs/config";
 import { LogJobActionCreator } from "./logaction/logaction.service";
 import { LogJobActionModule } from "./logaction/logaction.module";
 import { EmailJobActionCreator } from "./emailaction/emailaction.service";
@@ -43,7 +44,10 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
     LogJobActionModule,
     ValidateJobActionModule,
     URLJobActionModule,
-    RabbitMQJobActionModule,
+    ConditionalModule.registerWhen(
+      RabbitMQJobActionModule,
+      (env: NodeJS.ProcessEnv) => env.RABBITMQ_ENABLED === "yes",
+    ),
     SwitchJobActionModule,
     ErrorJobActionModule,
   ],
@@ -55,7 +59,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
         emailJobActionCreator,
         validateCreateJobActionCreator,
         urlJobActionCreator,
-        rabbitMQJobActionCreator,
+        rabbitMQJobActionCreator: RabbitMQJobActionCreator | null,
         switchCreateJobActionCreator,
         errorJobActionCreator,
       ) => {
@@ -74,7 +78,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
         EmailJobActionCreator,
         ValidateCreateJobActionCreator,
         URLJobActionCreator,
-        RabbitMQJobActionCreator,
+        { token: RabbitMQJobActionCreator, optional: true },
         SwitchCreateJobActionCreator,
         ErrorJobActionCreator,
       ],
@@ -86,7 +90,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
         emailJobActionCreator,
         validateJobActionCreator,
         urlJobActionCreator,
-        rabbitMQJobActionCreator,
+        rabbitMQJobActionCreator: RabbitMQJobActionCreator | null,
         switchUpdateJobActionCreator,
         errorJobActionCreator,
       ) => {
@@ -105,7 +109,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
         EmailJobActionCreator,
         ValidateJobActionCreator,
         URLJobActionCreator,
-        RabbitMQJobActionCreator,
+        { token: RabbitMQJobActionCreator, optional: true },
         SwitchUpdateJobActionCreator,
         ErrorJobActionCreator,
       ],


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
When the env variable `RABBITMQ_ENABLED` is not set to `"yes"`, the `RabbitMQModule` should be disabled. However, it was noticed that the module was still getting enabled and would result to throwing an error in case the other rabbitMQ env variables were not set.

It was confirmed that the module is set to be disabled by default, because it is defined as a `ConditionalModule` in `app.module` that is only going to be enabled when `RABBITMQ_ENABLED === "yes"`.  Additionally, the rule in `configuration.ts` sets `RABBITMQ_ENABLED` to `"no"` in case it is not defined.

The issue is caused by the way that `RabbitMQJobActionModule` is imported in `corejobactioncreators.module`. `RabbitMQJobActionModule` is not disabled by default, and depends on `RabbitMQModule`. This means that the job action module gets enabled regardless of the `RABBITMQ_ENABLED` value. As a result it also enables the `RabbitMQModule` which would then throw the error.

## Motivation
<!-- Background on use case, changes needed -->
https://github.com/SciCatProject/scicat-backend-next/issues/1798

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->
- Makes `RabbitMQJobActionModule` optional in `corejobactioncreators.module`

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
