### PR TITLE
fix: update value structure in elasticsearch initialSyncTransform

### DIFF
--- a/src/elastic-search/helpers/utils.ts
+++ b/src/elastic-search/helpers/utils.ts
@@ -65,7 +65,7 @@ export const initialSyncTransform = (obj: DatasetClass) => {
           const transformedKey = transformKey(key);
 
           if (!isObject(value)) {
-            return [transformedKey, value];
+            return [transformedKey, { value: value, unit: "" }];
           }
 
           if ("value" in value) {

--- a/src/elastic-search/interfaces/es-common.type.ts
+++ b/src/elastic-search/interfaces/es-common.type.ts
@@ -6,6 +6,7 @@ export type searchType =
   | "date"
   | "boolean"
   | "object"
+  | "flattened"
   | "nested";
 
 export type ObjectType = {


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This PR updates the initialSyncTransform function to ensure that all scientific metadata values follow a consistent structure of: `{ value: unknown, unit: string }` 

## Motivation
Previously, some metadata fields were stored as plain values (e.g., "someKey": 123). This caused inconsistencies when indexing into Elasticsearch.

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
