### PR TITLE
fix: stricter date validation for encode

### DIFF
--- a/src/common/pipes/filter.pipe.ts
+++ b/src/common/pipes/filter.pipe.ts
@@ -153,7 +153,8 @@ export class WherePipe<T = unknown> extends FilterPipeAbstract<T> {
         },
       },
       valueFn: (val: unknown) => {
-        if (typeof val !== "string") return val;
+        if (typeof val !== "string" || !/^\d{4}-\d{2}-\d{2}/.test(val))
+          return val;
         const dateFromString = new Date(val);
         return isNaN(dateFromString.getTime()) ? val : dateFromString;
       },


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This will try to convert to dates only if they start with YYYY-MM-DD. This caused strings like "a-1234" to be converted to 1234 Jan 1
