### PR TITLE
fix: keep filters when quering v3 dataset public

### DIFF
--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -235,7 +235,10 @@ export class DatasetsController {
           ownerGroup: { $in: user.currentGroups },
         };
       } else if (canViewPublic) {
-        mergedFilters.where = { isPublished: true };
+        mergedFilters.where = {
+          ...mergedFilters.where,
+          isPublished: true,
+        };
       }
     }
 

--- a/test/DatasetAuthorization.js
+++ b/test/DatasetAuthorization.js
@@ -189,6 +189,33 @@ describe("0300: DatasetAuthorization: Test access to dataset", () => {
       });
   });
 
+  it("0073: list of public datasets with pid filter should return 1", async () => {
+    const filter = { where: { pid: datasetPid1 } }
+    return request(appUrl)
+      .get("/api/v3/Datasets")
+      .set("Accept", "application/json")
+      .query({ filter: JSON.stringify(filter) })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(1);
+        res.body[0]["pid"].should.be.equal(datasetPid1);
+      });
+  });
+
+  it("0075: list of public datasets with pid filter should return 0", async () => {
+    const filter = { where: { pid: 'nonExistingPid' } }
+    return request(appUrl)
+      .get("/api/v3/Datasets")
+      .set("Accept", "application/json")
+      .query({ filter: JSON.stringify(filter) })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.an("array").to.have.lengthOf(0);
+      });
+  });
+
   it("0080: access public dataset as unauthenticated user", async () => {
     return request(appUrl)
       .get("/api/v3/Datasets/" + encodedDatasetPid1)


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Filters with a non valid token were overridden by isPublic: true. This keeps filters also when non auth and merges with isPublished.

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* merge filter rather than overriding

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
