### PR TITLE
docs: add note explaining duplicated V4 in SDK methods

### DIFF
--- a/src/attachments/attachments.v4.controller.ts
+++ b/src/attachments/attachments.v4.controller.ts
@@ -60,6 +60,11 @@ import {
 
 @ApiBearerAuth()
 @ApiTags("attachments v4")
+/* NOTE: SDK methods include "V4" twice.
+   - First "V4" comes from the controller class name.
+   - Second "V4" comes from the route version and is required for correct versioned routing.
+   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
+   and make the API harder to maintain. */
 @Controller({ path: "attachments", version: "4" })
 export class AttachmentsV4Controller {
   constructor(

--- a/src/attachments/attachments.v4.controller.ts
+++ b/src/attachments/attachments.v4.controller.ts
@@ -60,11 +60,11 @@ import {
 
 @ApiBearerAuth()
 @ApiTags("attachments v4")
-/* NOTE: SDK methods include "V4" twice.
-   - First "V4" comes from the controller class name.
-   - Second "V4" comes from the route version and is required for correct versioned routing.
-   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
-   and make the API harder to maintain. */
+/* NOTE: Generated SDK method names include "V4" twice:
+ *  - From the controller class name (AttachmentsV4Controller)
+ *  - From the route version (`version: '4'`)
+ * This is intentional for versioned routing.
+ */
 @Controller({ path: "attachments", version: "4" })
 export class AttachmentsV4Controller {
   constructor(

--- a/src/datasets/datasets-public.v4.controller.ts
+++ b/src/datasets/datasets-public.v4.controller.ts
@@ -37,6 +37,11 @@ import { AllowAny } from "src/auth/decorators/allow-any.decorator";
 
 @ApiExtraModels(HistoryClass, TechniqueClass, RelationshipClass)
 @ApiTags("datasets public v4")
+/* NOTE: SDK methods include "V4" twice.
+   - First "V4" comes from the controller class name.
+   - Second "V4" comes from the route version and is required for correct versioned routing.
+   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
+   and make the API harder to maintain. */
 @Controller({ path: "datasets/public", version: "4" })
 export class DatasetsPublicV4Controller {
   constructor(private datasetsService: DatasetsService) {}

--- a/src/datasets/datasets-public.v4.controller.ts
+++ b/src/datasets/datasets-public.v4.controller.ts
@@ -37,11 +37,11 @@ import { AllowAny } from "src/auth/decorators/allow-any.decorator";
 
 @ApiExtraModels(HistoryClass, TechniqueClass, RelationshipClass)
 @ApiTags("datasets public v4")
-/* NOTE: SDK methods include "V4" twice.
-   - First "V4" comes from the controller class name.
-   - Second "V4" comes from the route version and is required for correct versioned routing.
-   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
-   and make the API harder to maintain. */
+/* NOTE: Generated SDK method names include "V4" twice:
+ *  - From the controller class name (DatasetsPublicV4Controller)
+ *  - From the route version (`version: '4'`)
+ * This is intentional for versioned routing.
+ */
 @Controller({ path: "datasets/public", version: "4" })
 export class DatasetsPublicV4Controller {
   constructor(private datasetsService: DatasetsService) {}

--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -97,11 +97,11 @@ import { TechniqueClass } from "./schemas/technique.schema";
   RelationshipClass,
 )
 @ApiTags("datasets v4")
-/* NOTE: SDK methods include "V4" twice.
-   - First "V4" comes from the controller class name.
-   - Second "V4" comes from the route version and is required for correct versioned routing.
-   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
-   and make the API harder to maintain. */
+/* NOTE: Generated SDK method names include "V4" twice:
+ *  - From the controller class name (DatasetsV4Controller)
+ *  - From the route version (`version: '4'`)
+ * This is intentional for versioned routing.
+ */
 @Controller({ path: "datasets", version: "4" })
 export class DatasetsV4Controller {
   constructor(

--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -97,6 +97,11 @@ import { TechniqueClass } from "./schemas/technique.schema";
   RelationshipClass,
 )
 @ApiTags("datasets v4")
+/* NOTE: SDK methods include "V4" twice.
+   - First "V4" comes from the controller class name.
+   - Second "V4" comes from the route version and is required for correct versioned routing.
+   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
+   and make the API harder to maintain. */
 @Controller({ path: "datasets", version: "4" })
 export class DatasetsV4Controller {
   constructor(

--- a/src/jobs/jobs.v4.controller.ts
+++ b/src/jobs/jobs.v4.controller.ts
@@ -47,6 +47,11 @@ import { ALLOWED_JOB_KEYS, ALLOWED_JOB_FILTER_KEYS } from "./types/job-lookup";
 
 @ApiBearerAuth()
 @ApiTags("jobs v4")
+/* NOTE: SDK methods include "V4" twice.
+   - First "V4" comes from the controller class name.
+   - Second "V4" comes from the route version and is required for correct versioned routing.
+   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
+   and make the API harder to maintain. */
 @Controller({ path: "jobs", version: "4" })
 export class JobsV4Controller {
   constructor(

--- a/src/jobs/jobs.v4.controller.ts
+++ b/src/jobs/jobs.v4.controller.ts
@@ -47,11 +47,11 @@ import { ALLOWED_JOB_KEYS, ALLOWED_JOB_FILTER_KEYS } from "./types/job-lookup";
 
 @ApiBearerAuth()
 @ApiTags("jobs v4")
-/* NOTE: SDK methods include "V4" twice.
-   - First "V4" comes from the controller class name.
-   - Second "V4" comes from the route version and is required for correct versioned routing.
-   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
-   and make the API harder to maintain. */
+/* NOTE: Generated SDK method names include "V4" twice:
+ *  - From the controller class name (JobsV4Controller)
+ *  - From the route version (`version: '4'`)
+ * This is intentional for versioned routing.
+ */
 @Controller({ path: "jobs", version: "4" })
 export class JobsV4Controller {
   constructor(

--- a/src/origdatablocks/origdatablocks-public.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks-public.v4.controller.ts
@@ -27,11 +27,11 @@ import { FilterValidationPipe } from "src/common/pipes/filter-validation.pipe";
 import { AllowAny } from "src/auth/decorators/allow-any.decorator";
 
 @ApiTags("origdatablocks public v4")
-/* NOTE: SDK methods include "V4" twice.
-   - First "V4" comes from the controller class name.
-   - Second "V4" comes from the route version and is required for correct versioned routing.
-   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
-   and make the API harder to maintain. */
+/* NOTE: Generated SDK method names include "V4" twice:
+ *  - From the controller class name (OrigDatablocksPublicV4Controller)
+ *  - From the route version (`version: '4'`)
+ * This is intentional for versioned routing.
+ */
 @Controller({ path: "origdatablocks/public", version: "4" })
 export class OrigDatablocksPublicV4Controller {
   constructor(private readonly origDatablocksService: OrigDatablocksService) {}

--- a/src/origdatablocks/origdatablocks-public.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks-public.v4.controller.ts
@@ -27,6 +27,11 @@ import { FilterValidationPipe } from "src/common/pipes/filter-validation.pipe";
 import { AllowAny } from "src/auth/decorators/allow-any.decorator";
 
 @ApiTags("origdatablocks public v4")
+/* NOTE: SDK methods include "V4" twice.
+   - First "V4" comes from the controller class name.
+   - Second "V4" comes from the route version and is required for correct versioned routing.
+   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
+   and make the API harder to maintain. */
 @Controller({ path: "origdatablocks/public", version: "4" })
 export class OrigDatablocksPublicV4Controller {
   constructor(private readonly origDatablocksService: OrigDatablocksService) {}

--- a/src/origdatablocks/origdatablocks.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.ts
@@ -70,11 +70,11 @@ import { FilterValidationPipe } from "src/common/pipes/filter-validation.pipe";
 
 @ApiBearerAuth()
 @ApiTags("origdatablocks v4")
-/* NOTE: SDK methods include "V4" twice.
-   - First "V4" comes from the controller class name.
-   - Second "V4" comes from the route version and is required for correct versioned routing.
-   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
-   and make the API harder to maintain. */
+/* NOTE: Generated SDK method names include "V4" twice:
+ *  - From the controller class name (OrigDatablocksV4Controller)
+ *  - From the route version (`version: '4'`)
+ * This is intentional for versioned routing.
+ */
 @Controller({ path: "origdatablocks", version: "4" })
 export class OrigDatablocksV4Controller {
   constructor(

--- a/src/origdatablocks/origdatablocks.v4.controller.ts
+++ b/src/origdatablocks/origdatablocks.v4.controller.ts
@@ -70,6 +70,11 @@ import { FilterValidationPipe } from "src/common/pipes/filter-validation.pipe";
 
 @ApiBearerAuth()
 @ApiTags("origdatablocks v4")
+/* NOTE: SDK methods include "V4" twice.
+   - First "V4" comes from the controller class name.
+   - Second "V4" comes from the route version and is required for correct versioned routing.
+   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
+   and make the API harder to maintain. */
 @Controller({ path: "origdatablocks", version: "4" })
 export class OrigDatablocksV4Controller {
   constructor(

--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -60,11 +60,11 @@ import { RegisteredFilterPipe } from "./pipes/registered.pipe";
 
 @ApiBearerAuth()
 @ApiTags("published data v4")
-/* NOTE: SDK methods include "V4" twice.
-   - First "V4" comes from the controller class name.
-   - Second "V4" comes from the route version and is required for correct versioned routing.
-   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
-   and make the API harder to maintain. */
+/* NOTE: Generated SDK method names include "V4" twice:
+ *  - From the controller class name (PublishedDataV4Controller)
+ *  - From the route version (`version: '4'`)
+ * This is intentional for versioned routing.
+ */
 @Controller({ path: "publisheddata", version: "4" })
 export class PublishedDataV4Controller {
   constructor(

--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -60,6 +60,11 @@ import { RegisteredFilterPipe } from "./pipes/registered.pipe";
 
 @ApiBearerAuth()
 @ApiTags("published data v4")
+/* NOTE: SDK methods include "V4" twice.
+   - First "V4" comes from the controller class name.
+   - Second "V4" comes from the route version and is required for correct versioned routing.
+   We considered manually defining operationId in each endpoint to solve this, but that would require many changes
+   and make the API harder to maintain. */
 @Controller({ path: "publisheddata", version: "4" })
 export class PublishedDataV4Controller {
   constructor(


### PR DESCRIPTION
## Description
This PR adds a comment in each v4 controller explaining why SDK methods include "V4" twice.

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
