### PR TITLE
refactor: remove unused code using Action.DatasetReadManyOwner

### DIFF
--- a/src/datasets/datasets-access.service.ts
+++ b/src/datasets/datasets-access.service.ts
@@ -194,7 +194,6 @@ export class DatasetsAccessService {
       Action.DatasetReadManyAccess,
       DatasetClass,
     );
-    const canViewOwner = ability.can(Action.DatasetReadManyOwner, DatasetClass);
 
     if (!canViewAny) {
       if (canViewAccess) {
@@ -206,12 +205,6 @@ export class DatasetsAccessService {
               { sharedWith: { $in: [currentUser.email] } },
               { isPublished: true },
             ],
-          },
-        });
-      } else if (canViewOwner) {
-        fieldValue.$lookup.pipeline?.unshift({
-          $match: {
-            ownerGroup: { $in: currentUser.currentGroups },
           },
         });
       } else {

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -168,7 +168,7 @@ export class DatasetsController {
 
     const ability = this.caslAbilityFactory.datasetInstanceAccess(user);
     const canViewAny = ability.can(Action.DatasetReadAny, DatasetClass);
-    const canViewOwner = ability.can(Action.DatasetReadManyOwner, DatasetClass);
+
     const canViewAccess = ability.can(
       Action.DatasetReadManyAccess,
       DatasetClass,
@@ -205,11 +205,6 @@ export class DatasetsController {
             },
           ];
         }
-      } else if (canViewOwner) {
-        mergedFilters.where = {
-          ...mergedFilters.where,
-          ownerGroup: { $in: user.currentGroups },
-        };
       } else if (canViewPublic) {
         mergedFilters.where = {
           ...mergedFilters.where,
@@ -982,16 +977,9 @@ export class DatasetsController {
         Action.DatasetReadManyAccess,
         DatasetClass,
       );
-      const canViewOwner = ability.can(
-        Action.DatasetReadManyOwner,
-        DatasetClass,
-      );
       if (canViewAccess) {
         fields.userGroups = fields.userGroups ?? [];
         fields.userGroups.push(...user.currentGroups);
-      } else if (canViewOwner) {
-        fields.ownerGroup = fields.ownerGroup ?? [];
-        fields.ownerGroup.push(...user.currentGroups);
       } else {
         fields.isPublished = true;
       }
@@ -1064,17 +1052,10 @@ export class DatasetsController {
         Action.DatasetReadManyAccess,
         DatasetClass,
       );
-      const canViewOwner = ability.can(
-        Action.DatasetReadManyOwner,
-        DatasetClass,
-      );
 
       if (canViewAccess) {
         fields.userGroups = fields.userGroups ?? [];
         fields.userGroups.push(...user.currentGroups);
-      } else if (canViewOwner) {
-        fields.ownerGroup = fields.ownerGroup ?? [];
-        fields.ownerGroup.push(...user.currentGroups);
       } else {
         fields.isPublished = true;
       }
@@ -1135,31 +1116,15 @@ export class DatasetsController {
     const canViewAny = ability.can(Action.DatasetReadAny, DatasetClass);
 
     if (!canViewAny && !fields.isPublished) {
-      // delete fields.isPublished;
 
       const canViewAccess = ability.can(
         Action.DatasetReadManyAccess,
         DatasetClass,
       );
-      const canViewOwner = ability.can(
-        Action.DatasetReadManyOwner,
-        DatasetClass,
-      );
-      // const canViewPublic = ability.can(
-      //   Action.DatasetReadManyPublic,
-      //   DatasetClass,
-      // );
 
       if (canViewAccess) {
         fields.userGroups?.push(...user.currentGroups);
-        // fields.sharedWith = user.email;
-        // fields.isPublished = true; //are they in or?
-      } else if (canViewOwner) {
-        fields.ownerGroup?.push(...user.currentGroups);
       }
-      // else if (canViewPublic) {
-      //   fields.isPublished = true;
-      // }
     }
 
     const parsedFilters: IFilters<DatasetDocument, IDatasetFields> = {

--- a/src/datasets/datasets.v4.controller.ts
+++ b/src/datasets/datasets.v4.controller.ts
@@ -218,7 +218,6 @@ export class DatasetsV4Controller {
   ): IDatasetFiltersV4<DatasetDocument, IDatasetFields> {
     const ability = this.caslAbilityFactory.datasetInstanceAccess(user);
     const canViewAny = ability.can(Action.DatasetReadAny, DatasetClass);
-    const canViewOwner = ability.can(Action.DatasetReadManyOwner, DatasetClass);
     const canViewAccess = ability.can(
       Action.DatasetReadManyAccess,
       DatasetClass,
@@ -251,11 +250,6 @@ export class DatasetsV4Controller {
             },
           ];
         }
-      } else if (canViewOwner) {
-        filter.where = {
-          ...filter.where,
-          ownerGroup: { $in: user.currentGroups },
-        };
       }
     }
 
@@ -495,17 +489,10 @@ export class DatasetsV4Controller {
         Action.DatasetReadManyAccess,
         DatasetClass,
       );
-      const canViewOwner = ability.can(
-        Action.DatasetReadManyOwner,
-        DatasetClass,
-      );
 
       if (canViewAccess) {
         fields.userGroups = fields.userGroups ?? [];
         fields.userGroups.push(...user.currentGroups);
-      } else if (canViewOwner) {
-        fields.ownerGroup = fields.ownerGroup ?? [];
-        fields.ownerGroup.push(...user.currentGroups);
       }
     }
 
@@ -567,15 +554,9 @@ export class DatasetsV4Controller {
         Action.DatasetReadManyAccess,
         DatasetClass,
       );
-      const canViewOwner = ability.can(
-        Action.DatasetReadManyOwner,
-        DatasetClass,
-      );
 
       if (canViewAccess) {
         fields.userGroups?.push(...user.currentGroups);
-      } else if (canViewOwner) {
-        fields.ownerGroup?.push(...user.currentGroups);
       }
     }
 

--- a/src/proposals/proposals.controller.ts
+++ b/src/proposals/proposals.controller.ts
@@ -982,10 +982,7 @@ export class ProposalsController {
         Action.DatasetReadManyAccess,
         DatasetClass,
       );
-      const canViewOwner = ability.can(
-        Action.DatasetReadManyOwner,
-        DatasetClass,
-      );
+      
       const canViewPublic = ability.can(
         Action.DatasetReadManyPublic,
         DatasetClass,
@@ -994,9 +991,6 @@ export class ProposalsController {
         fields.userGroups = user.currentGroups ?? [];
         fields.userGroups.push(...user.currentGroups);
         // fields.sharedWith = user.email;
-      } else if (canViewOwner) {
-        fields.ownerGroup = user.currentGroups ?? [];
-        fields.ownerGroup.push(...user.currentGroups);
       } else if (canViewPublic) {
         fields.isPublished = true;
       }

--- a/src/samples/samples.controller.ts
+++ b/src/samples/samples.controller.ts
@@ -1009,10 +1009,6 @@ export class SamplesController {
         Action.DatasetReadManyAccess,
         DatasetClass,
       );
-      const canViewOwner = ability.can(
-        Action.DatasetReadManyOwner,
-        DatasetClass,
-      );
       const canViewPublic = ability.can(
         Action.DatasetReadManyPublic,
         DatasetClass,
@@ -1021,9 +1017,6 @@ export class SamplesController {
         fields.userGroups = user.currentGroups ?? [];
         fields.userGroups.push(...user.currentGroups);
         // fields.sharedWith = user.email;
-      } else if (canViewOwner) {
-        fields.ownerGroup = user.currentGroups ?? [];
-        fields.ownerGroup.push(...user.currentGroups);
       } else if (canViewPublic) {
         fields.isPublished = true;
       }


### PR DESCRIPTION
## Description
Variable `canViewAccess` is true for all authenticated users.

`Action.DatasetReadManyOwner` is never granted, even if was it would presumably only be for authenticated users which means the code removed would never be reached anyway. 

## Motivation
Cleanup

## Tests included

- [x ] Included for each change/fix?
- [x] Passing?

