### PR TITLE
fix: revert nested query object to individual parameters for Angular SDK compatibility

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -82,8 +82,12 @@ import {
 } from "./dto/update-derived-dataset-obsolete.dto";
 import { CreateDatasetDatablockDto } from "src/datablocks/dto/create-dataset-datablock";
 import {
+  datasetsFullQueryDescriptionFields,
+  datasetsFullQueryExampleFields,
   filterDescription,
   filterExample,
+  fullQueryDescriptionLimits,
+  fullQueryExampleLimits,
   replaceLikeOperator,
 } from "src/common/utils";
 import { HistoryClass } from "./schemas/history.schema";
@@ -964,12 +968,22 @@ export class DatasetsController {
       "It returns a list of datasets matching the query provided.<br>This endpoint still needs some work on the query specification.",
   })
   @ApiQuery({
-    name: "filters",
-    description: "Defines query limits and fields",
+    name: "fields",
+    description:
+      "Database filters to apply when retrieving datasets\n" +
+      datasetsFullQueryDescriptionFields,
     required: false,
-    type: FullQueryFilters,
-    example:
-      '{"limits": {"limit": 1, "skip": 1, "order": "creationTime:desc"}, fields: {"ownerGroup":["group1"],"scientific":[{"lhs":"sample","relation":"EQUAL_TO_STRING","rhs":"my sample"}]}}',
+    type: String,
+    example: datasetsFullQueryExampleFields,
+  })
+  @ApiQuery({
+    name: "limits",
+    description:
+      "Define further query parameters like skip, limit, order\n" +
+      fullQueryDescriptionLimits,
+    required: false,
+    type: String,
+    example: fullQueryExampleLimits,
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -1036,13 +1050,20 @@ export class DatasetsController {
   @UseInterceptors(SubDatasetsPublicInterceptor)
   @Get("/fullfacet")
   @ApiQuery({
-    name: "filters",
+    name: "fields",
+    description:
+      "Define the filter conditions by specifying the name of values of fields requested. There is also support for a `text` search to look for strings anywhere in the dataset.",
+    required: false,
+    type: String,
+    example: {},
+  })
+  @ApiQuery({
+    name: "facets",
     description:
       "Defines list of field names, for which facet counts should be calculated",
     required: false,
-    type: FullFacetFilters,
-    example:
-      '{"facets": ["type","creationLocation","ownerGroup","keywords"], fields: {}}',
+    type: String,
+    example: '["type","creationLocation","ownerGroup","keywords"]',
   })
   @ApiResponse({
     status: HttpStatus.OK,

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -56,6 +56,7 @@ import { validate, ValidatorOptions } from "class-validator";
 import {
   filterDescription,
   filterExample,
+  fullQueryDescriptionLimits,
   fullQueryExampleLimits,
   proposalsFullQueryDescriptionFields,
   proposalsFullQueryExampleFields,
@@ -477,11 +478,22 @@ export class ProposalsController {
       "It returns a list of proposals matching the query provided.<br>This endpoint still needs some work on the query specification.",
   })
   @ApiQuery({
-    name: "filters",
-    description: "Defines query limits and fields",
+    name: "fields",
+    description:
+      "Full query filters to apply when retrieving proposals\n" +
+      proposalsFullQueryDescriptionFields,
     required: false,
-    type: FullQueryFilters,
-    example: `{"limits": ${fullQueryExampleLimits}, fields: ${proposalsFullQueryExampleFields}}`,
+    type: String,
+    example: proposalsFullQueryExampleFields,
+  })
+  @ApiQuery({
+    name: "limits",
+    description:
+      "Define further query parameters like skip, limit, order\n" +
+      fullQueryDescriptionLimits,
+    required: false,
+    type: String,
+    example: fullQueryExampleLimits,
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -543,13 +555,19 @@ export class ProposalsController {
     description:
       "It returns a list of proposal facets matching the filter provided.<br>This endpoint still needs some work on the filter and facets specification.",
   })
+  @ApiOperation({
+    summary:
+      "It returns a list of proposal facets matching the filter provided.",
+    description:
+      "It returns a list of proposal facets matching the filter provided.<br>This endpoint still needs some work on the filter and facets specification.",
+  })
   @ApiQuery({
     name: "filters",
     description:
       "Full facet query filters to apply when retrieving proposals\n" +
       proposalsFullQueryDescriptionFields,
     required: false,
-    type: FullFacetFilters,
+    type: String,
     example: proposalsFullQueryExampleFields,
   })
   @ApiResponse({

--- a/src/samples/samples.controller.ts
+++ b/src/samples/samples.controller.ts
@@ -56,7 +56,9 @@ import {
 import {
   filterDescription,
   filterExample,
+  fullQueryDescriptionLimits,
   fullQueryExampleLimits,
+  samplesFullQueryDescriptionFields,
   samplesFullQueryExampleFields,
 } from "src/common/utils";
 import { Request } from "express";
@@ -64,11 +66,7 @@ import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
 import { IDatasetFields } from "src/datasets/interfaces/dataset-filters.interface";
 import { CreateSubAttachmentV3Dto } from "src/attachments/dto-obsolete/create-sub-attachment.v3.dto";
 import { AuthenticatedPoliciesGuard } from "src/casl/guards/auth-check.guard";
-import {
-  CountApiResponse,
-  FullQueryFilters,
-  SampleCountFilters,
-} from "src/common/types";
+import { CountApiResponse, SampleCountFilters } from "src/common/types";
 import { OutputAttachmentV3Dto } from "src/attachments/dto-obsolete/output-attachment.v3.dto";
 
 export class FindByIdAccessResponse {
@@ -399,11 +397,22 @@ export class SamplesController {
       "It returns a list of samples matching the query provided.<br>This endpoint still needs some work on the query specification.",
   })
   @ApiQuery({
-    name: "filters",
-    description: "Defines query limits and fields",
+    name: "fields",
+    description:
+      "Full query filters to apply when retrieve samples\n" +
+      samplesFullQueryDescriptionFields,
     required: false,
-    type: FullQueryFilters,
-    example: `{"limits": ${fullQueryExampleLimits}, fields: ${samplesFullQueryExampleFields}}`,
+    type: String,
+    example: samplesFullQueryExampleFields,
+  })
+  @ApiQuery({
+    name: "limits",
+    description:
+      "Define further query parameters like skip, limit, order\n" +
+      fullQueryDescriptionLimits,
+    required: false,
+    type: String,
+    example: fullQueryExampleLimits,
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -466,13 +475,19 @@ export class SamplesController {
       "It returns a list of sample metadata keys matching the query provided.",
   })
   @ApiQuery({
-    name: "filters",
+    name: "fields",
     description:
-      "Full query filters to apply when retrieve sample metadata keys",
+      "Define the filter conditions by specifying the name of values of fields requested. ",
     required: false,
     type: String,
-    // NOTE: This is custom example because the service function metadataKeys expects input like the following.
-    example: '{ "fields": { "metadataKey": "chemical_formula" } }',
+    example: {},
+  })
+  @ApiQuery({
+    name: "limits",
+    description: "Define further query parameters like skip, limit, order",
+    required: false,
+    type: String,
+    example: '{ "skip": 0, "limit": 25, "order": "creationTime:desc" }',
   })
   @ApiResponse({
     status: HttpStatus.OK,


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
The generated Angular SDK cannot correctly handle nested query objects via @ApiQuery, resulting in malformed requests. This change reverts the composite query parameter introduced in PR #1490 back to separate top-level parameters to ensure proper SDK generation and request serialization.

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
