### PR TITLE
fix: remove measurementPeriod inheritance

### DIFF
--- a/src/proposals/schemas/measurement-period.schema.ts
+++ b/src/proposals/schemas/measurement-period.schema.ts
@@ -1,6 +1,5 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
 import { Document } from "mongoose";
-import { QueryableClass } from "src/common/schemas/queryable.schema";
 
 export type MeasurementPeriodDocument = MeasurementPeriodClass & Document;
 

--- a/src/proposals/schemas/measurement-period.schema.ts
+++ b/src/proposals/schemas/measurement-period.schema.ts
@@ -5,7 +5,7 @@ import { QueryableClass } from "src/common/schemas/queryable.schema";
 export type MeasurementPeriodDocument = MeasurementPeriodClass & Document;
 
 @Schema()
-export class MeasurementPeriodClass extends QueryableClass {
+export class MeasurementPeriodClass {
   /**
    * Instrument or beamline identifier where measurement was pursued, e.g. /PSI/SLS/TOMCAT
    */


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This was problematic because the "[timestamps](https://mongoosejs.com/docs/guide.html#timestamps)" option is missing in the measurementsPeriod schema. The createAt and updatedAt are not defaulted when left empty. This then complains whenever using the SDK as they are checked by pydantic and missing.

I believe his could have been fixed by setting the timestamps and adding a migration script (as legacy measurements have no createdAt and updatedAt so any GET with the SDK would return error), but I don't think we require these extra properties in measurements

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* remove extends QueryableClass

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
