### PR TITLE
fix: datablock find forwards correct id

### DIFF
--- a/src/datablocks/datablocks.controller.ts
+++ b/src/datablocks/datablocks.controller.ts
@@ -234,7 +234,7 @@ export class DatablocksController {
     const user: JWTUser = request.user as JWTUser;
     const abilities = this.caslAbilityFactory.datablockInstanceAccess(user);
 
-    const instance = await this.datablocksService.findOne({ _id: id });
+    const instance = await this.datablocksService.findOne({ where: { _id: id } });
     if (!instance) {
       throw new NotFoundException();
     }
@@ -260,7 +260,7 @@ export class DatablocksController {
     @Body() updateDatablockDto: PartialUpdateDatablockDto,
   ): Promise<Datablock | null> {
     try {
-      const instance = await this.datablocksService.findOne({ _id: id });
+      const instance = await this.datablocksService.findOne({ where: { _id: id } });
       const user: JWTUser = request.user as JWTUser;
       const ability = this.caslAbilityFactory.datablockInstanceAccess(user);
 

--- a/src/datasets/datasets.controller.ts
+++ b/src/datasets/datasets.controller.ts
@@ -2620,8 +2620,7 @@ export class DatasetsController {
     );
     if (!dataset) throw new NotFoundException(`dataset: ${pid} not found`);
 
-    const datablockBeforeUpdate = await this.datablocksService.findOne({
-      _id: did,
+    const datablockBeforeUpdate = await this.datablocksService.findOne({where: {_id: did,}
     });
     if (!datablockBeforeUpdate)
       throw new NotFoundException(`datablock: ${did} not found`);

--- a/test/Datablock.js
+++ b/test/Datablock.js
@@ -34,7 +34,7 @@ describe("Datablocks", () => {
       .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
       .expect(TestData.EntryCreatedStatusCode)
       .expect("Content-Type", /json/)
-  
+
     await request(appUrl)
       .post("/api/v3/Datasets")
       .send(TestData.RawCorrect)
@@ -115,6 +115,24 @@ describe("Datablocks", () => {
       });
   });
 
+  ["filter", "where"].forEach((queryKey, index) => {
+    it(`004${(index + 1) * 3}: should count datablocks associated with dataset`, async () => {
+      var filter = { where: { _id: datablockId2 } };
+
+      return request(appUrl)
+        .get(
+          `/api/v3/datablocks/count?${queryKey}=${encodeURIComponent(JSON.stringify(filter))} `,
+        )
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) =>
+          res.body.should.have.property("count").and.equal(1)
+        );
+    });
+  });
+
   it("0050: should fetch datablocks associated with dataset", async () => {
     var filter = { where: { datasetId: datasetId } };
 
@@ -133,6 +151,22 @@ describe("Datablocks", () => {
           .and.be.instanceof(Array)
           .and.to.have.length(TestData.DataBlockCorrect.dataFileList.length);
       });
+  });
+
+  ["datablockId", "datablockId2"].forEach((dbId, index) => {
+    it(`005${(index + 1) * 3}: should fetch datablock by id`, async () => {
+      const datablocks = { datablockId: datablockId, datablockId2: datablockId2 };
+      const id = datablocks[dbId];
+      return request(appUrl)
+        .get(`/api/v3/datablocks/${encodeURIComponent(id)}`)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) =>
+          res.body.should.have.property("id").and.equal(id)
+        );
+    });
   });
 
   it("0060: The size and numFiles fields in the dataset should be correctly updated", async () => {
@@ -156,6 +190,23 @@ describe("Datablocks", () => {
           .property("numberOfFilesArchived")
           .and.equal(TestData.DataBlockCorrect.dataFileList.length * 2);
       });
+  });
+
+  ["datablockId", "datablockId2"].forEach((dbId, index) => {
+    it(`006${(index + 1) * 3}: should update datablock by id`, async () => {
+      const datablocks = { datablockId: datablockId, datablockId2: datablockId2 };
+      const version = `new-version-${index}`;
+      return request(appUrl)
+        .patch(`/api/v3/datablocks/${encodeURIComponent(datablocks[dbId])}`)
+        .send({ version: version })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) =>
+          res.body.should.have.property("version").and.equal(version)
+        );
+    });
   });
 
   it("0070: should delete first datablock", async () => {

--- a/test/DerivedDatasetDatablock.js
+++ b/test/DerivedDatasetDatablock.js
@@ -385,6 +385,20 @@ describe("0750: DerivedDatasetDatablock: Test Datablocks and their relation to d
       });
   });
 
+  it("193: should patch datablock by id", async () => {
+    const version = "new-version";
+    return request(appUrl)
+      .patch(`/api/v3/Datasets/${datasetPid}/datablocks/${datablockId1}`)
+      .send({ version: version, dataFileList: TestData.DataBlockCorrect.dataFileList })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) =>
+        res.body.should.have.property("version").and.equal(version)
+      );
+  });
+
   it("195: Should delete second datablock", async () => {
     await request(appUrl)
       .delete(`/api/v3/Datasets/${datasetPid}/datablocks/${datablockId2}`)


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
The wrong datablock filter was passed to the service resulting in mixup of datablocks

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
