### PR TITLE
fix: forbid .only in Mocha tests on GitHub CI

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,4 @@
 import typescriptEslintEslintPlugin from "@typescript-eslint/eslint-plugin";
-import stylistic from "@stylistic/eslint-plugin";
 import globals from "globals";
 import tsParser from "@typescript-eslint/parser";
 import path from "node:path";
@@ -7,60 +6,77 @@ import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
 import { FlatCompat } from "@eslint/eslintrc";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
 const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all
+  baseDirectory: dirname,
+  recommendedConfig: js.configs.recommended,
+  allConfig: js.configs.all,
 });
 
-export default [...compat.extends(
+export default [
+  ...compat.extends(
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended",
     "prettier",
-), {
+  ),
+  {
     plugins: {
-        "@typescript-eslint": typescriptEslintEslintPlugin,
+      "@typescript-eslint": typescriptEslintEslintPlugin,
     },
 
     languageOptions: {
-        globals: {
-            ...globals.node,
-            ...globals.jest,
-        },
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+      },
 
-        parser: tsParser,
-        ecmaVersion: 5,
-        sourceType: "module",
+      parser: tsParser,
+      ecmaVersion: 5,
+      sourceType: "module",
 
-        parserOptions: {
-            project: "tsconfig.json",
-        },
+      parserOptions: {
+        project: "tsconfig.json",
+      },
     },
 
     rules: {
-        "@typescript-eslint/interface-name-prefix": "off",
-        "@typescript-eslint/explicit-function-return-type": "off",
-        "@typescript-eslint/explicit-module-boundary-types": "off",
+      "@typescript-eslint/interface-name-prefix": "off",
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/explicit-module-boundary-types": "off",
 
-        "@typescript-eslint/naming-convention": ["error", {
-            format: ["camelCase", "PascalCase", "snake_case", "UPPER_CASE"],
-            selector: ["variable", "function"],
-        }],
+      "@typescript-eslint/naming-convention": [
+        "error",
+        {
+          format: ["camelCase", "PascalCase", "snake_case", "UPPER_CASE"],
+          selector: ["variable", "function"],
+        },
+      ],
 
-        "@typescript-eslint/no-explicit-any": "error",
-        "@typescript-eslint/no-inferrable-types": "error",
+      "@typescript-eslint/no-explicit-any": "error",
+      "@typescript-eslint/no-inferrable-types": "error",
 
-        "quotes": ["error", "double", {
-            allowTemplateLiterals: true,
-            avoidEscape: true,
-        }],
+      quotes: [
+        "error",
+        "double",
+        {
+          allowTemplateLiterals: true,
+          avoidEscape: true,
+        },
+      ],
 
-        "no-constant-condition": ["error", {
-            checkLoops: false,
-        }],
+      "no-constant-condition": [
+        "error",
+        {
+          checkLoops: false,
+        },
+      ],
 
-        "@typescript-eslint/no-unused-vars": "warn",
+      "@typescript-eslint/no-unused-vars": "warn",
     },
-}];
+  },
+  {
+    files: ["**/*.js"],
+    languageOptions: { ecmaVersion: 2022, sourceType: "module" },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:api": "npm run test:api:jest --maxWorkers=50% && concurrently -k -s first \"wait-on http://localhost:3000/explorer/ && npm run test:api:mocha\" \"npm run start:test\"",
     "test:api:jest": "dotenv -o -e test/config/.env -e test/config/.env.override -- jest --config ./test/config/jest-e2e.json --maxWorkers=50%",
-    "test:api:mocha": "dotenv -o -e test/config/.env -e test/config/.env.override -- mocha --config ./test/config/.mocharc.json -r chai/register-should.js",
+    "test:api:mocha": "dotenv -o -e test/config/.env -e test/config/.env.override -- mocha --config ./test/config/.mocharc.js -r chai/register-should.js",
     "prepare:local": "docker-compose -f CI/E2E/docker-compose-local.yaml --env-file CI/E2E/.env.elastic-search up  -d && cp test/config/functionalAccounts.json functionalAccounts.json && cp proposalTypes.example.json proposalTypes.json"
   },
   "dependencies": {

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -104,7 +104,7 @@ describe("1110: Jobs: Test New Job Model: possible real configurations", () => {
       });
   });
 
-  it.only("0020: Add dataset 2 as Admin Ingestor", async () => {
+  it("0020: Add dataset 2 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset2)

--- a/test/Jobs.js
+++ b/test/Jobs.js
@@ -104,7 +104,7 @@ describe("1110: Jobs: Test New Job Model: possible real configurations", () => {
       });
   });
 
-  it("0020: Add dataset 2 as Admin Ingestor", async () => {
+  it.only("0020: Add dataset 2 as Admin Ingestor", async () => {
     return request(appUrl)
       .post("/api/v3/Datasets")
       .send(dataset2)

--- a/test/config/.mocharc.js
+++ b/test/config/.mocharc.js
@@ -1,0 +1,7 @@
+module.exports = {
+  recursive: true,
+  exit: true,
+  timeout: 60000,
+  file: ["./test/config/pretest.js"],
+  "forbid-only": !!process.env.GITHUB_ACTIONS,
+};

--- a/test/config/.mocharc.json
+++ b/test/config/.mocharc.json
@@ -1,6 +1,0 @@
-{
-  "recursive": true,
-  "exit": true,
-  "timeout": 60000,
-  "file": ["./test/config/pretest.js"]
-}


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This change ensures no accidental `describe.only` or `it.only` passes Github Actions pipeline
- added `forbid-only` in the Mocha configuration which is only true when runs on the github actions pipeline (GITHUB_ACTIONS=true)
- local test will not be affected 

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
