### PR TITLE
feat: enable scoped search on relations

### DIFF
--- a/src/attachments/interfaces/attachment-filters.interface.ts
+++ b/src/attachments/interfaces/attachment-filters.interface.ts
@@ -1,5 +1,4 @@
-import { FilterQuery } from "mongoose";
-import { ILimitsFilter } from "src/common/interfaces/common.interface";
+import { IFiltersV4 } from "src/common/interfaces/common.interface";
 import { AttachmentRelationshipsV4Dto } from "../dto/attachment-relationships.v4.dto";
 
 export interface IAttachmentFields {
@@ -18,8 +17,7 @@ export interface IAttachmentFields {
   [key: string]: unknown;
 }
 
-export interface IAttachmentFiltersV4<T, Y = null> {
-  where?: FilterQuery<T>;
-  fields?: Y;
-  limits?: ILimitsFilter;
-}
+export type IAttachmentFiltersV4<T, Y = null> = Omit<
+  IFiltersV4<T, Y>,
+  "include"
+>;

--- a/src/common/interfaces/common.interface.ts
+++ b/src/common/interfaces/common.interface.ts
@@ -68,3 +68,15 @@ export interface IDatafileFilter {
   perm?: string;
   type?: string;
 }
+
+export type IFiltersV4<T, Y = null, Z = null> = IFilters<T, Y> & {
+  include?: Z;
+  limits?: ILimitsV4<T>;
+  fields?: (keyof Y)[];
+};
+
+export interface ILimitsV4<T = null> {
+  limit: number;
+  skip: number;
+  sort: Record<keyof T, "asc" | "desc">;
+}

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -38,7 +38,11 @@ import {
   PartialUpdateDatasetWithHistoryDto,
   UpdateDatasetDto,
 } from "./dto/update-dataset.dto";
-import { IDatasetFields } from "./interfaces/dataset-filters.interface";
+import {
+  IDatasetFields,
+  IDatasetFiltersV4,
+  IDatasetRelation,
+} from "./interfaces/dataset-filters.interface";
 import { DatasetClass, DatasetDocument } from "./schemas/dataset.schema";
 import {
   DATASET_LOOKUP_FIELDS,
@@ -64,25 +68,71 @@ export class DatasetsService {
 
   addLookupFields(
     pipeline: PipelineStage[],
-    datasetLookupFields?: DatasetLookupKeysEnum[],
+    datasetLookupFields?:
+      | DatasetLookupKeysEnum[]
+      | IDatasetRelation<DatasetDocument, IDatasetFields>[],
   ) {
-    if (datasetLookupFields?.includes(DatasetLookupKeysEnum.all)) {
-      datasetLookupFields = Object.keys(DATASET_LOOKUP_FIELDS).filter(
-        (field) => field !== DatasetLookupKeysEnum.all,
-      ) as DatasetLookupKeysEnum[];
-    }
+    const relationsAndScopes =
+      this.extractRelationsAndScopes(datasetLookupFields);
 
-    datasetLookupFields?.forEach((field) => {
+    const scopes = relationsAndScopes.scopes;
+    for (const field of relationsAndScopes.relations) {
       const fieldValue = structuredClone(DATASET_LOOKUP_FIELDS[field]);
+      if (!fieldValue) continue;
+      fieldValue.$lookup.as = field;
+      const scope = scopes[field];
 
-      if (fieldValue) {
-        fieldValue.$lookup.as = field;
+      this.datasetsAccessService.addRelationFieldAccess(fieldValue);
 
-        this.datasetsAccessService.addRelationFieldAccess(fieldValue);
+      const includePipeline = [];
+      if (scope?.where) includePipeline.push({ $match: scope.where });
+      if (scope?.fields)
+        includePipeline.push({
+          $project: parsePipelineProjection(scope.fields as string[]),
+        });
+      if (scope?.limits?.skip)
+        includePipeline.push({ $skip: scope.limits.skip });
+      if (scope?.limits?.limit)
+        includePipeline.push({ $limit: scope.limits.limit });
 
-        pipeline.push(fieldValue);
+      if (includePipeline.length > 0)
+        fieldValue.$lookup.pipeline = (
+          fieldValue.$lookup.pipeline ?? []
+        ).concat(includePipeline);
+
+      pipeline.push(fieldValue);
+    }
+  }
+
+  private extractRelationsAndScopes(
+    datasetLookupFields:
+      | DatasetLookupKeysEnum[]
+      | IDatasetRelation<DatasetDocument, IDatasetFields>[]
+      | undefined,
+  ) {
+    const scopes = {} as Record<
+      DatasetLookupKeysEnum,
+      IDatasetFiltersV4<DatasetDocument, IDatasetFields>
+    >;
+    const fieldsList: DatasetLookupKeysEnum[] = [];
+    let isAll = false;
+    datasetLookupFields?.forEach((f) => {
+      if (typeof f === "object" && "relation" in f) {
+        fieldsList.push(f.relation);
+        scopes[f.relation] = f.scope;
+        isAll = f.relation === DatasetLookupKeysEnum.all;
+        return;
       }
+      isAll = f === DatasetLookupKeysEnum.all;
+      fieldsList.push(f);
     });
+
+    const relations = isAll
+      ? (Object.keys(DATASET_LOOKUP_FIELDS).filter(
+          (field) => field !== DatasetLookupKeysEnum.all,
+        ) as DatasetLookupKeysEnum[])
+      : fieldsList;
+    return { scopes, relations };
   }
 
   async create(createDatasetDto: CreateDatasetDto): Promise<DatasetDocument> {
@@ -119,10 +169,10 @@ export class DatasetsService {
   }
 
   async findAllComplete(
-    filter: FilterQuery<DatasetDocument>,
+    filter: IDatasetFiltersV4<DatasetDocument, IDatasetFields>,
   ): Promise<PartialOutputDatasetDto[]> {
     const whereFilter: FilterQuery<DatasetDocument> = filter.where ?? {};
-    const fieldsProjection: string[] = filter.fields ?? {};
+    const fieldsProjection = (filter.fields ?? []) as string[];
     const limits: QueryOptions<DatasetDocument> = filter.limits ?? {
       limit: 10,
       skip: 0,

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -42,6 +42,7 @@ import {
   IDatasetFields,
   IDatasetFiltersV4,
   IDatasetRelation,
+  IDatasetScopes,
 } from "./interfaces/dataset-filters.interface";
 import { DatasetClass, DatasetDocument } from "./schemas/dataset.schema";
 import {
@@ -68,9 +69,7 @@ export class DatasetsService {
 
   addLookupFields(
     pipeline: PipelineStage[],
-    datasetLookupFields?:
-      | DatasetLookupKeysEnum[]
-      | IDatasetRelation<DatasetDocument, IDatasetFields>[],
+    datasetLookupFields?: DatasetLookupKeysEnum[] | IDatasetRelation[],
   ) {
     const relationsAndScopes =
       this.extractRelationsAndScopes(datasetLookupFields);
@@ -111,13 +110,10 @@ export class DatasetsService {
   private extractRelationsAndScopes(
     datasetLookupFields:
       | DatasetLookupKeysEnum[]
-      | IDatasetRelation<DatasetDocument, IDatasetFields>[]
+      | IDatasetRelation[]
       | undefined,
   ) {
-    const scopes = {} as Record<
-      DatasetLookupKeysEnum,
-      IDatasetFiltersV4<DatasetDocument, IDatasetFields>
-    >;
+    const scopes = {} as Record<DatasetLookupKeysEnum, IDatasetScopes>;
     const fieldsList: DatasetLookupKeysEnum[] = [];
     let isAll = false;
     datasetLookupFields?.forEach((f) => {
@@ -177,7 +173,7 @@ export class DatasetsService {
   ): Promise<PartialOutputDatasetDto[]> {
     const whereFilter: FilterQuery<DatasetDocument> = filter.where ?? {};
     const fieldsProjection = (filter.fields ?? []) as string[];
-    const limits: QueryOptions<DatasetDocument> = filter.limits ?? {
+    const limits = filter.limits ?? {
       limit: 10,
       skip: 0,
       sort: { createdAt: "desc" },

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -94,6 +94,10 @@ export class DatasetsService {
         includePipeline.push({ $skip: scope.limits.skip });
       if (scope?.limits?.limit)
         includePipeline.push({ $limit: scope.limits.limit });
+      if (scope?.limits?.sort) {
+        const sort = parsePipelineSort(scope.limits.sort);
+        pipeline.push({ $sort: sort });
+      }
 
       if (includePipeline.length > 0)
         fieldValue.$lookup.pipeline = (

--- a/src/datasets/interfaces/dataset-filters.interface.ts
+++ b/src/datasets/interfaces/dataset-filters.interface.ts
@@ -1,8 +1,5 @@
 import { FilterQuery } from "mongoose";
-import {
-  ILimitsFilter,
-  IScientificFilter,
-} from "src/common/interfaces/common.interface";
+import { IScientificFilter } from "src/common/interfaces/common.interface";
 import { DatasetLookupKeysEnum } from "../types/dataset-lookup";
 
 export interface IDatasetFields {
@@ -35,5 +32,11 @@ export interface IDatasetFiltersV4<T, Y = null> {
   where?: FilterQuery<T>;
   include?: DatasetLookupKeysEnum[] | IDatasetRelation<T, Y>[];
   fields?: (keyof Y)[];
-  limits?: ILimitsFilter;
+  limits?: IDatasetLimitsV4<T>;
+}
+
+interface IDatasetLimitsV4<T> {
+  limit: number;
+  skip: number;
+  sort: Record<keyof T, "asc" | "desc">;
 }

--- a/src/datasets/interfaces/dataset-filters.interface.ts
+++ b/src/datasets/interfaces/dataset-filters.interface.ts
@@ -26,9 +26,14 @@ export interface IDatasetFields {
   [key: string]: unknown;
 }
 
+export interface IDatasetRelation<T, Y = null> {
+  relation: DatasetLookupKeysEnum;
+  scope: IDatasetFiltersV4<T, Y>;
+}
+
 export interface IDatasetFiltersV4<T, Y = null> {
   where?: FilterQuery<T>;
-  include?: DatasetLookupKeysEnum[];
-  fields?: Y;
+  include?: DatasetLookupKeysEnum[] | IDatasetRelation<T, Y>[];
+  fields?: (keyof Y)[];
   limits?: ILimitsFilter;
 }

--- a/src/datasets/interfaces/dataset-filters.interface.ts
+++ b/src/datasets/interfaces/dataset-filters.interface.ts
@@ -1,6 +1,25 @@
-import { FilterQuery } from "mongoose";
-import { IScientificFilter } from "src/common/interfaces/common.interface";
+import {
+  IFiltersV4,
+  IScientificFilter,
+} from "src/common/interfaces/common.interface";
 import { DatasetLookupKeysEnum } from "../types/dataset-lookup";
+import {
+  IOrigDatablockFields,
+  IOrigDatablockFiltersV4,
+} from "src/origdatablocks/interfaces/origdatablocks.interface";
+import { DatablockDocument } from "src/datablocks/schemas/datablock.schema";
+import { OrigDatablockDocument } from "src/origdatablocks/schemas/origdatablock.schema";
+import { IDatablockFields } from "src/datablocks/interfaces/datablocks.interface";
+import { InstrumentDocument } from "src/instruments/schemas/instrument.schema";
+import { ProposalDocument } from "src/proposals/schemas/proposal.schema";
+import { IProposalFields } from "src/proposals/interfaces/proposal-filters.interface";
+import { AttachmentDocument } from "src/attachments/schemas/attachment.schema";
+import {
+  IAttachmentFields,
+  IAttachmentFiltersV4,
+} from "src/attachments/interfaces/attachment-filters.interface";
+import { SampleDocument } from "src/samples/schemas/sample.schema";
+import { ISampleFields } from "src/samples/interfaces/sample-filters.interface";
 
 export interface IDatasetFields {
   mode?: Record<string, unknown>;
@@ -23,20 +42,19 @@ export interface IDatasetFields {
   [key: string]: unknown;
 }
 
-export interface IDatasetRelation<T, Y = null> {
+export type IDatasetScopes =
+  | IOrigDatablockFiltersV4<OrigDatablockDocument, IOrigDatablockFields>
+  | IFiltersV4<DatablockDocument, IDatablockFields>
+  | IFiltersV4<InstrumentDocument>
+  | IFiltersV4<ProposalDocument, IProposalFields>
+  | IAttachmentFiltersV4<AttachmentDocument, IAttachmentFields>
+  | IFiltersV4<SampleDocument, ISampleFields>;
+
+export interface IDatasetRelation {
   relation: DatasetLookupKeysEnum;
-  scope: IDatasetFiltersV4<T, Y>;
+  scope: IDatasetScopes;
 }
 
-export interface IDatasetFiltersV4<T, Y = null> {
-  where?: FilterQuery<T>;
-  include?: DatasetLookupKeysEnum[] | IDatasetRelation<T, Y>[];
-  fields?: (keyof Y)[];
-  limits?: IDatasetLimitsV4<T>;
-}
-
-interface IDatasetLimitsV4<T> {
-  limit: number;
-  skip: number;
-  sort: Record<keyof T, "asc" | "desc">;
-}
+export type IDatasetFiltersV4<T, Y = null> = IFiltersV4<T, Y> & {
+  include?: DatasetLookupKeysEnum[] | IDatasetRelation[];
+};

--- a/src/datasets/types/dataset-filter-content.ts
+++ b/src/datasets/types/dataset-filter-content.ts
@@ -14,8 +14,29 @@ const FILTERS: Record<"limits" | "fields" | "where" | "include", object> = {
   include: {
     type: "array",
     items: {
-      type: "string",
-      example: "attachments",
+      oneOf: [
+        {
+          type: "string",
+          example: "attachments",
+        },
+        {
+          type: "object",
+          properties: {
+            relation: {
+              type: "string",
+              example: "attachments",
+            },
+            scope: {
+              type: "object",
+              example: {
+                fields: ["filename", "mimetype"],
+                limits: { limit: 5, skip: 0, sort: { filename: "asc" } },
+                where: { filename: { $regex: "data", $options: "i" } },
+              },
+            },
+          },
+        },
+      ],
     },
   },
   fields: {

--- a/src/origdatablocks/interfaces/origdatablocks.interface.ts
+++ b/src/origdatablocks/interfaces/origdatablocks.interface.ts
@@ -1,7 +1,6 @@
-import { FilterQuery } from "mongoose";
 import {
-  ILimitsFilter,
   IDatafileFilter,
+  IFiltersV4,
 } from "src/common/interfaces/common.interface";
 import { OrigDatablockLookupKeysEnum } from "../types/origdatablock-lookup";
 
@@ -18,9 +17,8 @@ export interface IOrigDatablockFields {
   isPublished?: boolean;
 }
 
-export interface IOrigDatablockFiltersV4<T, Y = null> {
-  where?: FilterQuery<T>;
-  include?: OrigDatablockLookupKeysEnum[];
-  fields?: Y;
-  limits?: ILimitsFilter;
-}
+export type IOrigDatablockFiltersV4<T, Y = null> = IFiltersV4<
+  T,
+  Y,
+  OrigDatablockLookupKeysEnum[]
+>;

--- a/test/DatasetV4.js
+++ b/test/DatasetV4.js
@@ -512,84 +512,6 @@ describe("2500: Datasets v4 tests", () => {
         });
     });
 
-    it("0204.0: should fetch dataset relation fields if provided in the filter as obj", async () => {
-      const filter = {
-        include: [{ relation: "instruments" }, { relation: "proposals" }],
-      };
-
-      return request(appUrl)
-        .get(`/api/v4/datasets`)
-        .query({ filter: JSON.stringify(filter) })
-        .auth(accessTokenAdminIngestor, { type: "bearer" })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.a("array");
-          const [firstDataset] = res.body;
-
-          firstDataset.should.have.property("pid");
-          firstDataset.should.have.property("instruments");
-          firstDataset.should.have.property("proposals");
-          firstDataset.should.not.have.property("datablocks");
-        });
-    });
-
-    it("0204.1: should fetch dataset relation fields if provided in the filter as obj and add scopes", async () => {
-      const filter = {
-        where: { pid: derivedDatasetMinPid },
-        include: [{
-          relation: "instruments",
-          scope: {
-            where:
-              { uniqueName: TestData.InstrumentCorrect1.uniqueName }, fields: ["uniqueName"]
-          }
-        }],
-      };
-
-      const instrument1 = await request(appUrl)
-        .post("/api/v3/Instruments")
-        .send(TestData.InstrumentCorrect1)
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
-        .expect(TestData.EntryCreatedStatusCode)
-        .expect("Content-Type", /json/)
-
-      const instrument2 = await request(appUrl)
-        .post("/api/v3/Instruments")
-        .send(TestData.InstrumentCorrect2)
-        .set("Accept", "application/json")
-        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
-        .expect(TestData.EntryCreatedStatusCode)
-        .expect("Content-Type", /json/)
-
-      await request(appUrl)
-        .patch(`/api/v4/datasets/${encodeURIComponent(derivedDatasetMinPid)}`)
-        .send({ instrumentIds: [instrument1.body.id, instrument2.body.id] })
-        .auth(accessTokenAdminIngestor, { type: "bearer" })
-        .expect(TestData.SuccessfulPatchStatusCode)
-        .expect("Content-Type", /json/);
-
-      return request(appUrl)
-        .get(`/api/v4/datasets`)
-        .query({ filter: JSON.stringify(filter) })
-        .auth(accessTokenAdminIngestor, { type: "bearer" })
-        .expect(TestData.SuccessfulGetStatusCode)
-        .expect("Content-Type", /json/)
-        .then((res) => {
-          res.body.should.be.a("array");
-          const [firstDataset] = res.body;
-
-          firstDataset.should.have.property("pid");
-          firstDataset.should.have.property("instruments").eql([{
-            _id: instrument1.body.id,
-            uniqueName: TestData.InstrumentCorrect1.uniqueName
-          }]
-          );
-          firstDataset.should.not.have.property("datablocks");
-        });
-    });
-
-
     it("0205: should fetch all datasets with related items when requested with all relations", async () => {
       const filter = {
         include: ["all"],
@@ -718,6 +640,83 @@ describe("2500: Datasets v4 tests", () => {
             .and.be.equal(
               "Invalid JSON in filter: Expected double-quoted property name in JSON at position 22",
             );
+        });
+    });
+
+    it("0210: should fetch dataset relation fields if provided in the filter as obj", async () => {
+      const filter = {
+        include: [{ relation: "instruments" }, { relation: "proposals" }],
+      };
+
+      return request(appUrl)
+        .get(`/api/v4/datasets`)
+        .query({ filter: JSON.stringify(filter) })
+        .auth(accessTokenAdminIngestor, { type: "bearer" })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.a("array");
+          const [firstDataset] = res.body;
+
+          firstDataset.should.have.property("pid");
+          firstDataset.should.have.property("instruments");
+          firstDataset.should.have.property("proposals");
+          firstDataset.should.not.have.property("datablocks");
+        });
+    });
+
+    it("0211: should fetch dataset relation fields if provided in the filter as obj and add scopes", async () => {
+      const filter = {
+        where: { pid: derivedDatasetMinPid },
+        include: [{
+          relation: "instruments",
+          scope: {
+            where:
+              { uniqueName: TestData.InstrumentCorrect1.uniqueName }, fields: ["uniqueName"]
+          }
+        }],
+      };
+
+      const instrument1 = await request(appUrl)
+        .post("/api/v3/Instruments")
+        .send(TestData.InstrumentCorrect1)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode)
+        .expect("Content-Type", /json/)
+
+      const instrument2 = await request(appUrl)
+        .post("/api/v3/Instruments")
+        .send(TestData.InstrumentCorrect2)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode)
+        .expect("Content-Type", /json/)
+
+      await request(appUrl)
+        .patch(`/api/v4/datasets/${encodeURIComponent(derivedDatasetMinPid)}`)
+        .send({ instrumentIds: [instrument1.body.id, instrument2.body.id] })
+        .auth(accessTokenAdminIngestor, { type: "bearer" })
+        .expect(TestData.SuccessfulPatchStatusCode)
+        .expect("Content-Type", /json/);
+
+      return request(appUrl)
+        .get(`/api/v4/datasets`)
+        .query({ filter: JSON.stringify(filter) })
+        .auth(accessTokenAdminIngestor, { type: "bearer" })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.a("array");
+          const [firstDataset] = res.body;
+
+          firstDataset.should.have.property("pid");
+          firstDataset.should.have.property("instruments").eql([{
+            _id: instrument1.body.id,
+            uniqueName: TestData.InstrumentCorrect1.uniqueName
+          }]
+          );
+          firstDataset.should.not.have.property("datablocks");
         });
     });
   });


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This makes possible to pass a relation with scopes in the V4 endpoint, in addition to a list of relations as before

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* openapi descriptor extended to support include: [{relation: abc, scope: {where: {...}, fields: [...]...}}]
* include validation pipe extended to check array of objects 
* addRelation extended to add pipeline stages for scope.where (match), scope.field (project), and limits

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
