### PR TITLE
feat: implement DELETE datasets/{pid}/datablocks

### DIFF
--- a/src/datablocks/datablocks.service.ts
+++ b/src/datablocks/datablocks.service.ts
@@ -74,6 +74,10 @@ export class DatablocksService {
     return this.datablockModel.findOneAndDelete(filter).exec();
   }
 
+  async removeMany(filter: FilterQuery<DatablockDocument>): Promise<unknown> {
+    return this.datablockModel.deleteMany(filter).exec();
+  }
+
   async count(filter: IFilters<DatablockDocument>): Promise<CountApiResponse> {
     const whereFilter: FilterQuery<DatablockDocument> = filter.where ?? {};
 

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -2569,6 +2569,58 @@ export class DatasetsController {
     return null;
   }
 
+  // DELETE /datasets/:id/datablocks
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("datasets", (ability: AppAbility) =>
+    ability.can(Action.DatasetDatablockDelete, DatasetClass),
+  )
+  @Delete("/:pid/datablocks")
+  @ApiOperation({
+    summary: "It deletes all datablock from the dataset.",
+    description:
+      "It deletes all datablocks from the dataset.<br>This endpoint is obsolete and will be dropped in future versions.<br>Deleting datablocks will be done only from the datablocks endpoint.",
+  })
+  @ApiParam({
+    name: "pid",
+    description:
+      "Persistent identifier of the dataset for which we would like to delete the datablock specified",
+    type: String,
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    schema: {
+      type: "object",
+      properties: {
+        deletedCount: { type: "integer" },
+      },
+    },
+    description:
+      "Return the number of deleted datablocks in the following format: { deleteCount: integer }",
+  })
+  async deleteAllDatablocksFromDatasetId(
+    @Req() request: Request,
+    @Param("pid") pid: string,
+  ): Promise<unknown> {
+    const dataset = await this.checkPermissionsForDatasetExtended(
+      request,
+      pid,
+      Action.DatasetDatablockDelete,
+    );
+    if (!dataset) return null;
+    // remove datablock
+    const res = await this.datablocksService.removeMany({
+      datasetId: pid,
+    });
+    // update dataset size and files number
+    await this.datasetsService.findByIdAndUpdate(dataset.pid, {
+      packedSize: 0,
+      numberOfFilesArchived: 0,
+      size: 0,
+      numberOfFiles: 0,
+    });
+    return res;
+  }
+
   @UseGuards(PoliciesGuard)
   @CheckPolicies("datasets", (ability: AppAbility) =>
     ability.can(Action.DatasetLogbookRead, DatasetClass),

--- a/test/DerivedDatasetDatablock.js
+++ b/test/DerivedDatasetDatablock.js
@@ -5,6 +5,7 @@ const { TestData } = require("./TestData");
 describe("0750: DerivedDatasetDatablock: Test Datablocks and their relation to derived Datasets", () => {
   let accessTokenAdminIngestor = null;
   let accessTokenArchiveManager = null;
+  let accessTokenUser1 = null;
 
   let datasetPid = null;
 
@@ -23,6 +24,11 @@ describe("0750: DerivedDatasetDatablock: Test Datablocks and their relation to d
     accessTokenArchiveManager = await utils.getToken(appUrl, {
       username: "archiveManager",
       password: TestData.Accounts["archiveManager"]["password"],
+    });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
     });
   });
 
@@ -178,6 +184,110 @@ describe("0750: DerivedDatasetDatablock: Test Datablocks and their relation to d
           .property("numberOfFiles")
           .and.equal(TestData.DataBlockCorrect.dataFileList.length * 2);
       });
+  });
+
+  it("0181: should delete all datablocks without auth", async () => {
+    return request(appUrl)
+      .delete(`/api/v3/datasets/${datasetPid}/Datablocks`)
+      .set("Accept", "application/json")
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/);
+  });
+
+  it("0182: should delete all datablocks with wrong auth", async () => {
+    return request(appUrl)
+      .delete(`/api/v3/datasets/${datasetPid}/Datablocks`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/);
+  });
+
+  it("0183: should delete all datablocks with non-existing pid", async () => {
+    return request(appUrl)
+      .delete(`/api/v3/datasets/123/Datablocks`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.NotFoundStatusCode)
+      .expect("Content-Type", /json/);
+  });
+
+  [null, undefined, "", 0, false].forEach((pid, i) => {
+    it(`018${4 + i}: should delete all datablocks with ${pid} pid`, async () => {
+      return request(appUrl)
+        .delete(`/api/v3/datasets/${pid}/Datablocks`)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+        .expect(TestData.NotFoundStatusCode)
+        .expect("Content-Type", /json/);
+    });
+  });
+
+  it("0189: should delete all datablocks attached to dataset", async () => {
+    const dataset2 = await request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(TestData.DerivedCorrect)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+    const datasetPid2 = encodeURIComponent(dataset2.body["pid"]);
+
+    await request(appUrl)
+      .post(`/api/v3/datasets/${datasetPid2}/Datablocks`)
+      .send({ ...TestData.DataBlockCorrect, archiveId: "delete-all-archive1" })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+
+    await request(appUrl)
+      .post(`/api/v3/datasets/${datasetPid2}/Datablocks`)
+      .send({ ...TestData.DataBlockCorrect, archiveId: "delete-all-archive2" })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+
+    await request(appUrl)
+      .get(`/api/v3/Datasets/${datasetPid2}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("size").and.be.greaterThan(0);
+        res.body.should.have.property("packedSize").and.be.greaterThan(0);
+        res.body.should.have.property("numberOfFiles").and.be.greaterThan(0);
+        res.body.should.have.property("numberOfFilesArchived").and.be.greaterThan(0);
+      });
+
+    await request(appUrl)
+      .delete(`/api/v3/datasets/${datasetPid2}/Datablocks`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.SuccessfulDeleteStatusCode)
+      .expect("Content-Type", /json/);
+
+    await request(appUrl)
+      .get(`/api/v3/Datasets/${datasetPid2}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("size").and.equal(0);
+        res.body.should.have.property("packedSize").and.equal(0);
+        res.body.should.have.property("numberOfFiles").and.equal(0);
+        res.body.should.have.property("numberOfFilesArchived").and.equal(0);
+      });
+
+    await request(appUrl)
+      .delete(`/api/v3/Datasets/${datasetPid2}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.SuccessfulDeleteStatusCode)
+      .expect("Content-Type", /json/);
   });
 
   it("0190: should delete first datablock", async () => {

--- a/test/RawDatasetDatablock.js
+++ b/test/RawDatasetDatablock.js
@@ -5,6 +5,7 @@ const { TestData } = require("./TestData");
 describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw Datasets", () => {
   var accessTokenAdminIngestor = null;
   var accessTokenArchiveManager = null;
+  let accessTokenUser1 = null;
 
   var datasetPid = null;
   var datablockId = null;
@@ -22,6 +23,10 @@ describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw D
     accessTokenArchiveManager = await utils.getToken(appUrl, {
       username: "archiveManager",
       password: TestData.Accounts["archiveManager"]["password"],
+    });
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
     });
   });
 
@@ -193,6 +198,110 @@ describe("1800: RawDatasetDatablock: Test Datablocks and their relation to raw D
           .property("numberOfFilesArchived")
           .and.equal(TestData.DataBlockCorrect.dataFileList.length * 2);
       });
+  });
+
+  it("0081: should delete all datablocks without auth", async () => {
+    return request(appUrl)
+      .delete(`/api/v3/datasets/${datasetPid}/Datablocks`)
+      .set("Accept", "application/json")
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/);
+  });
+
+  it("0182: should delete all datablocks with wrong auth", async () => {
+    return request(appUrl)
+      .delete(`/api/v3/datasets/${datasetPid}/Datablocks`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/);
+  });
+
+  it("0083: should delete all datablocks with non-existing pid", async () => {
+    return request(appUrl)
+      .delete(`/api/v3/datasets/123/Datablocks`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.NotFoundStatusCode)
+      .expect("Content-Type", /json/);
+  });
+
+  [null, undefined, "", 0, false].forEach((pid, i) => {
+    it(`008${4 + i}: should delete all datablocks with ${pid} pid`, async () => {
+      return request(appUrl)
+        .delete(`/api/v3/datasets/${pid}/Datablocks`)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+        .expect(TestData.NotFoundStatusCode)
+        .expect("Content-Type", /json/);
+    });
+  });
+
+  it("0089: should delete all datablocks attached to dataset", async () => {
+    const dataset2 = await request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(TestData.RawCorrect)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+    const datasetPid2 = encodeURIComponent(dataset2.body["pid"]);
+
+    await request(appUrl)
+      .post(`/api/v3/datasets/${datasetPid2}/Datablocks`)
+      .send({ ...TestData.DataBlockCorrect, archiveId: "delete-all-archive1" })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+
+    await request(appUrl)
+      .post(`/api/v3/datasets/${datasetPid2}/Datablocks`)
+      .send({ ...TestData.DataBlockCorrect, archiveId: "delete-all-archive2" })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+
+    await request(appUrl)
+      .get(`/api/v3/Datasets/${datasetPid2}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("size").and.be.greaterThan(0);
+        res.body.should.have.property("packedSize").and.be.greaterThan(0);
+        res.body.should.have.property("numberOfFiles").and.be.greaterThan(0);
+        res.body.should.have.property("numberOfFilesArchived").and.be.greaterThan(0);
+      });
+
+    await request(appUrl)
+      .delete(`/api/v3/datasets/${datasetPid2}/Datablocks`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.SuccessfulDeleteStatusCode)
+      .expect("Content-Type", /json/);
+
+    await request(appUrl)
+      .get(`/api/v3/Datasets/${datasetPid2}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("size").and.equal(0);
+        res.body.should.have.property("packedSize").and.equal(0);
+        res.body.should.have.property("numberOfFiles").and.equal(0);
+        res.body.should.have.property("numberOfFilesArchived").and.equal(0);
+      });
+
+    await request(appUrl)
+      .delete(`/api/v3/Datasets/${datasetPid2}`)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.SuccessfulDeleteStatusCode)
+      .expect("Content-Type", /json/);
   });
 
   it("0090: should delete first datablock", async () => {


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Implement DELETE datasets/{pid}/datablocks

## Motivation
In our archive/retrieve scripts we sometimes need to clean space on tape and remove files. To keep scicat in sync, we remove the dataset and the attached datablocks which can be many (sometimes >1000). This PR adds an endpoint to delete all datablocks attached to a PID, in v3. In v4, this will need to be rethought, maybe leveraging this PR #1939 and providing a deleteMany and a recovery mechanism.

Follows from #2078 

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* DELETE datasets/{pid}/datablocks
* removeMany in datablocks service

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
