### PR TITLE
feat: add scopes to v3 datasets

### DIFF
--- a/src/common/interfaces/common.interface.ts
+++ b/src/common/interfaces/common.interface.ts
@@ -40,9 +40,9 @@ export interface ILimitsFilter {
   order?: string;
 }
 
-export interface IFilters<T, Y = null> {
+export interface IFilters<T, Y = null, Z = string> {
   where?: FilterQuery<T>;
-  include?: { relation: string }[];
+  include?: { relation: Z }[];
   fields?: Y;
   limits?: ILimitsFilter;
 }
@@ -69,16 +69,15 @@ export interface IDatafileFilter {
   type?: string;
 }
 
-export type IFiltersV4<T, Y = null, Z = null> = Pick<
+export type IFiltersV4<T, Y = null, Z = string> = Pick<
   IFilters<T, Y>,
-  "where"
+  "where" | "fields"
 > & {
   include?: Z;
-  limits?: ILimitsV4<T>;
-  fields?: (keyof Y)[];
+  limits?: ILimitsFilterV4<T>;
 };
 
-export interface ILimitsV4<T = null> {
+export interface ILimitsFilterV4<T = null> {
   limit?: number;
   skip?: number;
   sort?: Record<keyof T, "asc" | "desc">;

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -7,10 +7,12 @@ import {
   IAxiosError,
   IFilters,
   ILimitsFilter,
+  ILimitsFilterV4,
   IScientificFilter,
 } from "./interfaces/common.interface";
 import { ScientificRelation } from "./scientific-relation.enum";
 import { DatasetType } from "src/datasets/types/dataset-type.enum";
+import _ from "lodash";
 
 // add Å to mathjs accepted units as equivalent to angstrom
 const isAlphaOriginal = Unit.isValidAlpha;
@@ -383,26 +385,28 @@ export const updateAllTimesToUTC = <T>(
     : [];
 };
 
-export const parseLimitFilters = (
+export const parseOrderLimits = (
   limits: ILimitsFilter | undefined,
-): {
-  limit: number;
-  skip: number;
-  sort?: { [key: string]: "asc" | "desc" };
-} => {
+): ILimitsFilterV4 => {
+  if (!limits) return {};
+  const limitFilters: ILimitsFilterV4 = structuredClone(limits);
+  if (!limits.order) return limitFilters;
+  const sort: Record<string, "asc" | "desc"> = {};
+  const [field, direction] = limits.order.split(":");
+  if (direction === "asc" || direction === "desc") sort[field] = direction;
+  limitFilters.sort = sort;
+  return _.omit(limitFilters, "order");
+};
+
+export const parseLimitFilters = (limits: ILimitsFilter | undefined) => {
   if (!limits) {
     return { limit: 100, skip: 0, sort: {} };
   }
-  const limit = limits.limit ? limits.limit : 100;
-  const skip = limits.skip ? limits.skip : 0;
-  let sort = {};
-  if (limits.order) {
-    const [field, direction] = limits.order.split(":");
-    if (direction === "asc" || direction === "desc") {
-      sort = { [field]: direction as "asc" | "desc" };
-    }
-  }
-  return { limit, skip, sort };
+  const limitFilters = parseOrderLimits(limits);
+  limitFilters.limit = limitFilters.limit ?? 100;
+  limitFilters.skip = limitFilters.skip ?? 0;
+  return limitFilters as ILimitsFilterV4 &
+    Required<Pick<ILimitsFilterV4, "limit" | "skip">>;
 };
 
 export const parsePipelineSort = (sort: Record<string, "asc" | "desc">) => {

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -388,7 +388,7 @@ export const parseLimitFilters = (
 ): {
   limit: number;
   skip: number;
-  sort?: { [key: string]: "asc" | "desc" } | string;
+  sort?: { [key: string]: "asc" | "desc" };
 } => {
   if (!limits) {
     return { limit: 100, skip: 0, sort: {} };
@@ -969,8 +969,9 @@ export const filterDescription =
     "field": "value"\n \
   },\n \
   "include?": [\n \
+    "target1",\n \
     {\n \
-      "relation": "target",\n \
+      "relation": "target2",\n \
       "scope": {\n \
         "where" : "<where_condition>"\n \
       ]\n \

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -117,9 +117,9 @@ import { TechniqueClass } from "./schemas/technique.schema";
 import { DatasetType } from "./types/dataset-type.enum";
 import { HistoryService } from "src/history/history.service";
 import { convertGenericHistoriesToObsoleteHistories } from "src/datasets/utils/history.util";
-import { getSwaggerDatasetFilterContent } from "./types/dataset-filter-content";
 import { IncludeValidationPipe } from "src/common/pipes/include-validation.pipe";
 import { DATASET_LOOKUP_FIELDS } from "./types/dataset-lookup";
+import { getSwaggerDatasetFilterContentV3 } from "./types/dataset-filter-content.v3";
 
 @ApiBearerAuth()
 @ApiExtraModels(
@@ -902,7 +902,7 @@ export class DatasetsController {
       filterDescription,
     required: false,
     type: String,
-    content: getSwaggerDatasetFilterContent(undefined, "v3"),
+    content: getSwaggerDatasetFilterContentV3(),
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -931,7 +931,9 @@ export class DatasetsController {
     );
     return Promise.all(
       (datasets as DatasetDocument[]).map((dataset) =>
-        this.convertCurrentToObsoleteSchema(dataset),
+        this.convertCurrentToObsoleteSchema(
+          this.datasetsService.hydrate(dataset),
+        ),
       ),
     );
   }
@@ -1195,7 +1197,7 @@ export class DatasetsController {
       filterDescription,
     required: false,
     type: String,
-    content: getSwaggerDatasetFilterContent(undefined, "v3"),
+    content: getSwaggerDatasetFilterContentV3(),
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -1276,7 +1278,7 @@ export class DatasetsController {
       filterDescription,
     required: false,
     type: String,
-    content: getSwaggerDatasetFilterContent(undefined, "v3"),
+    content: getSwaggerDatasetFilterContentV3(),
   })
   @ApiResponse({
     status: HttpStatus.OK,

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -635,7 +635,7 @@ export class DatasetsController {
     }
 
     const outputDataset: OutputDatasetObsoleteDto = {
-      ...(inputDataset as DatasetDocument).toObject(),
+      ...((inputDataset as DatasetDocument).toObject?.() ?? inputDataset),
       ...propertiesModifier,
     };
 
@@ -934,9 +934,7 @@ export class DatasetsController {
     );
     return Promise.all(
       (datasets as DatasetDocument[]).map((dataset) =>
-        this.convertCurrentToObsoleteSchema(
-          this.datasetsService.hydrate(dataset),
-        ),
+        this.convertCurrentToObsoleteSchema(dataset),
       ),
     );
   }

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -63,7 +63,6 @@ import {
   datasetsFullQueryDescriptionFields,
   datasetsFullQueryExampleFields,
   filterDescription,
-  filterExample,
   fullQueryDescriptionLimits,
   fullQueryExampleLimits,
   replaceLikeOperator,
@@ -106,7 +105,10 @@ import {
   SubDatasetsPublicInterceptor,
 } from "./interceptors/datasets-public.interceptor";
 import { FullQueryInterceptor } from "./interceptors/fullquery.interceptor";
-import { IDatasetFields } from "./interfaces/dataset-filters.interface";
+import {
+  IDatasetFields,
+  IDatasetFiltersV3,
+} from "./interfaces/dataset-filters.interface";
 import { DatasetClass, DatasetDocument } from "./schemas/dataset.schema";
 import { HistoryClass } from "./schemas/history.schema";
 import { LifecycleClass } from "./schemas/lifecycle.schema";
@@ -115,6 +117,9 @@ import { TechniqueClass } from "./schemas/technique.schema";
 import { DatasetType } from "./types/dataset-type.enum";
 import { HistoryService } from "src/history/history.service";
 import { convertGenericHistoriesToObsoleteHistories } from "src/datasets/utils/history.util";
+import { getSwaggerDatasetFilterContent } from "./types/dataset-filter-content";
+import { IncludeValidationPipe } from "src/common/pipes/include-validation.pipe";
+import { DATASET_LOOKUP_FIELDS } from "./types/dataset-lookup";
 
 @ApiBearerAuth()
 @ApiExtraModels(
@@ -897,7 +902,7 @@ export class DatasetsController {
       filterDescription,
     required: false,
     type: String,
-    example: filterExample,
+    content: getSwaggerDatasetFilterContent(undefined, "v3"),
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -915,61 +920,21 @@ export class DatasetsController {
         request,
         this.getFilters(headers, queryFilter),
       ) as Record<string, unknown>,
-    ) as IFilters<DatasetDocument, IDatasetFields>;
-
-    // this should be implemented at database level
-    const datasets = await this.datasetsService.findAll(mergedFilters);
-    let outputDatasets: OutputDatasetObsoleteDto[] = [];
-    if (datasets && datasets.length > 0) {
-      const includeFilters = mergedFilters.include ?? [];
-      outputDatasets = await Promise.all(
-        datasets.map((dataset) => this.convertCurrentToObsoleteSchema(dataset)),
+    ) as IDatasetFiltersV3<DatasetDocument, IDatasetFields>;
+    if (queryFilter.filter)
+      new IncludeValidationPipe(DATASET_LOOKUP_FIELDS).transform(
+        queryFilter.filter,
       );
-      await Promise.all(
-        outputDatasets.map(async (dataset) => {
-          if (includeFilters) {
-            await Promise.all(
-              includeFilters.map(async ({ relation }) => {
-                switch (relation) {
-                  case "attachments": {
-                    dataset.attachments = await this.attachmentsService.findAll(
-                      {
-                        datasetId: dataset.pid,
-                      },
-                    );
-                    break;
-                  }
-                  case "origdatablocks": {
-                    dataset.origdatablocks =
-                      await this.origDatablocksService.findAll({
-                        where: {
-                          datasetId: dataset.pid,
-                        },
-                      });
-                    break;
-                  }
-                  case "datablocks": {
-                    dataset.datablocks = await this.datablocksService.findAll({
-                      where: {
-                        datasetId: dataset.pid,
-                      },
-                    });
-                    break;
-                  }
-                }
-              }),
-            );
-          } else {
-            /* eslint-disable @typescript-eslint/no-unused-expressions */
-            // TODO: check the eslint error  "Expected an assignment or function call and instead saw an expression"
-            dataset;
-          }
-        }),
-      );
-    }
-    return outputDatasets as OutputDatasetObsoleteDto[];
+    const datasets = await this.datasetsService.findAllComplete(
+      mergedFilters,
+      false,
+    );
+    return Promise.all(
+      (datasets as DatasetDocument[]).map((dataset) =>
+        this.convertCurrentToObsoleteSchema(dataset),
+      ),
+    );
   }
-
   // GET /datasets/fullquery
   @UseGuards(PoliciesGuard)
   @CheckPolicies(
@@ -1230,7 +1195,7 @@ export class DatasetsController {
       filterDescription,
     required: false,
     type: String,
-    example: filterExample,
+    content: getSwaggerDatasetFilterContent(undefined, "v3"),
   })
   @ApiResponse({
     status: HttpStatus.OK,
@@ -1242,51 +1207,8 @@ export class DatasetsController {
     @Headers() headers: Record<string, string>,
     @Query(new FilterPipe()) queryFilter: { filter?: string },
   ): Promise<OutputDatasetObsoleteDto | null> {
-    const mergedFilters = replaceLikeOperator(
-      this.updateMergedFiltersForList(
-        request,
-        this.getFilters(headers, queryFilter),
-      ) as Record<string, unknown>,
-    ) as IFilters<DatasetDocument, IDatasetFields>;
-
-    const databaseDataset = await this.datasetsService.findOne(mergedFilters);
-
-    const outputDataset =
-      await this.convertCurrentToObsoleteSchema(databaseDataset);
-
-    if (outputDataset) {
-      const includeFilters = mergedFilters.include ?? [];
-      await Promise.all(
-        includeFilters.map(async ({ relation }) => {
-          switch (relation) {
-            case "attachments": {
-              outputDataset.attachments = await this.attachmentsService.findAll(
-                {
-                  where: {
-                    datasetId: outputDataset.pid,
-                  },
-                },
-              );
-              break;
-            }
-            case "origdatablocks": {
-              outputDataset.origdatablocks =
-                await this.origDatablocksService.findAll({
-                  where: { datasetId: outputDataset.pid },
-                });
-              break;
-            }
-            case "datablocks": {
-              outputDataset.datablocks = await this.datablocksService.findAll({
-                where: { datasetId: outputDataset.pid },
-              });
-              break;
-            }
-          }
-        }),
-      );
-    }
-    return outputDataset;
+    const dataset = await this.findAll(request, headers, queryFilter);
+    return dataset[0] as OutputDatasetObsoleteDto;
   }
 
   // GET /datasets/count
@@ -1347,6 +1269,15 @@ export class DatasetsController {
     description: "Id of the dataset to return",
     type: String,
   })
+  @ApiQuery({
+    name: "filter",
+    description:
+      "Database filters to apply when retrieving datasets\n" +
+      filterDescription,
+    required: false,
+    type: String,
+    content: getSwaggerDatasetFilterContent(undefined, "v3"),
+  })
   @ApiResponse({
     status: HttpStatus.OK,
     type: OutputDatasetObsoleteDto,
@@ -1357,12 +1288,20 @@ export class DatasetsController {
     status: HttpStatus.NOT_FOUND,
     description: "Dataset not found",
   })
-  async findById(@Req() request: Request, @Param("pid") id: string) {
-    const dataset = await this.convertCurrentToObsoleteSchema(
-      await this.checkPermissionsForDatasetObsolete(request, id),
-    );
-
-    return dataset as OutputDatasetObsoleteDto;
+  async findById(
+    @Req() request: Request,
+    @Param("pid") id: string,
+    @Headers() headers: Record<string, string>,
+    @Query(new FilterPipe()) queryFilter: { filter?: string },
+  ) {
+    const filterObj = JSON.parse(queryFilter.filter ?? "{}");
+    filterObj.where = filterObj.where ?? {};
+    filterObj.where.pid = id;
+    const dataset = await this.findAll(request, headers, {
+      filter: JSON.stringify(filterObj),
+    });
+    if (dataset.length == 0) throw new ForbiddenException();
+    return dataset[0] as OutputDatasetObsoleteDto;
   }
 
   // PATCH /datasets/:id

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -552,8 +552,4 @@ export class DatasetsService {
     const count = await this.ESClient.getCount();
     return count.count > 0;
   }
-
-  hydrate(dataset: DatasetClass) {
-    return this.datasetModel.hydrate(dataset);
-  }
 }

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -79,7 +79,7 @@ export class DatasetsService {
 
   addLookupFields(
     pipeline: PipelineStage[],
-    datasetLookupFields?: DatasetLookupKeysEnum[] | IDatasetRelation[],
+    datasetLookupFields?: (DatasetLookupKeysEnum | IDatasetRelation)[],
     applyDefaults = true,
   ) {
     const relationsAndScopes =
@@ -126,8 +126,7 @@ export class DatasetsService {
 
   private extractRelationsAndScopes(
     datasetLookupFields:
-      | DatasetLookupKeysEnum[]
-      | IDatasetRelation[]
+      | (DatasetLookupKeysEnum | IDatasetRelation)[]
       | undefined,
   ) {
     const scopes = {} as Record<DatasetLookupKeysEnum, IDatasetScopes>;

--- a/src/datasets/interfaces/dataset-filters.interface.ts
+++ b/src/datasets/interfaces/dataset-filters.interface.ts
@@ -67,11 +67,11 @@ export interface IDatasetRelationV4<T = IDatasetScopesV4> {
 export type IDatasetFiltersV4<T, Y = null> = IFiltersV4<
   T,
   Y,
-  DatasetLookupKeysEnum[] | IDatasetRelationV4[]
+  (DatasetLookupKeysEnum | IDatasetRelationV4)[]
 >;
 
 export type IDatasetFiltersV3<T, Y = null> = Omit<IFilters<T, Y>, "include"> & {
-  include: DatasetLookupKeysEnum[] | IDatasetRelationV4<IDatasetScopesV3>[];
+  include: (DatasetLookupKeysEnum | IDatasetRelationV4<IDatasetScopesV3>)[];
 };
 
 export type IDatasetFilters<T, Y = null> =

--- a/src/datasets/interfaces/dataset-filters.interface.ts
+++ b/src/datasets/interfaces/dataset-filters.interface.ts
@@ -1,4 +1,5 @@
 import {
+  IFilters,
   IFiltersV4,
   IScientificFilter,
 } from "src/common/interfaces/common.interface";
@@ -42,7 +43,7 @@ export interface IDatasetFields {
   [key: string]: unknown;
 }
 
-export type IDatasetScopes =
+export type IDatasetScopesV4 =
   | IOrigDatablockFiltersV4<OrigDatablockDocument, IOrigDatablockFields>
   | IFiltersV4<DatablockDocument, IDatablockFields>
   | IFiltersV4<InstrumentDocument>
@@ -50,13 +51,35 @@ export type IDatasetScopes =
   | IAttachmentFiltersV4<AttachmentDocument, IAttachmentFields>
   | IFiltersV4<SampleDocument, ISampleFields>;
 
-export interface IDatasetRelation {
+export type IDatasetScopesV3 =
+  | IFilters<OrigDatablockDocument, IOrigDatablockFields>
+  | IFilters<DatablockDocument, IDatablockFields>
+  | IFilters<InstrumentDocument>
+  | IFilters<ProposalDocument, IProposalFields>
+  | IFilters<AttachmentDocument, IAttachmentFields>
+  | IFilters<SampleDocument, ISampleFields>;
+
+export interface IDatasetRelationV4<T = IDatasetScopesV4> {
   relation: DatasetLookupKeysEnum;
-  scope: IDatasetScopes;
+  scope: T;
 }
 
 export type IDatasetFiltersV4<T, Y = null> = IFiltersV4<
   T,
   Y,
-  DatasetLookupKeysEnum[] | IDatasetRelation[]
+  DatasetLookupKeysEnum[] | IDatasetRelationV4[]
 >;
+
+export type IDatasetFiltersV3<T, Y = null> = Omit<IFilters<T, Y>, "include"> & {
+  include: DatasetLookupKeysEnum[] | IDatasetRelationV4<IDatasetScopesV3>[];
+};
+
+export type IDatasetFilters<T, Y = null> =
+  | IDatasetFiltersV3<T, Y>
+  | IDatasetFiltersV4<T, Y>;
+
+export type IDatasetScopes = IDatasetScopesV3 | IDatasetScopesV4;
+
+export type IDatasetRelation =
+  | IDatasetRelationV4<IDatasetScopesV3>
+  | IDatasetRelationV4;

--- a/src/datasets/types/dataset-filter-content.ts
+++ b/src/datasets/types/dataset-filter-content.ts
@@ -4,49 +4,35 @@ import {
 } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
 import { boolean } from "mathjs";
 
-const FILTERS: Record<"limits" | "fields" | "where" | "include", object> = {
-  where: {
+const WHERE = {
+  type: "object",
+  example: {
+    _id: "123",
+  },
+};
+
+const FIELDS = {
+  type: "array",
+  items: {
+    type: "string",
+    example: "createdAt",
+  },
+};
+
+const SORT = {
+  sort: {
     type: "object",
-    example: {
-      datasetName: { $regex: "Dataset", $options: "i" },
+    properties: {
+      createdAt: {
+        type: "string",
+        example: "asc | desc",
+      },
     },
   },
-  include: {
-    type: "array",
-    items: {
-      oneOf: [
-        {
-          type: "string",
-          example: "attachments",
-        },
-        {
-          type: "object",
-          properties: {
-            relation: {
-              type: "string",
-              example: "attachments",
-            },
-            scope: {
-              type: "object",
-              example: {
-                fields: ["filename", "mimetype"],
-                limits: { limit: 5, skip: 0, sort: { filename: "asc" } },
-                where: { filename: { $regex: "data", $options: "i" } },
-              },
-            },
-          },
-        },
-      ],
-    },
-  },
-  fields: {
-    type: "array",
-    items: {
-      type: "string",
-      example: "datasetName",
-    },
-  },
-  limits: {
+};
+
+const LIMITS = (sort: object = SORT) => {
+  return {
     type: "object",
     properties: {
       limit: {
@@ -57,17 +43,74 @@ const FILTERS: Record<"limits" | "fields" | "where" | "include", object> = {
         type: "number",
         example: 0,
       },
-      sort: {
+      ...sort,
+    },
+  };
+};
+
+const RELATION = (limits: object = LIMITS()) => {
+  return {
+    type: "object",
+    properties: {
+      relation: {
+        type: "string",
+        example: "datablock",
+      },
+      scope: {
         type: "object",
         properties: {
-          datasetName: {
-            type: "string",
-            example: "asc | desc",
-          },
+          where: WHERE,
+          fields: FIELDS,
+          limits: limits,
         },
       },
     },
+  };
+};
+
+const INCLUDE = (relation: object = RELATION()) => {
+  return {
+    oneOf: [
+      {
+        type: "string",
+        example: "attachments",
+      },
+      relation,
+    ],
+  };
+};
+
+const filtersV3Builder = () => {
+  const sort = {
+    order: {
+      type: "array",
+      items: { type: "string", example: "createdAt:asc" },
+    },
+  };
+  const limits = LIMITS(sort);
+  const relation = RELATION(limits);
+  const include = INCLUDE(relation);
+  return {
+    where: WHERE,
+    include: {
+      type: "array",
+      items: include,
+    },
+    fields: FIELDS,
+    limits: limits,
+  };
+};
+
+const FILTERSV3 = filtersV3Builder();
+
+const FILTERS: Record<"limits" | "fields" | "where" | "include", object> = {
+  where: WHERE,
+  include: {
+    type: "array",
+    items: INCLUDE(),
   },
+  fields: FIELDS,
+  limits: LIMITS(),
 };
 
 /**
@@ -82,10 +125,12 @@ export const getSwaggerDatasetFilterContent = (
     fields: true,
     limits: true,
   },
+  version = "v4",
 ): ContentObject | undefined => {
   if (boolean(process.env.SDK_PACKAGE_SWAGGER_HELPERS_DISABLED ?? false)) {
     return undefined;
   }
+  const filtersVersion = version === "v4" ? FILTERS : FILTERSV3;
 
   const filterContent: Record<string, { schema: SchemaObject }> = {
     "application/json": {
@@ -97,10 +142,11 @@ export const getSwaggerDatasetFilterContent = (
   };
 
   for (const filtersKey in filtersToInclude) {
-    const key = filtersKey as keyof typeof FILTERS;
+    const key = filtersKey as keyof typeof filtersVersion;
 
-    if (filtersToInclude[key] && FILTERS[key]) {
-      filterContent["application/json"].schema.properties![key] = FILTERS[key];
+    if (filtersToInclude[key] && filtersVersion[key]) {
+      filterContent["application/json"].schema.properties![key] =
+        filtersVersion[key];
     }
   }
 

--- a/src/datasets/types/dataset-filter-content.v3.ts
+++ b/src/datasets/types/dataset-filter-content.v3.ts
@@ -1,0 +1,56 @@
+import { getSwaggerDatasetFilterContent } from "./dataset-filter-content";
+
+const FILTERS: Record<"limits" | "fields" | "where" | "include", object> = {
+  where: { type: "object", example: { _id: "123" } },
+  include: {
+    type: "array",
+    items: {
+      oneOf: [
+        { type: "string", example: "attachments" },
+        {
+          type: "object",
+          properties: {
+            relation: { type: "string", example: "datablock" },
+            scope: {
+              type: "object",
+              properties: {
+                where: { type: "object", example: { _id: "123" } },
+                fields: {
+                  type: "array",
+                  items: { type: "string", example: "createdAt" },
+                },
+                limits: {
+                  type: "object",
+                  properties: {
+                    limit: { type: "number", example: 10 },
+                    skip: { type: "number", example: 0 },
+                    order: {
+                      type: "array",
+                      items: { type: "string", example: "createdAt:asc" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+  },
+  fields: { type: "array", items: { type: "string", example: "createdAt" } },
+  limits: {
+    type: "object",
+    properties: {
+      limit: { type: "number", example: 10 },
+      skip: { type: "number", example: 0 },
+      order: {
+        type: "array",
+        items: { type: "string", example: "createdAt:asc" },
+      },
+    },
+  },
+};
+
+export const getSwaggerDatasetFilterContentV3 = () => {
+  return getSwaggerDatasetFilterContent(undefined, FILTERS);
+};

--- a/src/datasets/utils/history.util.ts
+++ b/src/datasets/utils/history.util.ts
@@ -90,17 +90,19 @@ export function convertGenericHistoryToObsoleteHistory(
 // starting from the latest dataset, replay the history entries in reverse order to reconstruct the obsolete history entries
 export function convertGenericHistoriesToObsoleteHistories(
   histories: GenericHistory[],
-  currentDataset: DatasetDocument,
+  currentDataset: DatasetDocument | DatasetClass,
 ): HistoryClass[] {
-  currentDataset = currentDataset.$clone();
+  let currentDatasetCopy;
+  if ("$clone" in currentDataset) currentDatasetCopy = currentDataset.$clone();
+  else currentDatasetCopy = structuredClone(currentDataset);
   const result: HistoryClass[] = [];
   for (const history of histories) {
     const obsoleteHistory = convertGenericHistoryToObsoleteHistory(
       history,
-      currentDataset,
+      currentDatasetCopy,
     );
     for (const key of Object.keys(history.before || {})) {
-      (currentDataset as unknown as Record<string, unknown>)[key] =
+      (currentDatasetCopy as unknown as Record<string, unknown>)[key] =
         history.before?.[key];
     }
     result.push(obsoleteHistory);

--- a/test/RawDataset.js
+++ b/test/RawDataset.js
@@ -362,6 +362,117 @@ describe("1900: RawDataset: Raw Datasets", () => {
       });
   });
 
+  it("0132 should fetch datasets with include and scope", async () => {
+    const filter = {
+      where: { pid: decodeURIComponent(pid) },
+      include: [
+        { relation: "instruments" },
+        { relation: "proposals", scope: { fields: ["abstract"] } }
+      ],
+    };
+
+    return request(appUrl)
+      .get(`/api/v3/datasets`)
+      .query({ filter: JSON.stringify(filter) })
+      .auth(accessTokenAdminIngestor, { type: "bearer" })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.a("array");
+        const [firstDataset] = res.body;
+
+        firstDataset.should.have.property("pid");
+        firstDataset.should.have.property("instruments");
+        firstDataset.should.have.property("proposals").and.have.length(1);
+        firstDataset.proposals[0].should.not.have.property("title");
+        firstDataset.proposals[0].should.have.property("abstract")
+          .and.be.equal(TestData.ProposalCorrectComplete["abstract"]);
+        firstDataset.should.not.have.property("datablocks");
+      });
+  });
+
+  it("0134 should fetch dataset with findOne include and scope", async () => {
+    const filter = {
+      where: { pid: decodeURIComponent(pid) },
+      include: [
+        { relation: "instruments" },
+        { relation: "proposals", scope: { fields: ["abstract"] } }
+      ],
+    };
+
+    return request(appUrl)
+      .get(`/api/v3/datasets/findOne`)
+      .query({ filter: JSON.stringify(filter) })
+      .auth(accessTokenAdminIngestor, { type: "bearer" })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        const firstDataset = res.body;
+
+        firstDataset.should.have.property("pid");
+        firstDataset.should.have.property("instruments");
+        firstDataset.should.have.property("proposals").and.have.length(1);
+        firstDataset.proposals[0].should.not.have.property("title");
+        firstDataset.proposals[0].should.have.property("abstract")
+          .and.be.equal(TestData.ProposalCorrectComplete["abstract"]);
+        firstDataset.should.not.have.property("datablocks");
+      });
+  });
+
+  it("0136 should fetch dataset with findById and include and scope", async () => {
+    const filter = {
+      include: [
+        { relation: "instruments" },
+        { relation: "proposals", scope: { fields: ["abstract"] } }
+      ],
+    };
+
+    return request(appUrl)
+      .get(`/api/v3/datasets/${pid}`)
+      .query({ filter: JSON.stringify(filter) })
+      .auth(accessTokenAdminIngestor, { type: "bearer" })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        const firstDataset = res.body;
+
+        firstDataset.should.have.property("pid");
+        firstDataset.should.have.property("instruments");
+        firstDataset.should.have.property("proposals").and.have.length(1);
+        firstDataset.proposals[0].should.not.have.property("title");
+        firstDataset.proposals[0].should.have.property("abstract")
+          .and.be.equal(TestData.ProposalCorrectComplete["abstract"]);
+        firstDataset.should.not.have.property("datablocks");
+      });
+  });
+
+  it("0138 should fetch datasets with include list", async () => {
+    const filter = {
+      where: { pid: decodeURIComponent(pid) },
+      include: ["instruments", "proposals"],
+    };
+
+    return request(appUrl)
+      .get(`/api/v3/datasets`)
+      .query({ filter: JSON.stringify(filter) })
+      .auth(accessTokenAdminIngestor, { type: "bearer" })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.be.a("array");
+        const [firstDataset] = res.body;
+
+        firstDataset.should.have.property("pid");
+        firstDataset.should.have.property("instruments");
+        firstDataset.should.have.property("proposals").and.have.length(1);
+        firstDataset.proposals[0].should.have.property("title")
+          .and.be.equal(TestData.ProposalCorrectComplete["title"]);
+        firstDataset.proposals[0].should.have.property("abstract")
+          .and.be.equal(TestData.ProposalCorrectComplete["abstract"]);
+        firstDataset.should.not.have.property("datablocks");
+      });
+  });
+
   it("0140: should update data quality metrics of the dataset", async () => {
     return request(appUrl)
       .patch("/api/v3/datasets/" + pid)

--- a/test/RawDataset.js
+++ b/test/RawDataset.js
@@ -365,6 +365,7 @@ describe("1900: RawDataset: Raw Datasets", () => {
   it("0132 should fetch datasets with include and scope", async () => {
     const filter = {
       where: { pid: decodeURIComponent(pid) },
+      fields: ["pid", "datasetName"],
       include: [
         { relation: "instruments" },
         { relation: "proposals", scope: { fields: ["abstract"] } }
@@ -384,6 +385,7 @@ describe("1900: RawDataset: Raw Datasets", () => {
         firstDataset.should.have.property("pid");
         firstDataset.should.have.property("instruments");
         firstDataset.should.have.property("proposals").and.have.length(1);
+        firstDataset.should.not.have.property("description");
         firstDataset.proposals[0].should.not.have.property("title");
         firstDataset.proposals[0].should.have.property("abstract")
           .and.be.equal(TestData.ProposalCorrectComplete["abstract"]);


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description

Reuse findOneComplete and findOneAll for v3 endpoints to enable scopes. 

## Motivation
Reintroduce loopback3 features to v3 endpoints (removing the support is non backward compatible change), by few findAllComplet branching

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* findAll, findById and findOne in v3 all use the same function now. Avoids dup, shared with v4, same expected behaviour for the user
* richer swagger for v3 endpoints
* v3 findById supports filtering now
* types extended to union v3 and v4

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
