### PR TITLE
fix: prevent models.object import in Python SDK

### DIFF
--- a/.github/workflows/release-and-publish-sdk.yml
+++ b/.github/workflows/release-and-publish-sdk.yml
@@ -136,9 +136,7 @@ jobs:
         env:
           MONGODB_URI: "mongodb://localhost:27017/scicat"
           JWT_SECRET: thisIsTheJwtSecret
-          # It disables the content property on some of the endpoints as the sdk generator complains about it.
-          # We want to keep it when the app is running to improve the swagger documentation and usage.
-          SDK_PACKAGE_SWAGGER_HELPERS_DISABLED: true
+
         run: |
           npm install -g wait-on && npm install
           npm run start & wait-on http://localhost:3000/api/v3/health --timeout 200000

--- a/.github/workflows/upload-sdk-artifact.yml
+++ b/.github/workflows/upload-sdk-artifact.yml
@@ -33,9 +33,7 @@ jobs:
         env:
           MONGODB_URI: "mongodb://localhost:27017/scicat"
           JWT_SECRET: thisIsTheJwtSecret
-          # It disables the content property on some of the endpoints as the sdk generator complains about it.
-          # We want to keep it when the app is running to improve the swagger documentation and usage.
-          SDK_PACKAGE_SWAGGER_HELPERS_DISABLED: true
+
         run: |
           npm install -g wait-on && npm install
           npm run start & wait-on http://localhost:3000/api/v3/health --timeout 200000

--- a/src/attachments/attachments.v4.controller.ts
+++ b/src/attachments/attachments.v4.controller.ts
@@ -214,7 +214,12 @@ export class AttachmentsV4Controller {
     description: "Database filters to apply when retrieving attachments",
     required: false,
     type: String,
-    content: getSwaggerAttachmentFilterContent(),
+    schema: getSwaggerAttachmentFilterContent({
+      where: true,
+      include: false,
+      fields: true,
+      limits: true,
+    }),
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -257,7 +262,12 @@ export class AttachmentsV4Controller {
     description: "Database filters to apply when retrieving public attachments",
     required: false,
     type: String,
-    content: getSwaggerAttachmentFilterContent(),
+    schema: getSwaggerAttachmentFilterContent({
+      where: true,
+      include: false,
+      fields: true,
+      limits: true,
+    }),
   })
   @ApiResponse({
     status: HttpStatus.OK,

--- a/src/attachments/types/attachment-filter-contents.ts
+++ b/src/attachments/types/attachment-filter-contents.ts
@@ -1,7 +1,4 @@
-import {
-  ContentObject,
-  SchemaObject,
-} from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
+import { SchemaObject } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
 
 const FILTERS: Record<"limits" | "fields" | "where" | "include", object> = {
   where: {
@@ -24,21 +21,17 @@ export const getSwaggerAttachmentFilterContent = (
     fields: true,
     limits: true,
   },
-): ContentObject | undefined => {
-  const filterContent: Record<string, { schema: SchemaObject }> = {
-    "application/json": {
-      schema: {
-        type: "object",
-        example: {},
-      },
-    },
+): SchemaObject | undefined => {
+  const filterContent: SchemaObject = {
+    type: "object",
+    example: {},
   };
 
   for (const filtersKey in filtersToInclude) {
     const key = filtersKey as keyof typeof FILTERS;
 
     if (filtersToInclude[key] && FILTERS[key]) {
-      filterContent["application/json"].schema.example[key] = FILTERS[key];
+      filterContent.example[key] = FILTERS[key];
     }
   }
 

--- a/src/attachments/types/attachment-filter-contents.ts
+++ b/src/attachments/types/attachment-filter-contents.ts
@@ -2,54 +2,21 @@ import {
   ContentObject,
   SchemaObject,
 } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
-import { boolean } from "mathjs";
 
 const FILTERS: Record<"limits" | "fields" | "where" | "include", object> = {
   where: {
-    type: "object",
-    example: {
-      "relationships.targetId": "datasetId",
-      "relationships.targetType": "dataset",
-      "relationships.relationType": "is attached to",
-    },
+    "relationships.targetId": "datasetId",
+    "relationships.targetType": "dataset",
+    "relationships.relationType": "is attached to",
   },
-  include: {},
-  fields: {
-    type: "array",
-    items: {
-      type: "string",
-      example: "relationships",
-    },
-  },
+  include: [],
+  fields: ["relationships"],
   limits: {
-    type: "object",
-    properties: {
-      limit: {
-        type: "number",
-        example: 10,
-      },
-      skip: {
-        type: "number",
-        example: 0,
-      },
-      sort: {
-        type: "object",
-        properties: {
-          createdAt: {
-            type: "string",
-            example: "asc | desc",
-          },
-        },
-      },
-    },
+    limit: 10,
+    skip: 0,
+    sort: { createdAt: "desc" },
   },
 };
-
-/**
- * NOTE: This is disabled only for the official sdk package generation as the schema validation complains about the content field.
- * But we want to have it when we run the application as it improves swagger documentation and usage a lot.
- * We use "content" property as it is described in the swagger specification: https://swagger.io/docs/specification/v3_0/describing-parameters/#schema-vs-content:~:text=explode%3A%20false-,content,-is%20used%20in
- */
 export const getSwaggerAttachmentFilterContent = (
   filtersToInclude: Record<keyof typeof FILTERS, boolean> = {
     where: true,
@@ -58,15 +25,11 @@ export const getSwaggerAttachmentFilterContent = (
     limits: true,
   },
 ): ContentObject | undefined => {
-  if (boolean(process.env.SDK_PACKAGE_SWAGGER_HELPERS_DISABLED ?? false)) {
-    return undefined;
-  }
-
   const filterContent: Record<string, { schema: SchemaObject }> = {
     "application/json": {
       schema: {
         type: "object",
-        properties: {},
+        example: {},
       },
     },
   };
@@ -75,7 +38,7 @@ export const getSwaggerAttachmentFilterContent = (
     const key = filtersKey as keyof typeof FILTERS;
 
     if (filtersToInclude[key] && FILTERS[key]) {
-      filterContent["application/json"].schema.properties![key] = FILTERS[key];
+      filterContent["application/json"].schema.example[key] = FILTERS[key];
     }
   }
 

--- a/src/datasets/datasets-public.v4.controller.ts
+++ b/src/datasets/datasets-public.v4.controller.ts
@@ -58,7 +58,7 @@ export class DatasetsPublicV4Controller {
       "Database filters to apply when retrieving the public datasets",
     required: false,
     type: String,
-    content: getSwaggerDatasetFilterContent(),
+    schema: getSwaggerDatasetFilterContent(),
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -171,7 +171,7 @@ export class DatasetsPublicV4Controller {
     description: "Database filters to apply when retrieving public dataset",
     required: true,
     type: String,
-    content: getSwaggerDatasetFilterContent({
+    schema: getSwaggerDatasetFilterContent({
       where: true,
       include: true,
       fields: true,
@@ -208,7 +208,7 @@ export class DatasetsPublicV4Controller {
       "Database filters to apply when retrieving count for public datasets",
     required: false,
     type: String,
-    content: getSwaggerDatasetFilterContent({
+    schema: getSwaggerDatasetFilterContent({
       where: true,
       include: false,
       fields: false,

--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -355,7 +355,7 @@ export class DatasetsV4Controller {
     description: "Database filters to apply when retrieving datasets",
     required: false,
     type: String,
-    content: getSwaggerDatasetFilterContent(),
+    schema: getSwaggerDatasetFilterContent(),
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -523,7 +523,7 @@ export class DatasetsV4Controller {
     description: "Database filters to apply when retrieving dataset",
     required: true,
     type: String,
-    content: getSwaggerDatasetFilterContent({
+    schema: getSwaggerDatasetFilterContent({
       where: true,
       include: true,
       fields: true,
@@ -566,7 +566,7 @@ export class DatasetsV4Controller {
     description: "Database filters to apply when retrieving count for datasets",
     required: false,
     type: String,
-    content: getSwaggerDatasetFilterContent({
+    schema: getSwaggerDatasetFilterContent({
       where: true,
       include: false,
       fields: false,

--- a/src/datasets/types/dataset-filter-content.ts
+++ b/src/datasets/types/dataset-filter-content.ts
@@ -2,58 +2,18 @@ import {
   ContentObject,
   SchemaObject,
 } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
-import { boolean } from "mathjs";
 
 const FILTERS: Record<"limits" | "fields" | "where" | "include", object> = {
-  where: {
-    type: "object",
-    example: {
-      datasetName: { $regex: "Dataset", $options: "i" },
-    },
-  },
-  include: {
-    type: "array",
-    items: {
-      type: "string",
-      example: "attachments",
-    },
-  },
-  fields: {
-    type: "array",
-    items: {
-      type: "string",
-      example: "datasetName",
-    },
-  },
+  where: { datasetName: { $regex: "Dataset", $options: "i" } },
+  include: ["attachments"],
+  fields: ["datasetName"],
   limits: {
-    type: "object",
-    properties: {
-      limit: {
-        type: "number",
-        example: 10,
-      },
-      skip: {
-        type: "number",
-        example: 0,
-      },
-      sort: {
-        type: "object",
-        properties: {
-          datasetName: {
-            type: "string",
-            example: "asc | desc",
-          },
-        },
-      },
-    },
+    limit: 10,
+    skip: 0,
+    sort: { createdAt: "desc" },
   },
 };
 
-/**
- * NOTE: This is disabled only for the official sdk package generation as the schema validation complains about the content field.
- * But we want to have it when we run the application as it improves swagger documentation and usage a lot.
- * We use "content" property as it is described in the swagger specification: https://swagger.io/docs/specification/v3_0/describing-parameters/#schema-vs-content:~:text=explode%3A%20false-,content,-is%20used%20in
- */
 export const getSwaggerDatasetFilterContent = (
   filtersToInclude: Record<keyof typeof FILTERS, boolean> = {
     where: true,
@@ -62,15 +22,11 @@ export const getSwaggerDatasetFilterContent = (
     limits: true,
   },
 ): ContentObject | undefined => {
-  if (boolean(process.env.SDK_PACKAGE_SWAGGER_HELPERS_DISABLED ?? false)) {
-    return undefined;
-  }
-
   const filterContent: Record<string, { schema: SchemaObject }> = {
     "application/json": {
       schema: {
         type: "object",
-        properties: {},
+        example: {},
       },
     },
   };
@@ -79,7 +35,7 @@ export const getSwaggerDatasetFilterContent = (
     const key = filtersKey as keyof typeof FILTERS;
 
     if (filtersToInclude[key] && FILTERS[key]) {
-      filterContent["application/json"].schema.properties![key] = FILTERS[key];
+      filterContent["application/json"].schema.example[key] = FILTERS[key];
     }
   }
 

--- a/src/datasets/types/dataset-filter-content.ts
+++ b/src/datasets/types/dataset-filter-content.ts
@@ -32,7 +32,5 @@ export const getSwaggerDatasetFilterContent = (
     }
   }
 
-  console.log("filterContent", JSON.stringify(filterContent, null, 2));
-
   return filterContent;
 };

--- a/src/datasets/types/dataset-filter-content.ts
+++ b/src/datasets/types/dataset-filter-content.ts
@@ -1,7 +1,4 @@
-import {
-  ContentObject,
-  SchemaObject,
-} from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
+import { SchemaObject } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
 
 const FILTERS: Record<"limits" | "fields" | "where" | "include", object> = {
   where: { datasetName: { $regex: "Dataset", $options: "i" } },
@@ -21,23 +18,21 @@ export const getSwaggerDatasetFilterContent = (
     fields: true,
     limits: true,
   },
-): ContentObject | undefined => {
-  const filterContent: Record<string, { schema: SchemaObject }> = {
-    "application/json": {
-      schema: {
-        type: "object",
-        example: {},
-      },
-    },
+): SchemaObject => {
+  const filterContent: SchemaObject = {
+    type: "object",
+    example: {},
   };
 
   for (const filtersKey in filtersToInclude) {
     const key = filtersKey as keyof typeof FILTERS;
 
     if (filtersToInclude[key] && FILTERS[key]) {
-      filterContent["application/json"].schema.example[key] = FILTERS[key];
+      filterContent.example[key] = FILTERS[key];
     }
   }
+
+  console.log("filterContent", JSON.stringify(filterContent, null, 2));
 
   return filterContent;
 };


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
- Update the @ApiQuery filter schema to use an inline schema with only an example (no properties), preventing Swagger from hoisting a generic Object component and causing the models.object import error in the Python SDK.
- Remove the now-unused SDK_PACKAGE_SWAGGER_HELPERS_DISABLED flag, since the schema builder runs before environment variables are loaded,

## Motivation
latest python SDK throws error 

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
