### PR TITLE
fix: avoid changing the object types masking

### DIFF
--- a/src/common/interceptors/mask-sensitive-data.interceptor.ts
+++ b/src/common/interceptors/mask-sensitive-data.interceptor.ts
@@ -6,44 +6,43 @@ import {
   NestInterceptor,
 } from "@nestjs/common";
 import { APP_INTERCEPTOR } from "@nestjs/core";
-import { instanceToPlain } from "class-transformer";
 import { isEmail } from "class-validator";
 import { map, Observable } from "rxjs";
 
 @Injectable()
 class MaskSensitiveDataInterceptor implements NestInterceptor {
-  private maskSensitiveData<T>(data: T, ownEmail: string): T {
+  private maskSensitiveData<T>(
+    data: T,
+    ownEmail: string,
+    seen = new WeakSet(),
+  ): T {
+    if (seen.has(data as object)) return data;
+    if (!this.isPlainObject(data) && !Array.isArray(data)) return data;
     if (Array.isArray(data)) {
-      let allArrays = true;
       const maskedData = data.map((item) => {
         if (this.isToMaskEmail(item, ownEmail)) {
           return this.maskValue();
         }
-        allArrays = false;
-        return this.maskSensitiveData(item, ownEmail);
+        return this.maskSensitiveData(item, ownEmail, seen);
       });
-      return ((allArrays && [...new Set(maskedData)]) || maskedData) as T;
+      data.length = 0;
+      data.push(...new Set(maskedData));
+      return data;
     }
 
-    if (!this.isPlainObject(data)) return data as T;
-    const result: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(data)) {
+    seen.add(data as object);
+    for (const [key, value] of Object.entries(data as object)) {
       if (this.isToMaskEmail(value, ownEmail)) {
-        result[key] = this.maskValue();
+        (data as Record<string, unknown>)[key] = this.maskValue();
         continue;
       }
-      result[key] = this.maskSensitiveData(value, ownEmail);
+      this.maskSensitiveData(value, ownEmail, seen);
     }
-    return result as T;
+    return data;
   }
 
-  private isPlainObject(input: unknown): input is Record<string, unknown> {
-    return (
-      typeof input === "object" &&
-      input !== null &&
-      !Array.isArray(input) &&
-      Object.getPrototypeOf(input) === Object.prototype
-    );
+  private isPlainObject<T>(input: T): boolean {
+    return typeof input === "object" && input !== null;
   }
 
   private isToMaskEmail(value: string | unknown, ownEmail: string) {
@@ -54,35 +53,12 @@ class MaskSensitiveDataInterceptor implements NestInterceptor {
     return "*****";
   }
 
-  private toPlain<
-    T extends { toObject?: (options?: { virtuals?: boolean }) => object },
-  >(value: T): T {
-    if (Array.isArray(value)) {
-      return value.map((item) => this.toPlain(item)) as unknown as T;
-    }
-
-    if (value && typeof value === "object") {
-      if (typeof value.toObject === "function") {
-        return value.toObject({ virtuals: true }) as T;
-      }
-
-      try {
-        return instanceToPlain(value) as T;
-      } catch {
-        return value;
-      }
-    }
-
-    return value;
-  }
-
   intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
     const request = context.switchToHttp().getRequest();
     const ownEmail = request.user?.email;
     return next.handle().pipe(
       map((data) => {
-        const plainData = this.toPlain(data);
-        return this.maskSensitiveData(plainData, ownEmail);
+        return this.maskSensitiveData(data, ownEmail);
       }),
     );
   }

--- a/test/jest-e2e-tests/hidePersonalInfo.e2e-spec.ts
+++ b/test/jest-e2e-tests/hidePersonalInfo.e2e-spec.ts
@@ -53,6 +53,9 @@ describe("HidePersonalInfo test", () => {
       creationLocation: faker.location.city(),
       sampleId: "sample123",
       accessGroups: [faker.internet.email(), faker.internet.email()],
+      datasetlifecycle: {
+        _id: "68b85b9cf830ebdccde06a0e",
+      },
     };
 
     await request(app.getHttpServer())
@@ -77,7 +80,10 @@ describe("HidePersonalInfo test", () => {
         (result) => (
           expect(result.body[0].contactEmail).toEqual("*****"),
           expect(result.body[0].ownerEmail).toEqual("admin@scicat.project"),
-          expect(result.body[0].accessGroups).toEqual(["*****"])
+          expect(result.body[0].accessGroups).toEqual(["*****"]),
+          expect(result.body[0].datasetlifecycle._id).toEqual(
+            "68b85b9cf830ebdccde06a0e",
+          )
         ),
       );
   });


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This fixes the bug reported [here](https://github.com/paulscherrerinstitute/scicat-ci/issues/336). It was due to instanceToPlain applying the schema definition of lifecycle class which misses the _id def, which converted it to a buffer. This rewrite, being more generic, avoids changing the object with "toPlain" and replaces the emails inplace, checking the recursion with a weakSet. Without the weakSet, mongoose goes into recursion error as mongoose references itself infenitely 

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* avoid running toPlain that has side effects
* simplify recursion

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
