### PR TITLE
fix(test): skip DataCite intergartion tests until properly mocked

### DIFF
--- a/test/PublishedDataV4.js
+++ b/test/PublishedDataV4.js
@@ -37,6 +37,10 @@ const nonpublictestdataset = {
   ...TestData.RawCorrect,
   ownerGroup: "examplenonpublicgroup",
 };
+// Temporary fix:
+const hasDataCiteSecrets =
+  process.env.DOI_PASSWORD !== undefined ||
+  process.env.DOI_USERNAME !== undefined;
 
 describe("1600: PublishedDataV4: Test of access to published data v4 endpoints", () => {
   before(() => {
@@ -148,57 +152,71 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
         res.body.should.have.property("status").and.equal("public");
       });
   });
+  (hasDataCiteSecrets ? it : it.skip)(
+    "0050: should register this new published data",
+    async () => {
+      return request(appUrl)
+        .post("/api/v4/PublishedData/" + doi + "/register")
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode)
+        .expect("Content-Type", /json/);
+    },
+  );
 
-  it("0050: should register this new published data", async () => {
-    return request(appUrl)
-      .post("/api/v4/PublishedData/" + doi + "/register")
-      .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
-      .expect(TestData.EntryCreatedStatusCode)
-      .expect("Content-Type", /json/);
-  });
+  (hasDataCiteSecrets ? it : it.skip)(
+    "0055: should fetch this new published data",
+    async () => {
+      return request(appUrl)
+        .get("/api/v4/PublishedData/" + doi)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("status").and.equal("registered");
+        });
+    },
+  );
 
-  it("0055: should fetch this new published data", async () => {
-    return request(appUrl)
-      .get("/api/v4/PublishedData/" + doi)
-      .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
-      .expect(TestData.SuccessfulGetStatusCode)
-      .expect("Content-Type", /json/)
-      .then((res) => {
-        res.body.should.have.property("status").and.equal("registered");
-      });
-  });
+  (hasDataCiteSecrets ? it : it.skip)(
+    "0056: should not be able to delete published data in registrated",
+    async () => {
+      return request(appUrl)
+        .delete("/api/v4/PublishedData/" + doi)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+        .expect(TestData.BadRequestStatusCode)
+        .expect("Content-Type", /json/);
+    },
+  );
 
-  it("0056: should not be able to delete published data in registrated", async () => {
-    return request(appUrl)
-      .delete("/api/v4/PublishedData/" + doi)
-      .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
-      .expect(TestData.BadRequestStatusCode)
-      .expect("Content-Type", /json/);
-  });
+  (hasDataCiteSecrets ? it : it.skip)(
+    "0060: should amend this new registered published data",
+    async () => {
+      return request(appUrl)
+        .post("/api/v4/PublishedData/" + doi + "/amend")
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode)
+        .expect("Content-Type", /json/);
+    },
+  );
 
-  it("0060: should amend this new registered published data", async () => {
-    return request(appUrl)
-      .post("/api/v4/PublishedData/" + doi + "/amend")
-      .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
-      .expect(TestData.EntryCreatedStatusCode)
-      .expect("Content-Type", /json/);
-  });
-
-  it("0065: should fetch this amended published data", async () => {
-    return request(appUrl)
-      .get("/api/v4/PublishedData/" + doi)
-      .set("Accept", "application/json")
-      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
-      .expect(TestData.SuccessfulGetStatusCode)
-      .expect("Content-Type", /json/)
-      .then((res) => {
-        res.body.should.have.property("status").and.equal("amended");
-      });
-  });
+  (hasDataCiteSecrets ? it : it.skip)(
+    "0065: should fetch this amended published data",
+    async () => {
+      return request(appUrl)
+        .get("/api/v4/PublishedData/" + doi)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("status").and.equal("amended");
+        });
+    },
+  );
 
   it("0080: adds a new nonpublic dataset", async () => {
     return request(appUrl)

--- a/test/PublishedDataV4.js
+++ b/test/PublishedDataV4.js
@@ -39,8 +39,10 @@ const nonpublictestdataset = {
 };
 // Temporary fix:
 const hasDataCiteSecrets =
-  process.env.DOI_PASSWORD !== undefined ||
-  process.env.DOI_USERNAME !== undefined;
+  process.env.DOI_PASSWORD &&
+  process.env.DOI_USERNAME &&
+  process.env.DOI_PASSWORD !== "" &&
+  process.env.DOI_USERNAME !== "";
 
 describe("1600: PublishedDataV4: Test of access to published data v4 endpoints", () => {
   before(() => {


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
When PR's a coming from the forks ( or run locally) secrets to datacite aren't available to all of collaborators and some of the PublishedDataV4 tests fail.
This PR skips the tests that depend on this integration (secrets aren't available in the .env).

This is a temporary fix and should be mocked properly with jest.

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
