### PR TITLE
fix(dataset): proper error handling for field projections

### DIFF
--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -417,13 +417,12 @@ export const parsePipelineSort = (sort: Record<string, "asc" | "desc">) => {
 export const parsePipelineProjection = (fieldsProjection: string[]) => {
   const pipelineProjection: Record<string, boolean> = {};
 
-  if (Array.isArray(fieldsProjection)) {
-    fieldsProjection.forEach((field) => {
-      pipelineProjection[field] = true;
-    });
-  } else {
-    return fieldsProjection;
+  if (!Array.isArray(fieldsProjection)) {
+    throw new HttpException("fields must be an array", HttpStatus.BAD_REQUEST);
   }
+  fieldsProjection.forEach((field) => {
+    pipelineProjection[field] = true;
+  });
 
   return pipelineProjection;
 };

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -416,9 +416,14 @@ export const parsePipelineSort = (sort: Record<string, "asc" | "desc">) => {
 
 export const parsePipelineProjection = (fieldsProjection: string[]) => {
   const pipelineProjection: Record<string, boolean> = {};
-  fieldsProjection.forEach((field) => {
-    pipelineProjection[field] = true;
-  });
+
+  if (Array.isArray(fieldsProjection)) {
+    fieldsProjection.forEach((field) => {
+      pipelineProjection[field] = true;
+    });
+  } else {
+    return fieldsProjection;
+  }
 
   return pipelineProjection;
 };

--- a/test/DatasetV4.js
+++ b/test/DatasetV4.js
@@ -642,6 +642,30 @@ describe("2500: Datasets v4 tests", () => {
             );
         });
     });
+
+    it("0210: should be able to fetch the datasets providing where filter using object format", async () => {
+      const filter = {
+        where: {
+          owner : TestData.RawCorrectMinV4.owner
+        },
+        fields: {pid: true, owner: true}
+      };
+
+      return request(appUrl)
+        .get(`/api/v4/datasets`)
+        .query({ filter: JSON.stringify(filter) })
+        .auth(accessTokenAdminIngestor, { type: "bearer" })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.a("array");
+          res.body.forEach((dataset) => {
+            dataset.should.have.property("pid")
+            dataset.should.have.property("owner").and.equal(TestData.RawCorrectMinV4.owner);
+            dataset.should.not.have.property("description");
+          });
+        });
+    });
   });
 
   describe("Datasets v4 findOne tests", () => {

--- a/test/DatasetV4.js
+++ b/test/DatasetV4.js
@@ -642,30 +642,6 @@ describe("2500: Datasets v4 tests", () => {
             );
         });
     });
-
-    it("0210: should be able to fetch the datasets providing where filter using object format", async () => {
-      const filter = {
-        where: {
-          owner : TestData.RawCorrectMinV4.owner
-        },
-        fields: {pid: true, owner: true}
-      };
-
-      return request(appUrl)
-        .get(`/api/v4/datasets`)
-        .query({ filter: JSON.stringify(filter) })
-        .auth(accessTokenAdminIngestor, { type: "bearer" })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.a("array");
-          res.body.forEach((dataset) => {
-            dataset.should.have.property("pid")
-            dataset.should.have.property("owner").and.equal(TestData.RawCorrectMinV4.owner);
-            dataset.should.not.have.property("description");
-          });
-        });
-    });
   });
 
   describe("Datasets v4 findOne tests", () => {


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Fixes the dataset API to throw an error message if users try to use object format.

## Motivation
When users requested fields using object format `({"pid": true, "owner": true})`, it would throw a 500 error because it expected array format only.

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
