### PR TITLE
feat: customizable default job.statusCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `FUNCTIONAL_ACCOUNTS_FILE` | string | Yes | The file name for functional accounts, relative to the project root directory | "functionalAccounts.json"|
 | `JOB_CONFIGURATION_FILE` | string | Yes | Path of a job configuration file (conventionally `"jobConfig.yaml"`). If unset, jobs are disabled | |
 | `JOB_DEFAULT_STATUS_CODE` | string | Yes | Default statusCode for new jobs | "jobSubmitted" |
-| `JOB_DEFAULT_STATUS_MESSAGE | string | Yes | Default statusMessage for new jobs | "Job submitted" |
+| `JOB_DEFAULT_STATUS_MESSAGE | string | Yes | Default statusMessage for new jobs | "Job submitted." |
 
 ## Migrating from the old SciCat Backend
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `SWAGGER_PATH` | string | Yes | swaggerPath is the path where the swagger UI will be available. | "explorer"|
 | `MAX_FILE_UPLOAD_SIZE` | string | Yes | Maximum allowed file upload size. | "16mb"|
 | `FUNCTIONAL_ACCOUNTS_FILE` | string | Yes | The file name for functional accounts, relative to the project root directory | "functionalAccounts.json"|
+| `JOB_CONFIGURATION_FILE` | string | Yes | Path of a job configuration file (conventionally `"jobConfig.yaml"`). If unset, jobs are disabled | |
+| `JOB_DEFAULT_STATUS_CODE` | string | Yes | Default statusCode for new jobs | "jobSubmitted" |
+| `JOB_DEFAULT_STATUS_MESSAGE | string | Yes | Default statusMessage for new jobs | "Job submitted" |
 
 ## Migrating from the old SciCat Backend
 

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -146,6 +146,9 @@ const configuration = () => {
     },
     swaggerPath: process.env.SWAGGER_PATH || "explorer",
     jobConfigurationFile: jobConfigurationFile,
+    jobDefaultStatusCode: process.env.JOB_DEFAULT_STATUS_CODE || "jobSubmitted",
+    jobDefaultStatusMessage:
+      process.env.JOB_DEFAULT_STATUS_MESSAGE || "Job submitted",
     loggerConfigs: jsonConfigMap.loggers || [defaultLogger],
     accessGroups: {
       admin: adminGroups.split(",").map((v) => v.trim()) ?? [],

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -148,7 +148,7 @@ const configuration = () => {
     jobConfigurationFile: jobConfigurationFile,
     jobDefaultStatusCode: process.env.JOB_DEFAULT_STATUS_CODE || "jobSubmitted",
     jobDefaultStatusMessage:
-      process.env.JOB_DEFAULT_STATUS_MESSAGE || "Job submitted",
+      process.env.JOB_DEFAULT_STATUS_MESSAGE || "Job submitted.",
     loggerConfigs: jsonConfigMap.loggers || [defaultLogger],
     accessGroups: {
       admin: adminGroups.split(",").map((v) => v.trim()) ?? [],

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -345,9 +345,13 @@ export class JobsController {
     jobInstance.jobParams = jobCreateDto.jobParams;
     jobInstance.configVersion =
       jobConfiguration[JobsConfigSchema.ConfigVersion];
-    jobInstance.statusCode = "Initializing";
-    jobInstance.statusMessage =
-      "Building and validating job, verifying authorization";
+    jobInstance.statusCode = this.configService.get<string>(
+      "jobDefaultStatusCode",
+    )!;
+
+    jobInstance.statusMessage = this.configService.get<string>(
+      "jobDefaultStatusMessage",
+    )!;
 
     // validate datasetList, if it exists in jobParams
     let datasetList: DatasetListDto[] = [];

--- a/src/jobs/jobs.module.ts
+++ b/src/jobs/jobs.module.ts
@@ -12,6 +12,7 @@ import { CoreJobActionCreators } from "../config/job-config/actions/corejobactio
 import { EmailJobActionCreator } from "src/config/job-config/actions/emailaction/emailaction.service";
 import { CommonModule } from "src/common/common.module";
 import { CaslModule } from "src/casl/casl.module";
+import { ConfigModule } from "@nestjs/config";
 
 @Module({
   controllers: [JobsController],
@@ -42,6 +43,7 @@ import { CaslModule } from "src/casl/casl.module";
     ]),
     PoliciesModule,
     OrigDatablocksModule,
+    ConfigModule,
   ],
   providers: [JobsService, JobConfigService, EmailJobActionCreator],
 })

--- a/src/jobs/jobs.service.ts
+++ b/src/jobs/jobs.service.ts
@@ -26,12 +26,14 @@ import { CreateJobDto } from "./dto/create-job.dto";
 import { UpdateJobDto } from "./dto/update-job.dto";
 import { JobClass, JobDocument } from "./schemas/job.schema";
 import { IJobFields } from "./interfaces/job-filters.interface";
+import { ConfigService } from "@nestjs/config";
 
 @Injectable({ scope: Scope.REQUEST })
 export class JobsService {
   constructor(
     @InjectModel(JobClass.name) private jobModel: Model<JobDocument>,
     @Inject(REQUEST) private request: Request,
+    private configService: ConfigService,
   ) {}
 
   getUsername(): string {
@@ -47,8 +49,8 @@ export class JobsService {
     const createdJob = new this.jobModel(
       this.addStatusFields(
         addCreatedByFields(createJobDto, username),
-        "jobCreated",
-        "Job has been created.",
+        this.configService.get<string>("jobDefaultStatusCode")!,
+        this.configService.get<string>("jobDefaultStatusMessage")!,
       ),
     );
     return createdJob.save();

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -159,7 +159,7 @@ describe("1110: Jobs: Test New Job Model: possible real configurations", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -210,7 +210,7 @@ describe("1110: Jobs: Test New Job Model: possible real configurations", () => {
       .expect(TestData.EntryCreatedStatusCode)
       .expect("Content-Type", /json/)
       .then((res) => {
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -287,7 +287,7 @@ describe("1110: Jobs: Test New Job Model: possible real configurations", () => {
       .expect("Content-Type", /json/)
       .then((res) => {
         res.body.should.have.property("type").and.be.string;
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 

--- a/test/JobsAll.js
+++ b/test/JobsAll.js
@@ -252,7 +252,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
         res.body.should.have.property("contactEmail").and.be.equal(adminEmail);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -281,7 +281,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(newJob.contactEmail);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId1 = res.body["id"];
         encodedJobOwnedByAdmin = encodeURIComponent(jobId1);
       });
@@ -308,7 +308,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         res.body.should.have
           .property("contactEmail")
           .to.be.equal("user1@your.site");
@@ -338,7 +338,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
         res.body.should.have.property("contactEmail").to.be.equal(adminEmail);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId3 = res.body["id"];
         encodedJobOwnedByGroup1 = encodeURIComponent(jobId3);
       });
@@ -392,7 +392,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(newJob.contactEmail);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId6 = res.body["id"];
         encodedJobOwnedByAnonym = encodeURIComponent(jobId6);
       });
@@ -419,7 +419,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -446,7 +446,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
         res.body.should.have
           .property("contactEmail")
           .and.be.equal("user1@your.site");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -471,7 +471,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -495,7 +495,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerUser");
         res.body.should.have.property("ownerGroup").and.be.equal("group3");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId7 = res.body["id"];
         encodedJobOwnedByGroup3 = encodeURIComponent(jobId7);
       });
@@ -524,7 +524,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
         res.body.should.have
           .property("contactEmail")
           .and.be.equal("test@email.scicat");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -570,7 +570,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId4 = res.body["id"];
         encodedJobOwnedByUser51 = encodeURIComponent(jobId4);
       });
@@ -600,7 +600,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
         res.body.should.have
           .property("contactEmail")
           .and.be.equal(newJob.contactEmail);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId5 = res.body["id"];
         encodedJobOwnedByGroup5 = encodeURIComponent(jobId5);
       });
@@ -700,7 +700,7 @@ describe("1120: Jobs: Test New Job Model Authorization for all_access jobs type"
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerUser");
         res.body.should.not.have.property("ownerGroup");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 

--- a/test/JobsAuthenticated.js
+++ b/test/JobsAuthenticated.js
@@ -143,7 +143,7 @@ describe("1130: Jobs: Test New Job Model Authorization for authenticated_access 
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -171,7 +171,7 @@ describe("1130: Jobs: Test New Job Model Authorization for authenticated_access 
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -198,7 +198,7 @@ describe("1130: Jobs: Test New Job Model Authorization for authenticated_access 
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -228,7 +228,7 @@ describe("1130: Jobs: Test New Job Model Authorization for authenticated_access 
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(newJob.contactEmail);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -256,7 +256,7 @@ describe("1130: Jobs: Test New Job Model Authorization for authenticated_access 
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -284,7 +284,7 @@ describe("1130: Jobs: Test New Job Model Authorization for authenticated_access 
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 

--- a/test/JobsDatasetAccess.js
+++ b/test/JobsDatasetAccess.js
@@ -162,7 +162,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId1 = res.body["id"];
         encodedJobOwnedByAdmin = encodeURIComponent(jobId1);
       });
@@ -193,7 +193,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId2 = res.body["id"];
         encodedJobOwnedByUser1 = encodeURIComponent(jobId2);
       });
@@ -223,7 +223,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId3 = res.body["id"];
         encodedJobOwnedByGroup1 = encodeURIComponent(jobId3);
       });
@@ -253,7 +253,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId5 = res.body["id"];
         encodedJobOwnedByGroup5 = encodeURIComponent(jobId5);
       });
@@ -285,7 +285,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(newJob.contactEmail);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId6 = res.body["id"];
         encodedJobOwnedByAnonym = encodeURIComponent(jobId6);
       });
@@ -315,7 +315,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -372,7 +372,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -396,7 +396,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group3");
         res.body.should.have.property("ownerUser").and.be.equal("user3");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId7 = res.body["id"];
         encodedJobOwnedByUser3 = encodeURIComponent(jobId7);
       });
@@ -448,7 +448,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerGroup");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -494,7 +494,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerGroup");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -548,7 +548,7 @@ describe("1140: Jobs: Test New Job Model Authorization for dataset_access jobs t
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId4 = res.body["id"];
         encodedJobOwnedByUser51 = encodeURIComponent(jobId4);
       });

--- a/test/JobsDatasetOwner.js
+++ b/test/JobsDatasetOwner.js
@@ -170,7 +170,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId1 = res.body["id"];
         encodedJobOwnedByAdmin = encodeURIComponent(jobId1);
       });
@@ -201,7 +201,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -230,7 +230,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId2 = res.body["id"];
         encodedJobOwnedByUser1 = encodeURIComponent(jobId2);
       });
@@ -260,7 +260,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId3 = res.body["id"];
         encodedJobOwnedByGroup1 = encodeURIComponent(jobId3);
       });
@@ -290,7 +290,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId5 = res.body["id"];
         encodedJobOwnedByGroup5 = encodeURIComponent(jobId5);
       });
@@ -323,7 +323,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(newJob.contactEmail);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId6 = res.body["id"];
         encodedJobOwnedByAnonym = encodeURIComponent(jobId6);
       });
@@ -350,7 +350,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId7 = res.body["id"];
       });
   });
@@ -404,7 +404,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.2");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId51 = res.body["id"];
         encodedJobOwnedByUser52 = encodeURIComponent(jobId51);
       });
@@ -430,7 +430,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerGroup");
         res.body.should.have.property("ownerUser").and.be.equal("user5.2");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId51 = res.body["id"];
         encodedJobOwnedByUser52 = encodeURIComponent(jobId51);
       });
@@ -457,7 +457,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId4 = res.body["id"];
         encodedJobOwnedByUser51 = encodeURIComponent(jobId4);
       });
@@ -509,7 +509,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerUser").and.be.equal("user1");
         res.body.should.have.property("ownerGroup").and.be.equal("group3");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId12 = res.body["id"];
       });
   });
@@ -535,7 +535,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerUser").and.be.equal("user2");
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId21 = res.body["id"];
       });
   });
@@ -589,7 +589,7 @@ describe("1150: Jobs: Test New Job Model Authorization for owner_access jobs typ
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerUser").and.be.equal("user3");
         res.body.should.have.property("ownerGroup").and.be.equal("group3");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId7 = res.body["id"];
         encodedJobOwnedByUser3 = encodeURIComponent(jobId7);
       });

--- a/test/JobsDatasetPublic.js
+++ b/test/JobsDatasetPublic.js
@@ -140,7 +140,7 @@ describe("1160: Jobs: Test New Job Model Authorization for public_access jobs ty
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -168,7 +168,7 @@ describe("1160: Jobs: Test New Job Model Authorization for public_access jobs ty
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -196,7 +196,7 @@ describe("1160: Jobs: Test New Job Model Authorization for public_access jobs ty
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -223,7 +223,7 @@ describe("1160: Jobs: Test New Job Model Authorization for public_access jobs ty
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -253,7 +253,7 @@ describe("1160: Jobs: Test New Job Model Authorization for public_access jobs ty
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(newJob.contactEmail);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -278,7 +278,7 @@ describe("1160: Jobs: Test New Job Model Authorization for public_access jobs ty
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -303,7 +303,7 @@ describe("1160: Jobs: Test New Job Model Authorization for public_access jobs ty
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group3");
         res.body.should.have.property("ownerUser").and.be.equal("user3");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -356,7 +356,7 @@ describe("1160: Jobs: Test New Job Model Authorization for public_access jobs ty
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -407,7 +407,7 @@ describe("1160: Jobs: Test New Job Model Authorization for public_access jobs ty
         res.body.should.have.property("type").and.be.string;
         res.body.should.not.have.property("ownerUser");
         res.body.should.not.have.property("ownerGroup");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 

--- a/test/JobsJobAdmin.js
+++ b/test/JobsJobAdmin.js
@@ -154,7 +154,7 @@ describe("1170: Jobs: Test New Job Model Authorization for job_admin jobs type",
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId1 = res.body["id"];
         encodedJobOwnedByAdmin = encodeURIComponent(jobId1);
       });
@@ -185,7 +185,7 @@ describe("1170: Jobs: Test New Job Model Authorization for job_admin jobs type",
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId2 = res.body["id"];
         encodedJobOwnedByUser1 = encodeURIComponent(jobId2);
       });
@@ -215,7 +215,7 @@ describe("1170: Jobs: Test New Job Model Authorization for job_admin jobs type",
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group3");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId3 = res.body["id"];
         encodedJobOwnedByGroup3 = encodeURIComponent(jobId3);
       });
@@ -248,7 +248,7 @@ describe("1170: Jobs: Test New Job Model Authorization for job_admin jobs type",
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(newJob.contactEmail);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -273,7 +273,7 @@ describe("1170: Jobs: Test New Job Model Authorization for job_admin jobs type",
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId7 = res.body["id"];
       });
   });
@@ -302,7 +302,7 @@ describe("1170: Jobs: Test New Job Model Authorization for job_admin jobs type",
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -327,7 +327,7 @@ describe("1170: Jobs: Test New Job Model Authorization for job_admin jobs type",
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId51 = res.body["id"];
         encodedJobOwnedByUser51 = encodeURIComponent(jobId51);
       });

--- a/test/JobsSpecificGroup.js
+++ b/test/JobsSpecificGroup.js
@@ -180,7 +180,7 @@ describe("1180: Jobs: Test New Job Model Authorization for group_access type: co
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId1 = res.body["id"];
         encodedJobOwnedByAdmin = encodeURIComponent(jobId1);
       });
@@ -210,7 +210,7 @@ describe("1180: Jobs: Test New Job Model Authorization for group_access type: co
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId2 = res.body["id"];
         encodedJobOwnedByUser1 = encodeURIComponent(jobId2);
       });
@@ -239,7 +239,7 @@ describe("1180: Jobs: Test New Job Model Authorization for group_access type: co
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId3 = res.body["id"];
         encodedJobOwnedByGroup1 = encodeURIComponent(jobId3);
       });
@@ -268,7 +268,7 @@ describe("1180: Jobs: Test New Job Model Authorization for group_access type: co
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId5 = res.body["id"];
         encodedJobOwnedByGroup5 = encodeURIComponent(jobId5);
       });
@@ -298,7 +298,7 @@ describe("1180: Jobs: Test New Job Model Authorization for group_access type: co
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group3");
         res.body.should.have.property("ownerUser").and.be.equal("user3");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -328,7 +328,7 @@ describe("1180: Jobs: Test New Job Model Authorization for group_access type: co
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(newJob.contactEmail);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId6 = res.body["id"];
         encodedJobOwnedByAnonym = encodeURIComponent(jobId6);
       });
@@ -358,7 +358,7 @@ describe("1180: Jobs: Test New Job Model Authorization for group_access type: co
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -386,7 +386,7 @@ describe("1180: Jobs: Test New Job Model Authorization for group_access type: co
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -414,7 +414,7 @@ describe("1180: Jobs: Test New Job Model Authorization for group_access type: co
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group4");
         res.body.should.have.property("ownerUser").and.be.equal("user4");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId8 = res.body["id"];
         encodedJobOwnedByUser4 = encodeURIComponent(jobId8);
       });
@@ -469,7 +469,7 @@ describe("1180: Jobs: Test New Job Model Authorization for group_access type: co
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId4 = res.body["id"];
         encodedJobOwnedByUser51 = encodeURIComponent(jobId4);
       });
@@ -498,7 +498,7 @@ describe("1180: Jobs: Test New Job Model Authorization for group_access type: co
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -526,7 +526,7 @@ describe("1180: Jobs: Test New Job Model Authorization for group_access type: co
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.2");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId7 = res.body["id"];
         encodedJobOwnedByUser52 = encodeURIComponent(jobId7);
       });

--- a/test/JobsSpecificUser.js
+++ b/test/JobsSpecificUser.js
@@ -168,7 +168,7 @@ describe("1190: Jobs: Test New Job Model Authorization for user_access type: con
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("admin");
         res.body.should.have.property("ownerUser").and.be.equal("admin");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId1 = res.body["id"];
         encodedJobOwnedByAdmin = encodeURIComponent(jobId1);
       });
@@ -198,7 +198,7 @@ describe("1190: Jobs: Test New Job Model Authorization for user_access type: con
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId2 = res.body["id"];
         encodedJobOwnedByUser1 = encodeURIComponent(jobId2);
       });
@@ -227,7 +227,7 @@ describe("1190: Jobs: Test New Job Model Authorization for user_access type: con
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId3 = res.body["id"];
         encodedJobOwnedByGroup1 = encodeURIComponent(jobId3);
       });
@@ -256,7 +256,7 @@ describe("1190: Jobs: Test New Job Model Authorization for user_access type: con
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.not.have.property("ownerUser");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId5 = res.body["id"];
         encodedJobOwnedByGroup5 = encodeURIComponent(jobId5);
       });
@@ -286,7 +286,7 @@ describe("1190: Jobs: Test New Job Model Authorization for user_access type: con
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.2");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId7 = res.body["id"];
         encodedJobOwnedByUser52 = encodeURIComponent(jobId7);
       });
@@ -318,7 +318,7 @@ describe("1190: Jobs: Test New Job Model Authorization for user_access type: con
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(newJob.contactEmail);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId6 = res.body["id"];
         encodedJobOwnedByAnonym = encodeURIComponent(jobId6);
       });
@@ -348,7 +348,7 @@ describe("1190: Jobs: Test New Job Model Authorization for user_access type: con
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group1");
         res.body.should.have.property("ownerUser").and.be.equal("user1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -376,7 +376,7 @@ describe("1190: Jobs: Test New Job Model Authorization for user_access type: con
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -404,7 +404,7 @@ describe("1190: Jobs: Test New Job Model Authorization for user_access type: con
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group3");
         res.body.should.have.property("ownerUser").and.be.equal("user3");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 
@@ -457,7 +457,7 @@ describe("1190: Jobs: Test New Job Model Authorization for user_access type: con
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         jobId4 = res.body["id"];
         encodedJobOwnedByUser51 = encodeURIComponent(jobId4);
       });
@@ -486,7 +486,7 @@ describe("1190: Jobs: Test New Job Model Authorization for user_access type: con
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("ownerGroup").and.be.equal("group5");
         res.body.should.have.property("ownerUser").and.be.equal("user5.1");
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
       });
   });
 

--- a/test/JobsV3.js
+++ b/test/JobsV3.js
@@ -202,7 +202,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         res.body.should.have
           .property("statusMessage")
-          .to.be.equal("Job has been created.");
+          .to.be.equal("Job submitted.");
         res.body.should.have
           .property("jobParams")
           .that.deep.equals({ datasetList: jobCreateDtoByAdmin.datasetList });
@@ -281,7 +281,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         res.body.should.have
           .property("statusMessage")
-          .to.be.equal("Job has been created.");
+          .to.be.equal("Job submitted.");
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(jobCreateDtoForUser51.emailJobInitiator);
@@ -376,7 +376,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         res.body.should.have
           .property("statusMessage")
-          .to.be.equal("Job has been created.");
+          .to.be.equal("Job submitted.");
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(jobCreateDtoForUser51.emailJobInitiator);
@@ -412,7 +412,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         res.body.should.have
           .property("statusMessage")
-          .to.be.equal("Job has been created.");
+          .to.be.equal("Job submitted.");
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(jobCreateDtoForUser51.emailJobInitiator);
@@ -560,7 +560,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         res.body.should.have
           .property("statusMessage")
-          .to.be.equal("Job has been created.");
+          .to.be.equal("Job submitted.");
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(jobCreateDtoByUser1.emailJobInitiator);
@@ -976,7 +976,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         res.body.should.have
           .property("statusMessage")
-          .to.be.equal("Job has been created.");
+          .to.be.equal("Job submitted.");
         res.body.should.have.property("jobParams").that.deep.equals({
           datasetList: jobCreateDtoByAnonymous.datasetList,
         });

--- a/test/JobsV3.js
+++ b/test/JobsV3.js
@@ -168,7 +168,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have
           .property("jobStatusMessage")
-          .to.be.equal("jobCreated");
+          .to.be.equal("jobSubmitted");
         res.body.should.have
           .property("datasetList")
           .that.deep.equals(jobCreateDtoByAdmin.datasetList);
@@ -199,7 +199,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(TestData.Accounts["admin"]["email"]);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         res.body.should.have
           .property("statusMessage")
           .to.be.equal("Job has been created.");
@@ -253,7 +253,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have
           .property("jobStatusMessage")
-          .to.be.equal("jobCreated");
+          .to.be.equal("jobSubmitted");
         res.body.should.have
           .property("emailJobInitiator")
           .to.be.equal(jobCreateDtoForUser51.emailJobInitiator);
@@ -278,7 +278,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.not.have.property("creationTime");
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("configVersion").and.be.string;
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         res.body.should.have
           .property("statusMessage")
           .to.be.equal("Job has been created.");
@@ -340,7 +340,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have
           .property("jobStatusMessage")
-          .to.be.equal("jobCreated");
+          .to.be.equal("jobSubmitted");
         res.body.should.have
           .property("emailJobInitiator")
           .to.be.equal(jobCreateDtoForUser51.emailJobInitiator);
@@ -373,7 +373,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.not.have.property("creationTime");
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("configVersion").and.be.string;
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         res.body.should.have
           .property("statusMessage")
           .to.be.equal("Job has been created.");
@@ -409,7 +409,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.not.have.property("creationTime");
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("configVersion").and.be.string;
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         res.body.should.have
           .property("statusMessage")
           .to.be.equal("Job has been created.");
@@ -524,7 +524,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have
           .property("jobStatusMessage")
-          .to.be.equal("jobCreated");
+          .to.be.equal("jobSubmitted");
         res.body.should.have
           .property("emailJobInitiator")
           .to.be.equal(jobCreateDtoByUser1.emailJobInitiator);
@@ -557,7 +557,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.not.have.property("creationTime");
         res.body.should.have.property("type").and.be.string;
         res.body.should.have.property("configVersion").and.be.string;
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         res.body.should.have
           .property("statusMessage")
           .to.be.equal("Job has been created.");
@@ -588,7 +588,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have
           .property("jobStatusMessage")
-          .to.be.equal("jobCreated");
+          .to.be.equal("jobSubmitted");
         res.body.should.have
           .property("emailJobInitiator")
           .to.be.equal(jobCreateDtoByUser1.emailJobInitiator);
@@ -947,7 +947,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have.property("type").and.be.string;
         res.body.should.have
           .property("jobStatusMessage")
-          .to.be.equal("jobCreated");
+          .to.be.equal("jobSubmitted");
         res.body.should.have
           .property("emailJobInitiator")
           .to.be.equal(jobCreateDtoByAnonymous.emailJobInitiator);
@@ -973,7 +973,7 @@ describe("1200: Jobs: Test Backwards Compatibility", () => {
         res.body.should.have
           .property("contactEmail")
           .to.be.equal(jobCreateDtoByAnonymous.emailJobInitiator);
-        res.body.should.have.property("statusCode").to.be.equal("jobCreated");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
         res.body.should.have
           .property("statusMessage")
           .to.be.equal("Job has been created.");


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
The status code and message can be customized for new jobs using the `JOB_DEFAULT_STATUS_CODE` (default: "jobSubmitted" and `JOB_DEFAULT_STATUS_MESSAGE` (default: "Job submitted") variables.

## Motivation
<!-- Background on use case, changes needed -->
The default was previously hard-coded to "jobCreated", which was used in v3 to indicate the job was being processed by the archiver. This changes the default to the backwards-compatible "jobSubmitted" value but allows it to be overwritten if needed.

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->


## Changes:
<!-- Please provide a list of the changes implemented by this PR -->


## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [x] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
https://github.com/SciCatProject/documentation/pull/73