### PR TITLE
fix: improve error messages for misconfigured job actions

### DIFF
--- a/src/config/job-config/actions/emailaction/emailaction.service.ts
+++ b/src/config/job-config/actions/emailaction/emailaction.service.ts
@@ -14,7 +14,9 @@ export class EmailJobActionCreator implements JobActionCreator<JobDto> {
 
   public create<Options extends JobActionOptions>(options: Options) {
     if (!isEmailJobActionOptions(options)) {
-      throw new Error("Invalid options for EmailJobAction.");
+      throw new Error(
+        `Invalid options for email action: ${JSON.stringify(options)}`,
+      );
     }
     return new EmailJobAction(this.mailService, options);
   }

--- a/src/config/job-config/actions/erroraction/erroraction.service.ts
+++ b/src/config/job-config/actions/erroraction/erroraction.service.ts
@@ -13,7 +13,9 @@ export class ErrorJobActionCreator implements JobActionCreator<JobDto> {
 
   public create(options: JobActionOptions) {
     if (!isErrorJobActionOptions(options)) {
-      throw new Error("Invalid options for ErrorJobAction.");
+      throw new Error(
+        `Invalid options for error action: ${JSON.stringify(options)}`,
+      );
     }
 
     return new ErrorJobAction(options);

--- a/src/config/job-config/actions/logaction/logaction.service.ts
+++ b/src/config/job-config/actions/logaction/logaction.service.ts
@@ -13,7 +13,9 @@ export class LogJobActionCreator implements JobActionCreator<JobDto> {
 
   public create(options: JobActionOptions) {
     if (!isLogJobActionOptions(options)) {
-      throw new Error("Invalid options for LogJobAction.");
+      throw new Error(
+        `Invalid options for log action: ${JSON.stringify(options)}`,
+      );
     }
 
     return new LogJobAction(options);

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.service.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.service.ts
@@ -18,7 +18,9 @@ export class RabbitMQJobActionCreator implements JobActionCreator<JobDto> {
 
   public create<Options extends JobActionOptions>(options: Options) {
     if (!isRabbitMQJobActionOptions(options)) {
-      throw new Error("Invalid options for RabbitMQJobAction.");
+      throw new Error(
+        `Invalid options for rabbitmq action: ${JSON.stringify(options)}`,
+      );
     }
     return new RabbitMQJobAction(
       this.configService,

--- a/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.spec.ts
+++ b/src/config/job-config/actions/rabbitmqaction/rabbitmqaction.spec.ts
@@ -119,6 +119,8 @@ describe("RabbitMQJobAction", () => {
       rabbitMQJobActionCreator.create(
         invalidOptions as RabbitMQJobActionOptions,
       );
-    }).toThrowError("Invalid options for RabbitMQJobAction.");
+    }).toThrowError(
+      'Invalid options for rabbitmq action: {"actionType":"rabbitmq","queue":"testQueue","exchange":"testExchange"}',
+    );
   });
 });

--- a/src/config/job-config/actions/switchaction/switchaction.service.ts
+++ b/src/config/job-config/actions/switchaction/switchaction.service.ts
@@ -20,7 +20,7 @@ export class SwitchUpdateJobActionCreator
   public create<Options extends JobActionOptions>(options: Options) {
     if (!isSwitchJobActionOptions(options)) {
       throw new Error(
-        `Invalid options for ValidateJobAction: ${JSON.stringify(options)}`,
+        `Invalid options for switch action: ${JSON.stringify(options)}`,
       );
     }
     return new SwitchJobAction<UpdateJobDto>(
@@ -39,7 +39,9 @@ export class SwitchCreateJobActionCreator
 
   public create<Options extends JobActionOptions>(options: Options) {
     if (!isSwitchJobActionOptions(options)) {
-      throw new Error("Invalid options for ValidateJobAction.");
+      throw new Error(
+        `Invalid options for switch action: ${JSON.stringify(options)}`,
+      );
     }
     return new SwitchJobAction<CreateJobDto>(
       this.moduleRef,

--- a/src/config/job-config/actions/urlaction/urlaction.service.ts
+++ b/src/config/job-config/actions/urlaction/urlaction.service.ts
@@ -13,7 +13,9 @@ export class URLJobActionCreator implements JobActionCreator<JobDto> {
 
   public create<Options extends JobActionOptions>(options: Options) {
     if (!isURLJobActionOptions(options)) {
-      throw new Error("Invalid options for URLJobAction.");
+      throw new Error(
+        `Invalid options for url action: ${JSON.stringify(options)}`,
+      );
     }
     return new URLJobAction(options);
   }

--- a/src/config/job-config/actions/validateaction/validateaction.service.ts
+++ b/src/config/job-config/actions/validateaction/validateaction.service.ts
@@ -35,7 +35,7 @@ export class ValidateCreateJobActionCreator
   public create<Options extends JobActionOptions>(options: Options) {
     if (!isValidateCreateJobActionOptions(options)) {
       throw new Error(
-        "Invalid options for validate action: ${JSON.stringify(options)}",
+        `Invalid options for validate action: ${JSON.stringify(options)}`,
       );
     }
     return new ValidateCreateJobAction(this.moduleRef, options);

--- a/src/config/job-config/jobconfig.service.ts
+++ b/src/config/job-config/jobconfig.service.ts
@@ -119,6 +119,12 @@ export class JobConfigService {
           `Unknown action type ${opt.actionType} in ${this.filePath}`,
         );
       }
+      if (!creators[opt.actionType]) {
+        // This can happen for optional dependencies like RabbitMQ
+        throw new Error(
+          `Action type ${opt.actionType} in ${this.filePath} wasn't correctly initialized`,
+        );
+      }
       return creators[opt.actionType].create(opt);
     });
     return {


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
The error message for misconfigured `switch` actions in jobConfig.yaml was copy-pasted from the validate action. This updates it to clarify the source of the error. Similar errors for other job actions have also been updated to be consistent.

## Motivation
We ran into such an error in https://github.com/paulscherrerinstitute/scicat-ci/pull/285.

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Improve error reporting from jobConfig.yaml

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

## Tests included

- [ ] Included for each change/fix? N/A
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes) N/A
- [ ] official documentation updated N/A

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
