### PR TITLE
fix: avoid register endpoint to override nested

### DIFF
--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -58,6 +58,7 @@ import {
 } from "./schemas/published-data.schema";
 import { V4_FILTER_PIPE } from "./pipes/filter.pipe";
 import { ILimitsFilter } from "src/common/interfaces/common.interface";
+import { cloneDeep } from "lodash";
 
 @ApiBearerAuth()
 @ApiTags("published data v4")
@@ -569,12 +570,18 @@ export class PublishedDataV4Controller {
 
     await this.validateMetadata(publishedData.metadata);
 
+    const mergePatchRequest = cloneDeep(request);
+    mergePatchRequest.headers["content-type"] = "application/merge-patch+json";
     await Promise.all(
       publishedData.datasetPids.map(async (pid) => {
-        await this.datasetsController.findByIdAndUpdate(request, pid, {
-          isPublished: true,
-          datasetlifecycle: { publishedOn: data.registeredTime },
-        });
+        await this.datasetsController.findByIdAndUpdate(
+          mergePatchRequest,
+          pid,
+          {
+            isPublished: true,
+            datasetlifecycle: { publishedOn: data.registeredTime },
+          },
+        );
       }),
     );
 

--- a/test/jest-e2e-tests/publishedData.e2e-spec.ts
+++ b/test/jest-e2e-tests/publishedData.e2e-spec.ts
@@ -8,6 +8,10 @@ import request from "supertest";
 import { getToken } from "../LoginUtils";
 import { TestData } from "../TestData";
 import { createTestingApp, createTestingModuleFactory } from "./utlis";
+import { CreateDatasetObsoleteDto } from "src/datasets/dto/create-dataset-obsolete.dto";
+import { DatasetSchema } from "src/datasets/schemas/dataset.schema";
+import { PublishedDataSchema } from "src/published-data/schemas/published-data.schema";
+import { omit } from "lodash";
 
 describe.each([undefined, "", "https://api.test.datacite.org/dois"])(
   "Published data datacite test (url: %p)",
@@ -18,6 +22,7 @@ describe.each([undefined, "", "https://api.test.datacite.org/dois"])(
     let httpService: HttpService;
 
     let doi: string;
+    let dataset: CreateDatasetObsoleteDto;
 
     beforeAll(async () => {
       if (registerDoiUri) {
@@ -40,9 +45,19 @@ describe.each([undefined, "", "https://api.test.datacite.org/dois"])(
     });
 
     beforeAll(async () => {
+      const createDatasetResponse = await request(app.getHttpServer())
+        .post("/api/v3/datasets")
+        .send(TestData.RawCorrectMin)
+        .auth(token, { type: "bearer" })
+        .set("Accept", "application/json")
+        .expect(TestData.EntryCreatedStatusCode);
+      dataset = createDatasetResponse.body;
       await request(app.getHttpServer())
         .post("/api/v4/PublishedData")
-        .send(TestData.PublishedDataV4)
+        .send({
+          ...TestData.PublishedDataV4,
+          datasetPids: [createDatasetResponse.body.pid],
+        })
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${token}` })
         .expect(TestData.EntryCreatedStatusCode)
@@ -53,6 +68,12 @@ describe.each([undefined, "", "https://api.test.datacite.org/dois"])(
     afterAll(async () => {
       if (mongoConnection.db) await mongoConnection.db.dropDatabase();
       await app.close();
+
+      // Remove pre-save hooks added by forFeatureAsync factories to prevent
+      // stale closures from accumulating across describe.each iterations
+      for (const schema of [DatasetSchema, PublishedDataSchema]) {
+        schema.s.hooks._pres.get("save")?.splice(0);
+      }
     });
 
     it("Should register this new published data", async () => {
@@ -74,6 +95,21 @@ describe.each([undefined, "", "https://api.test.datacite.org/dois"])(
         .set({ Authorization: `Bearer ${token}` })
         .expect(TestData.EntryCreatedStatusCode)
         .expect("Content-Type", /json/);
+
+      await request(app.getHttpServer())
+        .get("/api/v3/datasets/" + encodeURIComponent(dataset.pid as string))
+        .auth(token, { type: "bearer" })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          expect(omit(res.body.datasetlifecycle, "publishedOn")).toEqual(
+            omit(dataset!.datasetlifecycle, "publishedOn"),
+          );
+          expect(res.body.isPublished).toEqual(true);
+          expect(res.body.datasetlifecycle.publishedOn).not.toEqual(
+            dataset!.datasetlifecycle.publishedOn,
+          );
+        });
     });
 
     it("Should fetch this new published data", async () => {


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Fields in datasetLifecycle were overridden on publishedData/register since the partial update was not applied on nested objs. This PR fixes it

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
