### PR TITLE
fix: split proposal fullfacet filter query into two queries

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -1013,6 +1013,8 @@ export const proposalsFullQueryDescriptionFields =
 }\n \
   </pre>';
 
+export const proposalFullFacetExampleFields = '["email","firstname"]';
+
 export const samplesFullQueryExampleFields =
   '{"text": "some text", "metadataKey": "key", "characteristics": [{"lhs":"material","relation":"EQUAL_TO_STRING","rhs":"my material"}]}';
 

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -58,6 +58,7 @@ import {
   filterExample,
   fullQueryDescriptionLimits,
   fullQueryExampleLimits,
+  proposalFullFacetExampleFields,
   proposalsFullQueryDescriptionFields,
   proposalsFullQueryExampleFields,
 } from "src/common/utils";
@@ -547,32 +548,26 @@ export class ProposalsController {
     ability.can(Action.ProposalsRead, ProposalClass),
   )
   @Get("/fullfacet")
-  @ApiOperation({
-    summary:
-      "It returns a list of proposal facets matching the filter provided.",
-    description:
-      "It returns a list of proposal facets matching the filter provided.<br>This endpoint still needs some work on the filter and facets specification.",
-  })
-  @ApiOperation({
-    summary:
-      "It returns a list of proposal facets matching the filter provided.",
-    description:
-      "It returns a list of proposal facets matching the filter provided.<br>This endpoint still needs some work on the filter and facets specification.",
-  })
   @ApiQuery({
-    name: "filters",
+    name: "fields",
     description:
-      "Full facet query filters to apply when retrieving proposals\n" +
-      proposalsFullQueryDescriptionFields,
+      "Define the filter conditions by specifying the name of values of fields requested. There is also support for a `text` search to look for strings anywhere in the proposals.",
     required: false,
     type: String,
     example: proposalsFullQueryExampleFields,
   })
+  @ApiQuery({
+    name: "facets",
+    description: "Full facet query filters to apply when retrieving proposals",
+    required: false,
+    type: String,
+    example: proposalFullFacetExampleFields,
+  })
   @ApiResponse({
-    status: 200,
+    status: HttpStatus.OK,
     type: FullFacetResponse,
     isArray: true,
-    description: "Return proposals requested",
+    description: "Return fullfacet response for proposals requested",
   })
   async fullfacet(
     @Req() request: Request,
@@ -581,6 +576,7 @@ export class ProposalsController {
     const user: JWTUser = request.user as JWTUser;
     const fields: IProposalFields = JSON.parse(filters.fields ?? "{}");
     const facets = JSON.parse(filters.facets ?? "[]");
+
     const ability = this.caslAbilityFactory.proposalsInstanceAccess(user);
     const canViewAll = ability.can(Action.ProposalsReadAny, ProposalClass);
 


### PR DESCRIPTION
## Description
This change replaces the single @ApiQuery({ name: "filters", … }) decorator on the /fullfacet endpoint with two distinct decorators: one for fields and one for facets.

## Motivation
Previously the /fullfacet endpoint used a single @ApiQuery({ name: "filters", … }) decorator for both fields and facets. This did not align with our SDK’s expectations, which require two distinct query parameters. 

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
