### PR TITLE
fix: returns 404 for non-existent proposal delete

### DIFF
--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -736,7 +736,7 @@ export class ProposalsController {
   // DELETE /proposals/:id
   @UseGuards(PoliciesGuard)
   @CheckPolicies("proposals", (ability: AppAbility) =>
-    ability.can(Action.ProposalsDelete, ProposalClass),
+    ability.can(Action.ProposalsRead, ProposalClass),
   )
   @Delete("/:pid")
   @ApiOperation({


### PR DESCRIPTION
## Description
Ensuring a 404 status code is returned for non existing proposals instead of 403. Cause of the bug is that the `PoliciesGuard` was checking for delete permission before the existence of the proposal could be verified.

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
