### PR TITLE
fix(apiv3): return 404 when no `PublishedData` is found

### DIFF
--- a/src/published-data/published-data.controller.ts
+++ b/src/published-data/published-data.controller.ts
@@ -232,9 +232,20 @@ export class PublishedDataController {
     isArray: false,
     description: "Return published data with id specified",
   })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: "PublishedData not found",
+  })
   @Get("/:id")
   async findOne(@Param("id") id: string): Promise<PublishedData | null> {
-    return this.publishedDataService.findOne({ doi: id });
+    const publishedData = await this.publishedDataService.findOne({ doi: id });
+    if (!publishedData) {
+      throw new NotFoundException(
+        `No PublishedData with the id '${id}' exists`,
+      );
+    }
+
+    return publishedData;
   }
 
   // PATCH /publisheddata/:id

--- a/test/PublishedData.js
+++ b/test/PublishedData.js
@@ -419,4 +419,12 @@ describe("1600: PublishedData: Test of access to published data", () => {
       .expect(TestData.SuccessfulDeleteStatusCode)
       .expect("Content-Type", /json/);
   });
+
+  it("0220: should return 404", async () => {
+    return request(appUrl)
+      .get("/api/v3/PublishedData/non-existing-id")
+      .set("Accept", "application/json")
+      .expect(TestData.NotFoundStatusCode)
+      .expect("Content-Type", /json/);
+  });
 });


### PR DESCRIPTION
Fixes #2036 

