### PR TITLE
feat(ldap-auth): make querying user groups possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `LDAP_GROUP_SEARCH_BASE` | string | Yes | Search base for the user groups. | |
 | `LDAP_GROUP_SEARCH_FILTER` | string | Yes | Search filter for the user groups. | |
 | `LDAP_ACCESS_GROUPS_PROPERTY`| string | Yes | Target field to get the access groups value from Ldap response. | |
+| `LDAP_USERNAME_ATTR`| string | Yes | Target field to get the username from the Ldap response. Defaults to displayName. | |
 | `OIDC_ISSUER` | string | Yes | URL of the OIDC server providing the authentication service. Example: https://identity.esss.dk/realm/ess. | |
 | `OIDC_CLIENT_ID` | string | Yes | Identity of the client used to obtain the user token. Example: scicat. | |
 | `OIDC_ADDITIONAL_AUTHORIZED_PARTIES` | string | No | Comma-separated list of additional OIDC client IDs allowed to present tokens to this backend. Used for token exchange scenarios where a third-party client obtains a token on behalf of a user. The client ID must appear as the `azp` claim in the token. Example: `additional-client1, additional-client2`. | |

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `ACCESS_GROUPS_STATIC_ENABLED` | string | Yes | Flag to enable/disable automatic assignment of predefined access groups to all users. | true |
 | `ACCESS_GROUPS_STATIC_VALUES` | string | Yes | Comma-separated list of access groups automatically assigned to all users. Example: "scicat, user". | |
 | `ACCESS_GROUPS_OIDCPAYLOAD_ENABLED` | string | Yes | Flag to enable/disable fetching access groups directly from OIDC response. Requires specifying a field via `OIDC_ACCESS_GROUPS_PROPERTY` to extract access groups. | false |
+| `ACCESS_GROUPS_LDAPPAYLOAD_ENABLED` | string | Yes | Flag to enable/disable fetching access groups directly from Ldap response. Requires specifying a field via `LDAP_ACCESS_GROUPS_PROPERTY` to extract access groups. | false |
 | `DOI_PREFIX` | string | | The facility DOI prefix, with trailing slash. | |
 | `DOI_SHORT_SUFFIX` | string | | By default `uuidv4` is used to generate the DOI suffix but if this flag is `true` the shorter version of 10 random characters is used as DOI suffix. | |
 | `DOI_USERNAME` | string | | The facility DOI DataCite username. | |
@@ -187,6 +188,9 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `LDAP_BIND_CREDENTIALS` | string | Yes | Credentials for your LDAP server. | |
 | `LDAP_SEARCH_BASE` | string | Yes | Search base for your LDAP server. | |
 | `LDAP_SEARCH_FILTER` | string | Yes | Search filter for your LDAP server. | |
+| `LDAP_GROUP_SEARCH_BASE` | string | Yes | Search base for the user groups. | |
+| `LDAP_GROUP_SEARCH_FILTER` | string | Yes | Search filter for the user groups. | |
+| `LDAP_ACCESS_GROUPS_PROPERTY`| string | Yes | Target field to get the access groups value from Ldap response. | |
 | `OIDC_ISSUER` | string | Yes | URL of the OIDC server providing the authentication service. Example: https://identity.esss.dk/realm/ess. | |
 | `OIDC_CLIENT_ID` | string | Yes | Identity of the client used to obtain the user token. Example: scicat. | |
 | `OIDC_ADDITIONAL_AUTHORIZED_PARTIES` | string | No | Comma-separated list of additional OIDC client IDs allowed to present tokens to this backend. Used for token exchange scenarios where a third-party client obtains a token on behalf of a user. The client ID must appear as the `azp` claim in the token. Example: `additional-client1, additional-client2`. | |

--- a/docs/index.md
+++ b/docs/index.md
@@ -135,6 +135,8 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `LDAP_BIND_CREDENTIALS` | string | Yes | Credentials for your LDAP server. | |
 | `LDAP_SEARCH_BASE` | string | Yes | Search base for your LDAP server. | |
 | `LDAP_SEARCH_FILTER` | string | Yes | Search filter for your LDAP server. | |
+| `LDAP_GROUP_SEARCH_BASE` | string | Yes | Search base for the user groups. | |
+| `LDAP_GROUP_SEARCH_FILTER` | string | Yes | Search filter for the user groups. | |
 | `OIDC_ISSUER` | string | Yes | URL of the OIDC server providing the authentication service. Example: https://identity.esss.dk/realm/ess. | |
 | `OIDC_CLIENT_ID` | string | Yes | Identity of the client used to obtain the user token. Example: scicat. | |
 | `OIDC_CLIENT_SECRET` | string | Yes | Secret to provide to the OIDC service to obtain the user token. Example: Aa1JIw3kv3mQlGFWhRrE3gOdkH6xreAwro. | |

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,7 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `ACCESS_GROUPS_STATIC_ENABLED` | string | Yes | Flag to enable/disable automatic assignment of predefined access groups to all users. | true |
 | `ACCESS_GROUPS_STATIC_VALUES` | string | Yes | Comma-separated list of access groups automatically assigned to all users. Example: "scicat, user". | |
 | `ACCESS_GROUPS_OIDCPAYLOAD_ENABLED` | string | Yes | Flag to enable/disable fetching access groups directly from OIDC response. Requires specifying a field via `OIDC_ACCESS_GROUPS_PROPERTY` to extract access groups. | false |
+| `ACCESS_GROUPS_LDAPPAYLOAD_ENABLED` | string | Yes | Flag to enable/disable fetching access groups directly from Ldap response. Requires specifying a field via `LDAP_ACCESS_GROUPS_PROPERTY` to extract access groups. | false |
 | `DOI_PREFIX` | string | | The facility DOI prefix, with trailing slash. | |
 | `EXPRESS_SESSION_SECRET` | string | No | Secret used to set up express session. Required if using OIDC authentication | |
 | `HTTP_MAX_REDIRECTS` | number | Yes | Max redirects for HTTP requests. | 5 |
@@ -137,6 +138,7 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `LDAP_SEARCH_FILTER` | string | Yes | Search filter for your LDAP server. | |
 | `LDAP_GROUP_SEARCH_BASE` | string | Yes | Search base for the user groups. | |
 | `LDAP_GROUP_SEARCH_FILTER` | string | Yes | Search filter for the user groups. | |
+| `LDAP_ACCESS_GROUPS_PROPERTY`| string | Yes | Target field to get the access groups value from Ldap response. | |
 | `OIDC_ISSUER` | string | Yes | URL of the OIDC server providing the authentication service. Example: https://identity.esss.dk/realm/ess. | |
 | `OIDC_CLIENT_ID` | string | Yes | Identity of the client used to obtain the user token. Example: scicat. | |
 | `OIDC_CLIENT_SECRET` | string | Yes | Secret to provide to the OIDC service to obtain the user token. Example: Aa1JIw3kv3mQlGFWhRrE3gOdkH6xreAwro. | |

--- a/docs/index.md
+++ b/docs/index.md
@@ -139,6 +139,7 @@ Valid environment variables for the .env file. See [.env.example](/.env.example)
 | `LDAP_GROUP_SEARCH_BASE` | string | Yes | Search base for the user groups. | |
 | `LDAP_GROUP_SEARCH_FILTER` | string | Yes | Search filter for the user groups. | |
 | `LDAP_ACCESS_GROUPS_PROPERTY`| string | Yes | Target field to get the access groups value from Ldap response. | |
+| `LDAP_USERNAME_ATTR`| string | Yes | Target field to get the username from the Ldap response. Defaults to displayName. | |
 | `OIDC_ISSUER` | string | Yes | URL of the OIDC server providing the authentication service. Example: https://identity.esss.dk/realm/ess. | |
 | `OIDC_CLIENT_ID` | string | Yes | Identity of the client used to obtain the user token. Example: scicat. | |
 | `OIDC_CLIENT_SECRET` | string | Yes | Secret to provide to the OIDC service to obtain the user token. Example: Aa1JIw3kv3mQlGFWhRrE3gOdkH6xreAwro. | |

--- a/src/auth/access-group-provider/access-group-from-ldap.service.spec.ts
+++ b/src/auth/access-group-provider/access-group-from-ldap.service.spec.ts
@@ -1,10 +1,10 @@
 import { ConfigService } from "@nestjs/config";
 import { Test, TestingModule } from "@nestjs/testing";
 import { UserPayload } from "../interfaces/userPayload.interface";
-import { AccessGroupFromPayloadService } from "./access-group-from-payload.service";
+import { AccessGroupFromLdapService } from "./access-group-from-ldap.service";
 
-describe("AccessGroupFromPayloadService", () => {
-  let service: AccessGroupFromPayloadService;
+describe("AccessGroupFromLdapService", () => {
+  let service: AccessGroupFromLdapService;
 
   const mockConfigService = {
     get: () => "access_group_property",
@@ -12,14 +12,14 @@ describe("AccessGroupFromPayloadService", () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AccessGroupFromPayloadService, ConfigService],
+      providers: [AccessGroupFromLdapService, ConfigService],
     })
       .overrideProvider(ConfigService)
       .useValue(mockConfigService)
       .compile();
 
-    service = module.get<AccessGroupFromPayloadService>(
-      AccessGroupFromPayloadService,
+    service = module.get<AccessGroupFromLdapService>(
+      AccessGroupFromLdapService,
     );
   });
 

--- a/src/auth/access-group-provider/access-group-from-ldap.service.spec.ts
+++ b/src/auth/access-group-provider/access-group-from-ldap.service.spec.ts
@@ -6,16 +6,14 @@ import { AccessGroupFromLdapService } from "./access-group-from-ldap.service";
 describe("AccessGroupFromLdapService", () => {
   let service: AccessGroupFromLdapService;
 
-  const mockConfigService = {
-    get: () => "access_group_property",
-  };
+  const mockAccessService = new AccessGroupFromLdapService("cn");
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [AccessGroupFromLdapService, ConfigService],
     })
-      .overrideProvider(ConfigService)
-      .useValue(mockConfigService)
+      .overrideProvider(AccessGroupFromLdapService)
+      .useValue(mockAccessService)
       .compile();
 
     service = module.get<AccessGroupFromLdapService>(
@@ -30,7 +28,6 @@ describe("AccessGroupFromLdapService", () => {
   it("Should resolve access groups", async () => {
     const userPayload = {
       userId: "test_user",
-      accessGroupProperty: "_groups",
       payload: {
         _groups: [
           {

--- a/src/auth/access-group-provider/access-group-from-ldap.service.spec.ts
+++ b/src/auth/access-group-provider/access-group-from-ldap.service.spec.ts
@@ -1,0 +1,51 @@
+import { ConfigService } from "@nestjs/config";
+import { Test, TestingModule } from "@nestjs/testing";
+import { UserPayload } from "../interfaces/userPayload.interface";
+import { AccessGroupFromPayloadService } from "./access-group-from-payload.service";
+
+describe("AccessGroupFromPayloadService", () => {
+  let service: AccessGroupFromPayloadService;
+
+  const mockConfigService = {
+    get: () => "access_group_property",
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [AccessGroupFromPayloadService, ConfigService],
+    })
+      .overrideProvider(ConfigService)
+      .useValue(mockConfigService)
+      .compile();
+
+    service = module.get<AccessGroupFromPayloadService>(
+      AccessGroupFromPayloadService,
+    );
+  });
+
+  it("should be defined", () => {
+    expect(service).toBeDefined();
+  });
+
+  it("Should resolve access groups", async () => {
+    const userPayload = {
+      userId: "test_user",
+      accessGroupProperty: "_groups",
+      payload: {
+        _groups: [
+          {
+            dn: 'cn=test_group,cn=groups,cn=accounts,dc=example,dc=com',
+            cn: 'testgroup',
+          },
+          {
+            dn: 'cn=example_group,cn=groups,cn=accounts,dc=example,dc=com',
+            cn: 'examplegroup',
+          }
+        ],
+      },
+    };
+    const expected = ["testgroup", "examplegroup"];
+    const actual = await service.getAccessGroups(userPayload as UserPayload);
+    expect(actual).toEqual(expected);
+  });
+});

--- a/src/auth/access-group-provider/access-group-from-ldap.service.spec.ts
+++ b/src/auth/access-group-provider/access-group-from-ldap.service.spec.ts
@@ -34,13 +34,13 @@ describe("AccessGroupFromPayloadService", () => {
       payload: {
         _groups: [
           {
-            dn: 'cn=test_group,cn=groups,cn=accounts,dc=example,dc=com',
-            cn: 'testgroup',
+            dn: "cn=test_group,cn=groups,cn=accounts,dc=example,dc=com",
+            cn: "testgroup",
           },
           {
-            dn: 'cn=example_group,cn=groups,cn=accounts,dc=example,dc=com',
-            cn: 'examplegroup',
-          }
+            dn: "cn=example_group,cn=groups,cn=accounts,dc=example,dc=com",
+            cn: "examplegroup",
+          },
         ],
       },
     };

--- a/src/auth/access-group-provider/access-group-from-ldap.service.ts
+++ b/src/auth/access-group-provider/access-group-from-ldap.service.ts
@@ -13,7 +13,7 @@ export class AccessGroupFromLdapService extends AccessGroupService {
   }
 
   async getAccessGroups(userPayload: UserPayload): Promise<string[]> {
-    let accessGroups: string[] = [];
+    const accessGroups: string[] = [];
 
     const accessGroupsProperty = userPayload.accessGroupProperty;
     if (accessGroupsProperty) {
@@ -24,9 +24,9 @@ export class AccessGroupFromLdapService extends AccessGroupService {
       ) {
         for (const group of payload[accessGroupsProperty]) {
           if (
-              typeof group === "object" &&
-              "cn" in group &&
-              typeof group["cn"] === "string"
+            typeof group === "object" &&
+            "cn" in group &&
+            typeof group["cn"] === "string"
           ) {
             accessGroups.push(group["cn"]);
           }

--- a/src/auth/access-group-provider/access-group-from-ldap.service.ts
+++ b/src/auth/access-group-provider/access-group-from-ldap.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
 import { UserPayload } from "../interfaces/userPayload.interface";
 import { AccessGroupService } from "./access-group.service";
 
@@ -8,27 +7,24 @@ import { AccessGroupService } from "./access-group.service";
  */
 @Injectable()
 export class AccessGroupFromLdapService extends AccessGroupService {
-  constructor(private configService: ConfigService) {
+  constructor(private accessGroupProperty: string) {
     super();
   }
 
   async getAccessGroups(userPayload: UserPayload): Promise<string[]> {
     const accessGroups: string[] = [];
 
-    const accessGroupsProperty = userPayload.accessGroupProperty;
+    const accessGroupsProperty = this.accessGroupProperty;
     if (accessGroupsProperty) {
       const payload: Record<string, unknown> | undefined = userPayload.payload;
-      if (
-        payload !== undefined &&
-        Array.isArray(payload[accessGroupsProperty])
-      ) {
-        for (const group of payload[accessGroupsProperty]) {
+      if (payload !== undefined && Array.isArray(payload["_groups"])) {
+        for (const group of payload["_groups"]) {
           if (
             typeof group === "object" &&
-            "cn" in group &&
-            typeof group["cn"] === "string"
+            accessGroupsProperty in group &&
+            typeof group[accessGroupsProperty] === "string"
           ) {
-            accessGroups.push(group["cn"]);
+            accessGroups.push(group[accessGroupsProperty]);
           }
         }
       }

--- a/src/auth/access-group-provider/access-group-from-ldap.service.ts
+++ b/src/auth/access-group-provider/access-group-from-ldap.service.ts
@@ -1,20 +1,18 @@
-//import { AccessGroupService as AccessGroupService } from "./access-group.service";
 import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import { UserPayload } from "../interfaces/userPayload.interface";
 import { AccessGroupService } from "./access-group.service";
-import { UserPayload } from "src/auth/interfaces/userPayload.interface";
 
 /**
- * This service is used to get the access groups from the payload of the IDP.
+ * This service is used to get the access groups from the payload of the ldap IDP.
  */
 @Injectable()
-export class AccessGroupFromPayloadService extends AccessGroupService {
+export class AccessGroupFromLdapService extends AccessGroupService {
   constructor(private configService: ConfigService) {
     super();
   }
 
   async getAccessGroups(userPayload: UserPayload): Promise<string[]> {
-    //const defaultAccessGroups: string[] = [];
     let accessGroups: string[] = [];
 
     const accessGroupsProperty = userPayload.accessGroupProperty;
@@ -24,15 +22,18 @@ export class AccessGroupFromPayloadService extends AccessGroupService {
         payload !== undefined &&
         Array.isArray(payload[accessGroupsProperty])
       ) {
-        for (var group of payload[accessGroupsProperty]) {
-          if (typeof group === "string") {
-            accessGroups.push(group);
+        for (const group of payload[accessGroupsProperty]) {
+          if (
+              typeof group === "object" &&
+              "cn" in group &&
+              typeof group["cn"] === "string"
+          ) {
+            accessGroups.push(group["cn"]);
           }
         }
       }
-      Logger.log(accessGroups, "AccessGroupFromPayloadService");
+      Logger.log(accessGroups, "AccessGroupFromLdapService");
     }
-
     return accessGroups;
   }
 }

--- a/src/auth/access-group-provider/access-group-from-payload.service.ts
+++ b/src/auth/access-group-provider/access-group-from-payload.service.ts
@@ -15,7 +15,7 @@ export class AccessGroupFromPayloadService extends AccessGroupService {
 
   async getAccessGroups(userPayload: UserPayload): Promise<string[]> {
     //const defaultAccessGroups: string[] = [];
-    let accessGroups: string[] = [];
+    const accessGroups: string[] = [];
 
     const accessGroupsProperty = userPayload.accessGroupProperty;
     if (accessGroupsProperty) {
@@ -24,7 +24,7 @@ export class AccessGroupFromPayloadService extends AccessGroupService {
         payload !== undefined &&
         Array.isArray(payload[accessGroupsProperty])
       ) {
-        for (var group of payload[accessGroupsProperty]) {
+        for (const group of payload[accessGroupsProperty]) {
           if (typeof group === "string") {
             accessGroups.push(group);
           }

--- a/src/auth/access-group-provider/access-group-service-factory.ts
+++ b/src/auth/access-group-provider/access-group-service-factory.ts
@@ -54,9 +54,7 @@ export const accessGroupServiceFactory = {
         JSON.stringify(accessGroupsLdapPayloadConfig),
         "loading ldap processor",
       );
-      accessGroupServices.push(
-        new AccessGroupFromLdapService(configService),
-      );
+      accessGroupServices.push(new AccessGroupFromLdapService(configService));
     }
 
     if (accessGroupsGraphQlConfig?.enabled == true) {

--- a/src/auth/access-group-provider/access-group-service-factory.ts
+++ b/src/auth/access-group-provider/access-group-service-factory.ts
@@ -4,6 +4,7 @@ import { AccessGroupService } from "./access-group.service";
 import { AccessGroupFromGraphQLApiService } from "./access-group-from-graphql-api-call.service";
 import { AccessGroupFromPayloadService } from "./access-group-from-payload.service";
 import { AccessGroupFromRestApiService } from "./access-group-from-rest-api-call.service";
+import { AccessGroupFromLdapService } from "./access-group-from-ldap.service";
 import { HttpService } from "@nestjs/axios";
 import { AccessGroupFromMultipleProvidersService } from "./access-group-from-multiple-providers.service";
 import { Logger } from "@nestjs/common";
@@ -22,6 +23,9 @@ export const accessGroupServiceFactory = {
     );
     const accessGroupsOIDCPayloadConfig = configService.get(
       "accessGroupsOIDCPayloadConfig",
+    );
+    const accessGroupsLdapPayloadConfig = configService.get(
+      "accessGroupsLdapPayloadConfig",
     );
 
     const accessGroupsRestConfig = configService.get("accessGroupsRestConfig");
@@ -43,6 +47,15 @@ export const accessGroupServiceFactory = {
       );
       accessGroupServices.push(
         new AccessGroupFromPayloadService(configService),
+      );
+    }
+    if (accessGroupsLdapPayloadConfig?.enabled == true) {
+      Logger.log(
+        JSON.stringify(accessGroupsLdapPayloadConfig),
+        "loading ldap processor",
+      );
+      accessGroupServices.push(
+        new AccessGroupFromLdapService(configService),
       );
     }
 

--- a/src/auth/access-group-provider/access-group-service-factory.ts
+++ b/src/auth/access-group-provider/access-group-service-factory.ts
@@ -54,7 +54,12 @@ export const accessGroupServiceFactory = {
         JSON.stringify(accessGroupsLdapPayloadConfig),
         "loading ldap processor",
       );
-      accessGroupServices.push(new AccessGroupFromLdapService(configService));
+
+      accessGroupServices.push(
+        new AccessGroupFromLdapService(
+          accessGroupsLdapPayloadConfig?.accessGroupProperty,
+        ),
+      );
     }
 
     if (accessGroupsGraphQlConfig?.enabled == true) {

--- a/src/auth/strategies/ldap.strategy.ts
+++ b/src/auth/strategies/ldap.strategy.ts
@@ -58,6 +58,8 @@ export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
         userId: user.id as string,
         username: user.username,
         email: user.email,
+        accessGroupProperty: "_groups",
+        payload: payload,
       };
       const accessGroups =
         await this.accessGroupService.getAccessGroups(userPayload);
@@ -99,6 +101,8 @@ export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
         userId: user.id as string,
         username: user.username,
         email: user.email,
+        accessGroupProperty: "_groups",
+        payload: payload,
       };
       const userIdentity = await this.usersService.findByIdUserIdentity(
         user._id,

--- a/src/auth/strategies/ldap.strategy.ts
+++ b/src/auth/strategies/ldap.strategy.ts
@@ -15,13 +15,16 @@ import { LdapConfig } from "src/config/configuration";
 
 @Injectable()
 export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
+  readonly ldapOptions: LdapConfig;
+
   constructor(
-    private configService: ConfigService,
+    configService: ConfigService,
     private usersService: UsersService,
     private accessGroupService: AccessGroupService,
   ) {
     const ldapOptions = configService.get<LdapConfig>("ldap")!;
     super(ldapOptions);
+    this.ldapOptions = ldapOptions;
   }
 
   async validate(
@@ -124,12 +127,12 @@ export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
   }
 
   private getUsername(payload: Record<string, unknown>) {
-    const userattr = this.configService.get<string>("usernameAttr") as string;
+    const userattr = this.ldapOptions.server.usernameAttr;
     if (userattr in payload) {
       return payload[userattr] as string;
     }
     throw new InternalServerErrorException(
-      "usernameAttr incorrectly configured: s" + userattr,
+      "usernameAttr incorrectly configured: " + userattr,
     );
   }
 

--- a/src/auth/strategies/ldap.strategy.ts
+++ b/src/auth/strategies/ldap.strategy.ts
@@ -129,7 +129,7 @@ export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
       return payload[userattr] as string;
     }
     throw new InternalServerErrorException(
-      "usernameAttr incorrectly configured",
+      "usernameAttr incorrectly configured: s" + userattr,
     );
   }
 

--- a/src/auth/strategies/ldap.strategy.ts
+++ b/src/auth/strategies/ldap.strategy.ts
@@ -21,7 +21,6 @@ export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
     private accessGroupService: AccessGroupService,
   ) {
     const ldapOptions = configService.get<LdapConfig>("ldap")!;
-
     super(ldapOptions);
   }
 
@@ -58,7 +57,6 @@ export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
         userId: user.id as string,
         username: user.username,
         email: user.email,
-        accessGroupProperty: "_groups",
         payload: payload,
       };
       const accessGroups =
@@ -101,7 +99,6 @@ export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
         userId: user.id as string,
         username: user.username,
         email: user.email,
-        accessGroupProperty: "_groups",
         payload: payload,
       };
       const userIdentity = await this.usersService.findByIdUserIdentity(

--- a/src/auth/strategies/ldap.strategy.ts
+++ b/src/auth/strategies/ldap.strategy.ts
@@ -16,7 +16,7 @@ import { LdapConfig } from "src/config/configuration";
 @Injectable()
 export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
   constructor(
-    configService: ConfigService,
+    private configService: ConfigService,
     private usersService: UsersService,
     private accessGroupService: AccessGroupService,
   ) {
@@ -29,10 +29,11 @@ export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
   ): Promise<Omit<User, "password">> {
     // add exception if displayName is empty
 
+    const username = this.getUsername(payload);
     const userFilter: FilterQuery<UserDocument> = {
       $or: [
-        { username: `ldap.${payload.displayName}` },
-        { username: payload.displayName as string },
+        { username: `ldap.${username}` },
+        { username: username as string },
         { email: payload.mail as string },
       ],
     };
@@ -40,7 +41,7 @@ export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
 
     if (!userExists) {
       const createUser: CreateUserDto = {
-        username: payload.displayName as string, //`ldap.${payload.displayName}`,
+        username: username as string,
         email: payload.mail as string,
         authStrategy: "ldap",
       };
@@ -67,9 +68,9 @@ export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
         credentials: {},
         externalId: payload.sAMAccountName as string,
         profile: {
-          displayName: payload.displayName as string,
+          displayName: username as string,
           email: payload.mail as string,
-          username: payload.displayName as string,
+          username: username as string,
           thumbnailPhoto: payload.thumbnailPhoto
             ? "data:image/jpeg;base64," +
               Buffer.from(payload.thumbnailPhoto as string, "binary").toString(
@@ -122,13 +123,24 @@ export class LdapStrategy extends PassportStrategy(Strategy, "ldap") {
     return user;
   }
 
+  private getUsername(payload: Record<string, unknown>) {
+    const userattr = this.configService.get<string>("usernameAttr") as string;
+    if (userattr in payload) {
+      return payload[userattr] as string;
+    }
+    throw new InternalServerErrorException(
+      "usernameAttr incorrectly configured",
+    );
+  }
+
   getProfile(payload: Record<string, unknown>) {
     type ldapProfile = Profile & UserProfile;
     const profile = {} as ldapProfile;
+    const username = this.getUsername(payload);
 
-    profile.displayName = payload.displayName as string;
+    profile.displayName = username as string;
     profile.email = payload.mail as string;
-    profile.username = payload.displayName as string;
+    profile.username = username as string;
     profile.thumbnailPhoto = payload.thumbnailPhoto
       ? "data:image/jpeg;base64," +
         Buffer.from(payload.thumbnailPhoto as string, "binary").toString(

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -337,7 +337,7 @@ const configuration = () => {
         groupSearchFilter: process.env.LDAP_GROUP_SEARCH_FILTER || "",
         Mode: process.env.LDAP_MODE ?? "ad",
         externalIdAttr: process.env.LDAP_EXTERNAL_ID ?? "sAMAccountName",
-        usernameAttr: process.env.LDAP_USERNAME ?? "displayName",
+        usernameAttr: process.env.LDAP_USERNAME_ATTR ?? "displayName",
       },
     },
     oidc: {

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -306,6 +306,10 @@ const configuration = () => {
       apiUrl: process.env.ACCESS_GROUPS_SERVICE_REST_API_URL,
       userIdField: process.env.ACCESS_GROUPS_SERVICE_REST_USER_ID_FIELD,
     },
+    accessGroupsLdapPayloadConfig: {
+      enabled: boolean(process.env?.ACCESS_GROUPS_LDAPPAYLOAD_ENABLED || false),
+      accessGroupProperty: process.env?.LDAP_ACCESS_GROUPS_PROPERTY, // Example: groups
+    },
     doiPrefix: process.env.DOI_PREFIX,
     expressSession: {
       secret: process.env.EXPRESS_SESSION_SECRET,
@@ -329,6 +333,8 @@ const configuration = () => {
         bindCredentials: process.env.LDAP_BIND_CREDENTIALS || "",
         searchBase: process.env.LDAP_SEARCH_BASE || "",
         searchFilter: process.env.LDAP_SEARCH_FILTER || "",
+        groupSearchBase: process.env.LDAP_GROUP_SEARCH_BASE || "",
+        groupSearchFilter: process.env.LDAP_GROUP_SEARCH_FILTER || "",
         Mode: process.env.LDAP_MODE ?? "ad",
         externalIdAttr: process.env.LDAP_EXTERNAL_ID ?? "sAMAccountName",
         usernameAttr: process.env.LDAP_USERNAME ?? "displayName",

--- a/src/config/configuration.ts
+++ b/src/config/configuration.ts
@@ -308,7 +308,7 @@ const configuration = () => {
     },
     accessGroupsLdapPayloadConfig: {
       enabled: boolean(process.env?.ACCESS_GROUPS_LDAPPAYLOAD_ENABLED || false),
-      accessGroupProperty: process.env?.LDAP_ACCESS_GROUPS_PROPERTY, // Example: groups
+      accessGroupProperty: process.env?.LDAP_ACCESS_GROUPS_PROPERTY || "cn", // Examples: "cn" or "ou"
     },
     doiPrefix: process.env.DOI_PREFIX,
     expressSession: {


### PR DESCRIPTION
The ldap authenticator did not query the groups from ldap until now.

Add the required config options for getting the groups from ldap. For this we just expose the existing options from node-ldapauth-fork/passport-ldapauth from the SciCat config.
Add a group extraction service for the LDAP response and register it to the servicefactory if enabled.

Additional fixes:
The `AccessGroupFromPayloadService` did not correctly check whether the elements in `payload[accessGroupsProperty]` are strings.
