### PR TITLE
fix: add check for unauthenticated users in origdatablock v3 controller

### DIFF
--- a/src/origdatablocks/origdatablocks.controller.ts
+++ b/src/origdatablocks/origdatablocks.controller.ts
@@ -321,7 +321,9 @@ export class OrigDatablocksController {
         OrigDatablock,
       );
 
-      if (canViewAccess) {
+      if (!user) {
+        parsedFilters.where.isPublished = true;
+      } else if (canViewAccess) {
         parsedFilters.where.userGroups = parsedFilters.where.userGroups ?? [];
         parsedFilters.where.userGroups.push(...user.currentGroups);
       } else if (canViewOwner) {
@@ -382,7 +384,9 @@ export class OrigDatablocksController {
         OrigDatablock,
       );
 
-      if (canViewAccess) {
+      if (!user) {
+        fields.isPublished = true;
+      } else if (canViewAccess) {
         fields.userGroups = fields.userGroups ?? [];
         fields.userGroups.push(...user.currentGroups);
       } else if (canViewOwner) {
@@ -444,7 +448,9 @@ export class OrigDatablocksController {
         OrigDatablock,
       );
 
-      if (canViewAccess) {
+      if (!user) {
+        fields.isPublished = true;
+      } else if (canViewAccess) {
         fields.userGroups = fields.userGroups ?? [];
         fields.userGroups.push(...user.currentGroups);
       } else if (canViewOwner) {
@@ -500,7 +506,9 @@ export class OrigDatablocksController {
         OrigDatablock,
       );
 
-      if (canViewAccess) {
+      if (!user) {
+        fields.isPublished = true;
+      } else if (canViewAccess) {
         fields.userGroups = fields.userGroups ?? [];
         fields.userGroups.push(...user.currentGroups);
       } else if (canViewOwner) {
@@ -550,7 +558,9 @@ export class OrigDatablocksController {
         OrigDatablock,
       );
 
-      if (canViewAccess) {
+      if (!user) {
+        fields.isPublished = true;
+      } else if (canViewAccess) {
         fields.userGroups = fields.userGroups ?? [];
         fields.userGroups.push(...user.currentGroups);
       } else if (canViewOwner) {


### PR DESCRIPTION
## Description
Small fix to check for unauthenticated users in all readMany functions in `OrigDatablocksController`.

## Motivation
Unauthenticated users have `OrigdatablockRead` permissions, but will cause a 500 error in all readMany API functions since user.currentGroups is read when building permission-based filters.

## Fixes

* Unauthenticated users will no longer cause 500 errors, instead only get access to public ODBs

## Tests included

- [x] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [x] swagger documentation updated (required for API changes)
- [x] official documentation updated