### PR TITLE
fix: update dataset output types to include PartialOutputDatasetDto

### DIFF
--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -58,7 +58,10 @@ import {
   UpdateDatasetDto,
 } from "./dto/update-dataset.dto";
 import { Logbook } from "src/logbooks/schemas/logbook.schema";
-import { OutputDatasetDto } from "./dto/output-dataset.dto";
+import {
+  OutputDatasetDto,
+  PartialOutputDatasetDto,
+} from "./dto/output-dataset.dto";
 import {
   CountApiResponse,
   FullFacetFilters,
@@ -359,7 +362,7 @@ export class DatasetsV4Controller {
   })
   @ApiResponse({
     status: HttpStatus.OK,
-    type: OutputDatasetDto,
+    type: PartialOutputDatasetDto,
     isArray: true,
     description: "Return the datasets requested",
   })
@@ -367,7 +370,7 @@ export class DatasetsV4Controller {
     @Req() request: Request,
     @Query("filter", new FilterValidationPipe(), new IncludeValidationPipe())
     queryFilter: string,
-  ) {
+  ): Promise<PartialOutputDatasetDto[]> {
     const parsedFilter = JSON.parse(queryFilter ?? "{}");
     const mergedFilters = this.addAccessBasedFilters(
       request.user as JWTUser,

--- a/src/datasets/dto/output-dataset.dto.ts
+++ b/src/datasets/dto/output-dataset.dto.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty, PartialType } from "@nestjs/swagger";
 import { CreateDatasetDto } from "./create-dataset.dto";
 import { IsDateString, IsString } from "class-validator";
 
@@ -48,3 +48,5 @@ export class OutputDatasetDto extends CreateDatasetDto {
   @IsString()
   version: string;
 }
+
+export class PartialOutputDatasetDto extends PartialType(OutputDatasetDto) {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { NestFactory } from "@nestjs/core";
 import {
   DocumentBuilder,

--- a/test/DatasetV4.js
+++ b/test/DatasetV4.js
@@ -546,14 +546,12 @@ describe("2500: Datasets v4 tests", () => {
             dataset.should.have.property("datasetName");
             dataset.should.have.property("pid");
             dataset.should.not.have.property("description");
-
-            dataset.should.have.property("pid");
-            dataset.should.have.property("instruments");
-            dataset.should.have.property("proposals");
-            dataset.should.have.property("datablocks");
-            dataset.should.have.property("attachments");
-            dataset.should.have.property("origdatablocks");
-            dataset.should.have.property("samples");
+            dataset.should.not.have.property("instruments");
+            dataset.should.not.have.property("proposals");
+            dataset.should.not.have.property("datablocks");
+            dataset.should.not.have.property("attachments");
+            dataset.should.not.have.property("origdatablocks");
+            dataset.should.not.have.property("samples");
 
             dataset.datasetName.should.match(/Dataset/i);
           });

--- a/test/DatasetV4Public.js
+++ b/test/DatasetV4Public.js
@@ -270,14 +270,12 @@ describe("2600: Datasets v4 public endpoints tests", () => {
             dataset.should.have.property("datasetName");
             dataset.should.have.property("pid");
             dataset.should.not.have.property("description");
-
-            dataset.should.have.property("pid");
-            dataset.should.have.property("instruments");
-            dataset.should.have.property("proposals");
-            dataset.should.have.property("datablocks");
-            dataset.should.have.property("attachments");
-            dataset.should.have.property("origdatablocks");
-            dataset.should.have.property("samples");
+            dataset.should.not.have.property("instruments");
+            dataset.should.not.have.property("proposals");
+            dataset.should.not.have.property("datablocks");
+            dataset.should.not.have.property("attachments");
+            dataset.should.not.have.property("origdatablocks");
+            dataset.should.not.have.property("samples");
 
             dataset.datasetName.should.match(/Dataset/i);
           });


### PR DESCRIPTION



<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This PR includes three changes: it reorders the MongoDB aggregation pipeline to run $lookup before $project, ensures the SDK_PACKAGE_SWAGGER_HELPERS_DISABLED flag loads after process.env variables, and updates the Dataset V4 controller’s findAll return type to Partial<OutputDatasetDto>[] to support projections without Python SDK errors.
## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
