### PR TITLE
feat(proposal): add numberOfDatasets field and sync on dataset changes with migration script

### DIFF
--- a/migrations/20250924140500-add-numberofdatasets-to-proposal.js
+++ b/migrations/20250924140500-add-numberofdatasets-to-proposal.js
@@ -1,0 +1,22 @@
+module.exports = {
+  async up(db, client) {
+    
+    const proposals = await db.collection("Proposal").find({}).toArray();
+
+    for (const proposal of proposals) {
+      
+      const datasetCount = await db
+        .collection("Dataset")
+        .countDocuments({ proposalIds: proposal.proposalId });
+
+      await db.collection("Proposal").updateOne(
+        { _id: proposal._id },
+        { $set: { numberOfDatasets: datasetCount } }
+      );
+    }
+  },
+
+  async down(db, client) {
+    // No path backward
+  },
+};

--- a/src/datasets/datasets.module.ts
+++ b/src/datasets/datasets.module.ts
@@ -22,6 +22,7 @@ import {
 } from "src/common/schemas/generic-history.schema";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { applyHistoryPluginOnce } from "src/common/mongoose/plugins/history.plugin.util";
+import { ProposalsModule } from "src/proposals/proposals.module";
 
 @Module({
   imports: [
@@ -31,6 +32,7 @@ import { applyHistoryPluginOnce } from "src/common/mongoose/plugins/history.plug
     OrigDatablocksModule,
     InitialDatasetsModule,
     ElasticSearchModule,
+    ProposalsModule,
     forwardRef(() => LogbooksModule),
     MongooseModule.forFeatureAsync([
       {

--- a/src/datasets/datasets.service.spec.ts
+++ b/src/datasets/datasets.service.spec.ts
@@ -9,6 +9,7 @@ import { DatasetsService } from "./datasets.service";
 import { DatasetClass } from "./schemas/dataset.schema";
 import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { DatasetsAccessService } from "./datasets-access.service";
+import { ProposalsService } from "src/proposals/proposals.service";
 
 class InitialDatasetsServiceMock {}
 
@@ -17,6 +18,8 @@ class LogbooksServiceMock {}
 class CaslAbilityFactoryMock {}
 
 class ElasticSearchServiceMock {}
+
+class ProposalsServiceMock {}
 
 const mockDataset: DatasetClass = {
   _id: "testId",
@@ -113,6 +116,7 @@ describe("DatasetsService", () => {
         { provide: LogbooksService, useClass: LogbooksServiceMock },
         { provide: ElasticSearchService, useClass: ElasticSearchServiceMock },
         { provide: CaslAbilityFactory, useClass: CaslAbilityFactoryMock },
+        { provide: ProposalsService, useClass: ProposalsServiceMock },
       ],
     }).compile();
 

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -104,8 +104,10 @@ export class DatasetsService {
 
     const savedDataset = await createdDataset.save();
 
-    if(savedDataset.proposalIds){
-      await this.proposalService.incrementNumberOfDatasets(savedDataset.proposalIds);
+    if (savedDataset.proposalIds) {
+      await this.proposalService.incrementNumberOfDatasets(
+        savedDataset.proposalIds,
+      );
     }
 
     return savedDataset;
@@ -393,10 +395,14 @@ export class DatasetsService {
     if (this.ESClient) {
       await this.ESClient.deleteDocument(id);
     }
-    const deletedDataset = await this.datasetModel.findOneAndDelete({ pid: id });
+    const deletedDataset = await this.datasetModel.findOneAndDelete({
+      pid: id,
+    });
 
     if (deletedDataset?.proposalIds) {
-      await this.proposalService.decrementNumberOfDatasets(deletedDataset.proposalIds);
+      await this.proposalService.decrementNumberOfDatasets(
+        deletedDataset.proposalIds,
+      );
     }
     return deletedDataset;
   }

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -104,7 +104,7 @@ export class DatasetsService {
 
     const savedDataset = await createdDataset.save();
 
-    if (savedDataset.proposalIds) {
+    if (savedDataset.proposalIds && savedDataset.proposalIds.length > 0) {
       await this.proposalService.incrementNumberOfDatasets(
         savedDataset.proposalIds,
       );
@@ -399,7 +399,7 @@ export class DatasetsService {
       pid: id,
     });
 
-    if (deletedDataset?.proposalIds) {
+    if (deletedDataset?.proposalIds && deletedDataset.proposalIds.length > 0) {
       await this.proposalService.decrementNumberOfDatasets(
         deletedDataset.proposalIds,
       );

--- a/src/datasets/datasets.v4.controller.spec.ts
+++ b/src/datasets/datasets.v4.controller.spec.ts
@@ -12,7 +12,6 @@ class CaslAbilityFactoryMock {}
 
 class LogbooksServiceMock {}
 
-
 describe("DatasetsController", () => {
   let controller: DatasetsV4Controller;
 

--- a/src/datasets/datasets.v4.controller.spec.ts
+++ b/src/datasets/datasets.v4.controller.spec.ts
@@ -5,12 +5,15 @@ import { ConfigModule } from "@nestjs/config";
 import { DatasetsV4Controller } from "./datasets.v4.controller";
 import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { HttpModule } from "@nestjs/axios";
+import { ProposalsService } from "src/proposals/proposals.service";
 
 class DatasetsServiceMock {}
 
 class CaslAbilityFactoryMock {}
 
 class LogbooksServiceMock {}
+
+class ProposalsServiceMock {}
 
 describe("DatasetsController", () => {
   let controller: DatasetsV4Controller;
@@ -23,6 +26,7 @@ describe("DatasetsController", () => {
         { provide: LogbooksService, useClass: LogbooksServiceMock },
         { provide: DatasetsService, useClass: DatasetsServiceMock },
         { provide: CaslAbilityFactory, useClass: CaslAbilityFactoryMock },
+        { provide: ProposalsService, useClass: ProposalsServiceMock },
       ],
     }).compile();
 

--- a/src/datasets/datasets.v4.controller.spec.ts
+++ b/src/datasets/datasets.v4.controller.spec.ts
@@ -5,7 +5,6 @@ import { ConfigModule } from "@nestjs/config";
 import { DatasetsV4Controller } from "./datasets.v4.controller";
 import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { HttpModule } from "@nestjs/axios";
-import { ProposalsService } from "src/proposals/proposals.service";
 
 class DatasetsServiceMock {}
 
@@ -13,7 +12,6 @@ class CaslAbilityFactoryMock {}
 
 class LogbooksServiceMock {}
 
-class ProposalsServiceMock {}
 
 describe("DatasetsController", () => {
   let controller: DatasetsV4Controller;
@@ -26,7 +24,6 @@ describe("DatasetsController", () => {
         { provide: LogbooksService, useClass: LogbooksServiceMock },
         { provide: DatasetsService, useClass: DatasetsServiceMock },
         { provide: CaslAbilityFactory, useClass: CaslAbilityFactoryMock },
-        { provide: ProposalsService, useClass: ProposalsServiceMock },
       ],
     }).compile();
 

--- a/src/proposals/proposals.service.ts
+++ b/src/proposals/proposals.service.ts
@@ -140,4 +140,19 @@ export class ProposalsService {
   async remove(filter: FilterQuery<ProposalDocument>): Promise<unknown> {
     return this.proposalModel.findOneAndDelete(filter).exec();
   }
+
+  async incrementNumberOfDatasets(proposalIds: string[]) {
+    await this.proposalModel.updateMany(
+        { proposalId: { $in: proposalIds } },
+        { $inc: { numberOfDatasets: 1 } },
+      );
+  }
+
+  async decrementNumberOfDatasets(proposalIds: string[]) {
+    await this.proposalModel.updateMany(
+        { proposalId: { $in: proposalIds } },
+        { $inc: { numberOfDatasets: -1 } },
+      );
+  }
+
 }

--- a/src/proposals/proposals.service.ts
+++ b/src/proposals/proposals.service.ts
@@ -143,16 +143,15 @@ export class ProposalsService {
 
   async incrementNumberOfDatasets(proposalIds: string[]) {
     await this.proposalModel.updateMany(
-        { proposalId: { $in: proposalIds } },
-        { $inc: { numberOfDatasets: 1 } },
-      );
+      { proposalId: { $in: proposalIds } },
+      { $inc: { numberOfDatasets: 1 } },
+    );
   }
 
   async decrementNumberOfDatasets(proposalIds: string[]) {
     await this.proposalModel.updateMany(
-        { proposalId: { $in: proposalIds } },
-        { $inc: { numberOfDatasets: -1 } },
-      );
+      { proposalId: { $in: proposalIds } },
+      { $inc: { numberOfDatasets: -1 } },
+    );
   }
-
 }

--- a/src/proposals/schemas/proposal.schema.ts
+++ b/src/proposals/schemas/proposal.schema.ts
@@ -176,11 +176,11 @@ export class ProposalClass extends OwnableClass {
    * Number of datasets associated with the proposal.
    */
   @Prop({
-   type: Number,
-   default: 0,
-   required: false,
- })
- numberOfDatasets?: number;
+    type: Number,
+    default: 0,
+    required: false,
+  })
+  numberOfDatasets?: number;
 }
 
 export const ProposalSchema = SchemaFactory.createForClass(ProposalClass);

--- a/src/proposals/schemas/proposal.schema.ts
+++ b/src/proposals/schemas/proposal.schema.ts
@@ -171,6 +171,16 @@ export class ProposalClass extends OwnableClass {
     required: false,
   })
   instrumentIds?: string[];
+
+  /**
+   * Number of datasets associated with the proposal.
+   */
+  @Prop({
+   type: Number,
+   default: 0,
+   required: false,
+ })
+ numberOfDatasets?: number;
 }
 
 export const ProposalSchema = SchemaFactory.createForClass(ProposalClass);

--- a/test/DatasetV4.js
+++ b/test/DatasetV4.js
@@ -412,7 +412,7 @@ describe("2500: Datasets v4 tests", () => {
       proposal.body.should.have.property("numberOfDatasets").and.equal(0);
     });
 
-    it.only("0130: should not increment or decrement numberOfDatasets when proposalIds is empty or undefined", async () => {
+    it("0130: should not increment or decrement numberOfDatasets when proposalIds is empty or undefined", async () => {
       const proposalBody = {
         ...TestData.ProposalCorrectMin,
         proposalId: "test0130",

--- a/test/DatasetV4.js
+++ b/test/DatasetV4.js
@@ -7,7 +7,6 @@ let accessTokenAdminIngestor = null,
   accessTokenArchiveManager = null,
   accessTokenUser1 = null,
   accessTokenUser2 = null,
-
   derivedDatasetMinPid = null,
   rawDatasetWithMetadataPid = null,
   datasetScientificPid = null,
@@ -353,6 +352,29 @@ describe("2500: Datasets v4 tests", () => {
           rawDatasetWithMetadataPid = res.body.pid;
         });
     });
+
+    it("0128: should increment numberOfDatasets in linked proposals when creating a new dataset", async () => {
+      const proposalRes = await request(appUrl)
+        .post("/api/v3/Proposals")
+        .send(TestData.ProposalCorrectMin)
+        .auth(accessTokenAdminIngestor, { type: "bearer" });
+      const proposalId = proposalRes.body.proposalId;
+
+      const dataset = {
+        ...TestData.DerivedCorrectMinV4,
+        proposalIds: [proposalId],
+      };
+      await request(appUrl)
+        .post("/api/v4/datasets")
+        .send(dataset)
+        .auth(accessTokenAdminIngestor, { type: "bearer" });
+
+      const proposal = await request(appUrl)
+        .get(`/api/v3/Proposals/${encodeURIComponent(proposalId)}`)
+        .auth(accessTokenAdminIngestor, { type: "bearer" });
+      console.log("numberOfDatasets: ", JSON.stringify(proposal.body.numberOfDatasets, null, 2));
+      proposal.body.should.have.property("numberOfDatasets").and.equal(1);
+    });
   });
 
   describe("Datasets v4 findAll tests", () => {
@@ -626,7 +648,7 @@ describe("2500: Datasets v4 tests", () => {
         },
       };
       const malformedJson = JSON.stringify(filter).replace("}", "},");
-      
+
       return request(appUrl)
         .get(`/api/v4/datasets`)
         .query({ filter: malformedJson })
@@ -1038,7 +1060,7 @@ describe("2500: Datasets v4 tests", () => {
 
     it("0604: should be able to partially update dataset's scientific metadata field", () => {
       const updatedDataset = {
-        datasetlifecycle:{storageLocation:"new location"},
+        datasetlifecycle: { storageLocation: "new location" },
         scientificMetadata: {
           with_unit_and_value_si: {
             value: 600,
@@ -1070,7 +1092,9 @@ describe("2500: Datasets v4 tests", () => {
             value: 111,
             unit: "",
           });
-          res.body.datasetlifecycle.should.have.property("storageLocation").and.equal("new location");
+          res.body.datasetlifecycle.should.have
+            .property("storageLocation")
+            .and.equal("new location");
         });
     });
 
@@ -1457,7 +1481,9 @@ describe("2500: Datasets v4 tests", () => {
         .then((res) => {
           res.body.should.be.a("object");
           res.body.should.be.deep.include(updatedDataset);
-          res.body.should.have.property("storageLocation").and.equal("new location");
+          res.body.should.have
+            .property("storageLocation")
+            .and.equal("new location");
         });
     });
 


### PR DESCRIPTION
## Description
This PR adds a `numberOfDatasets` field to the proposal schema and ensures it is incremented or decremented whenever datasets are created or deleted. It also includes a migration script to calculate and populate the `numberOfDatasets` field for existing proposals.

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
