### PR TITLE
feat: implement user password update functionality with validation

### DIFF
--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -49,3 +49,8 @@ export class IsValidResponse {
   @ApiPropertyOptional()
   reason?: ValidationError[];
 }
+
+export class passwordUpdateResponse {
+  @ApiProperty({ type: String })
+  message: string;
+}

--- a/src/users/dto/update-user-password.dto.ts
+++ b/src/users/dto/update-user-password.dto.ts
@@ -1,0 +1,27 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class UpdateUserPasswordDto {
+  /**
+   * The current password of the user.
+   */
+
+  @IsString()
+  @IsNotEmpty()
+  currentPassword: string;
+
+  /**
+   * The new password of the user.
+   */
+  @IsString()
+  @IsNotEmpty()
+  newPassword: string;
+}
+
+export class AdminUpdateUserPasswordDto {
+  /**
+   * The new password of the user
+   */
+  @IsString()
+  @IsNotEmpty()
+  newPassword: string;
+}

--- a/src/users/dto/update-user-password.dto.ts
+++ b/src/users/dto/update-user-password.dto.ts
@@ -15,6 +15,13 @@ export class UpdateUserPasswordDto {
   @IsString()
   @IsNotEmpty()
   newPassword: string;
+
+  /**
+   * Confirmation of the new password. This should match the new password.
+   */
+  @IsString()
+  @IsNotEmpty()
+  confirmPassword: string;
 }
 
 export class AdminUpdateUserPasswordDto {
@@ -24,4 +31,11 @@ export class AdminUpdateUserPasswordDto {
   @IsString()
   @IsNotEmpty()
   newPassword: string;
+
+  /**
+   * Confirmation of the new password. This should match the new password.
+   */
+  @IsString()
+  @IsNotEmpty()
+  confirmPassword: string;
 }

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -127,6 +127,15 @@ export class UsersController {
       user._id,
     );
 
+    if (
+      updateUserPasswordDto.newPassword !==
+      updateUserPasswordDto.confirmPassword
+    ) {
+      throw new BadRequestException(
+        "New password and confirmation password do not match",
+      );
+    }
+
     const validUser = await this.authService.validateUser(
       user.username,
       updateUserPasswordDto.currentPassword,
@@ -281,6 +290,14 @@ export class UsersController {
       [Action.UserUpdateAny],
       user._id,
     );
+    if (
+      updateUserPasswordDto.newPassword !==
+      updateUserPasswordDto.confirmPassword
+    ) {
+      throw new BadRequestException(
+        "New password and confirmation password do not match",
+      );
+    }
 
     const targetUser = await this.usersService.findById(id).catch((err) => {
       throw new BadRequestException(err.message);

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -11,6 +11,8 @@ import {
   Body,
   ForbiddenException,
   HttpCode,
+  BadRequestException,
+  HttpStatus,
 } from "@nestjs/common";
 import {
   ApiBearerAuth,
@@ -43,6 +45,11 @@ import { CreateCustomJwt } from "./dto/create-custom-jwt.dto";
 import { AuthenticatedPoliciesGuard } from "../casl/guards/auth-check.guard";
 import { ReturnedUserDto } from "./dto/returned-user.dto";
 import { ReturnedAuthLoginDto } from "src/auth/dto/returnedLogin.dto";
+import {
+  AdminUpdateUserPasswordDto,
+  UpdateUserPasswordDto,
+} from "./dto/update-user-password.dto";
+import { passwordUpdateResponse } from "src/common/types";
 
 @ApiBearerAuth()
 @ApiTags("users")
@@ -89,6 +96,55 @@ export class UsersController {
   })
   async getUserJWT(@Req() request: Request): Promise<CreateUserJWT | null> {
     return this.usersService.createUserJWT(request.user as JWTUser);
+  }
+
+  @UseGuards(AuthenticatedPoliciesGuard)
+  @CheckPolicies("users", (ability: AppAbility) =>
+    ability.can(Action.UserReadOwn, User),
+  )
+  @Post("/password")
+  @ApiBody({ type: UpdateUserPasswordDto })
+  @ApiOperation({
+    summary: "It change local user's own password.",
+    description:
+      "This endpoint change the password of the local user currently logged in",
+  })
+  @HttpCode(HttpStatus.OK)
+  @ApiResponse({
+    status: 200,
+    type: passwordUpdateResponse,
+    description: "Password changed successfully.",
+  })
+  async updateOwnPassword(
+    @Req() request: Request,
+    @Body() updateUserPasswordDto: UpdateUserPasswordDto,
+  ): Promise<passwordUpdateResponse | null> {
+    const user = request.user as JWTUser;
+
+    await this.checkUserAuthorization(
+      request,
+      [Action.UserUpdateOwn],
+      user._id,
+    );
+
+    const validUser = await this.authService.validateUser(
+      user.username,
+      updateUserPasswordDto.currentPassword,
+    );
+
+    if (!validUser) {
+      throw new BadRequestException("Current password is incorrect");
+    }
+    if (validUser.authStrategy !== "local") {
+      throw new ForbiddenException(
+        "Only local users are allowed to change password",
+      );
+    }
+    await this.usersService.updateUserPassword(
+      updateUserPasswordDto.newPassword,
+      user._id,
+    );
+    return { message: "Password updated successfully" };
   }
 
   @ApiBody({ type: CredentialsDto })
@@ -190,13 +246,69 @@ export class UsersController {
   }
 
   @UseGuards(AuthenticatedPoliciesGuard)
+  @CheckPolicies("users", (ability: AppAbility) =>
+    ability.can(Action.UserUpdateAny, User),
+  )
+  @Patch("/:id/password")
+  @ApiBody({ type: AdminUpdateUserPasswordDto })
+  @ApiParam({
+    name: "id",
+    description: "The ID of the user whose password is to be changed",
+    required: true,
+    type: String,
+    example: "1234567890abcdef12345678",
+  })
+  @ApiOperation({
+    summary: "Change a user’s password (admin only)",
+    description:
+      "Allows an administrator to update the password of a local user by their user ID.",
+  })
+  @HttpCode(HttpStatus.OK)
+  @ApiResponse({
+    status: 200,
+    type: passwordUpdateResponse,
+    description: "Password changed successfully.",
+  })
+  async updateUserPassword(
+    @Req() request: Request,
+    @Param("id") id: string,
+    @Body() updateUserPasswordDto: AdminUpdateUserPasswordDto,
+  ): Promise<passwordUpdateResponse | null> {
+    const user = request.user as JWTUser;
+
+    await this.checkUserAuthorization(
+      request,
+      [Action.UserUpdateAny],
+      user._id,
+    );
+
+    const targetUser = await this.usersService.findById(id).catch((err) => {
+      throw new BadRequestException(err.message);
+    });
+
+    if (targetUser && targetUser.authStrategy !== "local") {
+      throw new ForbiddenException(
+        "Only local users passwords can be changed by admin",
+      );
+    }
+
+    await this.usersService.updateUserPassword(
+      updateUserPasswordDto.newPassword,
+      id,
+    );
+    return {
+      message: `Password updated successfully for userId: ${id}`,
+    };
+  }
+
+  @UseGuards(AuthenticatedPoliciesGuard)
   @CheckPolicies(
     "users",
     (ability: AppAbility) =>
       ability.can(Action.UserReadOwn, User) ||
       ability.can(Action.UserReadAny, User),
   )
-  @Get(":id/userIdentity")
+  @Get("/:id/userIdentity")
   async getUserIdentity(
     @Req() request: Request,
     @Param("id") id: string,

--- a/src/users/users.service.spec.ts
+++ b/src/users/users.service.spec.ts
@@ -25,22 +25,23 @@ const mockUser: User = {
   userSettings: {
     _id: "testId",
     id: "testId",
-    columns: [],
+    externalSettings: {
+      filters: [
+        { type: "LocationFilterComponent", visible: true },
+        { type: "PidFilterComponent", visible: true },
+        { type: "PidFilterContainsComponent", visible: false },
+        { type: "PidFilterStartsWithComponent", visible: false },
+        { type: "GroupFilterComponent", visible: true },
+        { type: "TypeFilterComponent", visible: true },
+        { type: "KeywordFilterComponent", visible: true },
+        { type: "DateRangeFilterComponent", visible: true },
+        { type: "TextFilterComponent", visible: true },
+      ],
+      conditions: [],
+    },
     datasetCount: 25,
     jobCount: 25,
     userId: "testUserId",
-    filters: [
-      { type: "LocationFilterComponent", visible: true },
-      { type: "PidFilterComponent", visible: true },
-      { type: "PidFilterContainsComponent", visible: false },
-      { type: "PidFilterStartsWithComponent", visible: false },
-      { type: "GroupFilterComponent", visible: true },
-      { type: "TypeFilterComponent", visible: true },
-      { type: "KeywordFilterComponent", visible: true },
-      { type: "DateRangeFilterComponent", visible: true },
-      { type: "TextFilterComponent", visible: true },
-    ],
-    conditions: [],
   },
 };
 
@@ -66,22 +67,23 @@ const mockUserIdentity: UserIdentity = {
 const mockUserSettings: UserSettings = {
   _id: "testId",
   id: "testId",
-  columns: [],
+  externalSettings: {
+    filters: [
+      { type: "LocationFilterComponent", visible: true },
+      { type: "PidFilterComponent", visible: true },
+      { type: "PidFilterContainsComponent", visible: false },
+      { type: "PidFilterStartsWithComponent", visible: false },
+      { type: "GroupFilterComponent", visible: true },
+      { type: "TypeFilterComponent", visible: true },
+      { type: "KeywordFilterComponent", visible: true },
+      { type: "DateRangeFilterComponent", visible: true },
+      { type: "TextFilterComponent", visible: true },
+    ],
+    conditions: [],
+  },
   datasetCount: 25,
   jobCount: 25,
   userId: "testUserId",
-  filters: [
-    { type: "LocationFilterComponent", visible: true },
-    { type: "PidFilterComponent", visible: true },
-    { type: "PidFilterContainsComponent", visible: false },
-    { type: "PidFilterStartsWithComponent", visible: false },
-    { type: "GroupFilterComponent", visible: true },
-    { type: "TypeFilterComponent", visible: true },
-    { type: "KeywordFilterComponent", visible: true },
-    { type: "DateRangeFilterComponent", visible: true },
-    { type: "TextFilterComponent", visible: true },
-  ],
-  conditions: [],
 };
 
 describe("UsersService", () => {

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -221,6 +221,18 @@ export class UsersService implements OnModuleInit {
     return this.userModel.findOneAndUpdate({ _id: id }, updateUserDto).exec();
   }
 
+  async updateUserPassword(
+    newPassword: string,
+    id: string,
+  ): Promise<User | null> {
+    const salt = await genSalt();
+    const hashedPassword = await hash(newPassword, salt);
+
+    return this.userModel
+      .findOneAndUpdate({ _id: id }, { password: hashedPassword })
+      .exec();
+  }
+
   async findById2JWTUser(id: string): Promise<JWTUser | null> {
     const userIdentity = await this.userIdentityModel
       .findOne({ userId: id })

--- a/test/Users.js
+++ b/test/Users.js
@@ -1,11 +1,13 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 "use strict";
 
 const { TestData } = require("./TestData");
 const utils = require("./LoginUtils");
 
-let userIdUser1 = null,
-  accessTokenUser1 = null;
+let accessTokenAdminIngestor = null;
+let userIdUser1 = null;
+let accessTokenUser1 = null;
+let userIdUser2 = null;
+let accessTokenUser2 = null;
 
 describe("2350: Users: Login with functional accounts", () => {
   it("0010: Admin ingestor login fails with incorrect credentials", async () => {
@@ -47,7 +49,7 @@ describe("2360: Users settings", () => {
     accessTokenUser1 = loginResponseUser1.token;
   });
 
-  it("0020: Update users settings with valid value should success ", async () => {
+  it("0010: Update users settings with valid value should success ", async () => {
     return request(appUrl)
       .put(`/api/v3/Users/${userIdUser1}/settings`)
       .send(TestData.userSettingsCorrect)
@@ -63,7 +65,7 @@ describe("2360: Users settings", () => {
       });
   });
 
-  it("0030: Patch users settings with valid value should success ", async () => {
+  it("0020: Patch users settings with valid value should success ", async () => {
     return request(appUrl)
       .patch(`/api/v3/Users/${userIdUser1}/settings`)
       .send(TestData.userSettingsCorrect)
@@ -79,7 +81,7 @@ describe("2360: Users settings", () => {
       });
   });
 
-  it("0040: Patch users external settings with valid value should success ", async () => {
+  it("0030: Patch users external settings with valid value should success ", async () => {
     return request(appUrl)
       .patch(`/api/v3/Users/${userIdUser1}/settings/external`)
       .send(TestData.userSettingsCorrect.externalSettings)
@@ -92,6 +94,131 @@ describe("2360: Users settings", () => {
         res.body.should.have.property("datasetCount");
         res.body.should.have.property("jobCount");
         res.body.should.have.property("externalSettings");
+      });
+  });
+});
+
+describe("2370: Change password", () => {
+  before(async () => {
+    const loginResponseIngestor = await utils.getIdAndToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+    accessTokenAdminIngestor = loginResponseIngestor.token;
+
+    const loginResponseUser1 = await utils.getIdAndToken(appUrl, {
+      username: TestData.Accounts["user1"]["username"],
+      password: TestData.Accounts["user1"]["password"],
+    });
+    userIdUser1 = loginResponseUser1.userId;
+    accessTokenUser1 = loginResponseUser1.token;
+
+    const loginResponseUser2 = await utils.getIdAndToken(appUrl, {
+      username: TestData.Accounts["user2"]["username"],
+      password: TestData.Accounts["user2"]["password"],
+    });
+    userIdUser2 = loginResponseUser2.userId;
+    accessTokenUser2 = loginResponseUser2.token;
+
+    db.collection("User").updateOne(
+      { username: TestData.Accounts["user2"]["username"] },
+      { $set: { authStrategy: "oidc" } },
+    );
+  });
+
+  after(async () => {
+    db.collection("User").updateOne(
+      { username: TestData.Accounts["user2"]["username"] },
+      { $set: { authStrategy: "local" } },
+    );
+  });
+
+  it("0010: should fail to change password with incorrect password", async () => {
+    return request(appUrl)
+      .post("/api/v3/users/password")
+      .send({
+        currentPassword: "wrongOldPassword",
+        newPassword: TestData.Accounts["user1"]["password"],
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.BadRequestStatusCode)
+      .then((res) => {
+        res.body.should.have.property(
+          "message",
+          "Current password is incorrect",
+        );
+      });
+  });
+
+  it("0020: should change own password successfully", async () => {
+    return request(appUrl)
+      .post("/api/v3/users/password")
+      .send({
+        currentPassword: TestData.Accounts["user1"]["password"],
+        newPassword: "testpassword",
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.SuccessfulPostStatusCode)
+      .then((res) => {
+        res.body.should.have.property(
+          "message",
+          "Password updated successfully",
+        );
+      });
+  });
+  it("0030: oidc user should fail to change password", async () => {
+    return request(appUrl)
+      .post("/api/v3/users/password")
+      .send({
+        currentPassword: TestData.Accounts["user2"]["password"],
+        newPassword: "testpassword",
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser2}` })
+      .expect(TestData.CreationForbiddenStatusCode)
+      .then((res) => {
+        res.body.should.have.property(
+          "message",
+          "Only local users are allowed to change password",
+        );
+      });
+  });
+
+  it("0040: admin should be able to change user password", async () => {
+    return request(appUrl)
+      .patch(`/api/v3/users/${userIdUser1}/password`)
+      .send({
+        newPassword: TestData.Accounts["user1"]["password"],
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulPatchStatusCode)
+      .then((res) => {
+        console.log("res", res.body);
+        res.body.should.have.property(
+          "message",
+          `Password updated successfully for userId: ${userIdUser1}`,
+        );
+      });
+  });
+
+  it("0050: admin should fail to change oidc user password", async () => {
+    return request(appUrl)
+      .patch(`/api/v3/users/${userIdUser2}/password`)
+      .send({
+        newPassword: "testpassword",
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.CreationForbiddenStatusCode)
+      .then((res) => {
+        console.log("res", res.body);
+        res.body.should.have.property(
+          "message",
+          "Only local users passwords can be changed by admin",
+        );
       });
   });
 });

--- a/test/Users.js
+++ b/test/Users.js
@@ -156,8 +156,8 @@ describe("2370: Change password", () => {
     return request(appUrl)
       .post("/api/v3/users/password")
       .send({
-        currentPassword: "wrongOldPassword",
-        newPassword: TestData.Accounts["user1"]["password"],
+        currentPassword: TestData.Accounts["user1"]["password"],
+        newPassword: "testpassword",
         confirmPassword: "wrongConfirmPassword",
       })
       .set("Accept", "application/json")

--- a/test/Users.js
+++ b/test/Users.js
@@ -196,7 +196,6 @@ describe("2370: Change password", () => {
       .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
       .expect(TestData.SuccessfulPatchStatusCode)
       .then((res) => {
-        console.log("res", res.body);
         res.body.should.have.property(
           "message",
           `Password updated successfully for userId: ${userIdUser1}`,
@@ -214,7 +213,6 @@ describe("2370: Change password", () => {
       .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
       .expect(TestData.CreationForbiddenStatusCode)
       .then((res) => {
-        console.log("res", res.body);
         res.body.should.have.property(
           "message",
           "Only local users passwords can be changed by admin",


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Add endpoints for users to change their own password and for admins to change other users’ passwords, with input validation and auth-strategy checks.

## Motivation
Users need a secure way to rotate their password; admins need to manage local-only accounts. Enforces that only “local” users can have their passwords updated.


## Changes:

- Added UpdateUserPasswordDto and AdminUpdateUserPasswordDto DTOs
- Implemented updateOwnPassword (POST /users/password) and updateUserPassword (PATCH /users/:id/password) in UsersController
- Validate current password, enforce authStrategy === "local", and return standardized response
- Extended UsersService to perform password hash/update logic

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
