### PR TITLE
fix: only add https if needed to landingpage

### DIFF
--- a/src/published-data/published-data.v4.controller.spec.ts
+++ b/src/published-data/published-data.v4.controller.spec.ts
@@ -51,6 +51,10 @@ describe("PublishedDataController", () => {
     ...defaultUrl,
     metadata: { landingPage: "custom-landingpage/" },
   };
+  const customLandingPageWithProtocol: PublishedData = {
+    ...defaultUrl,
+    metadata: { landingPage: "https://custom-landingpage/" },
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -88,6 +92,15 @@ describe("PublishedDataController", () => {
     expect(controller.doiRegistrationJSON(customLandingPage)).toHaveProperty(
       "data.attributes.url",
       `https://${customLandingPage.metadata!.landingPage}${encodeURIComponent(customLandingPage.doi)}`,
+    );
+  });
+
+  it("should not double-prefix https:// when 'landingPage' already includes a protocol", () => {
+    expect(
+      controller.doiRegistrationJSON(customLandingPageWithProtocol),
+    ).toHaveProperty(
+      "data.attributes.url",
+      `${customLandingPageWithProtocol.metadata!.landingPage}${encodeURIComponent(customLandingPageWithProtocol.doi)}`,
     );
   });
 });

--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -740,9 +740,14 @@ export class PublishedDataV4Controller {
       landingPage,
     } = metadata ?? {};
 
+    const landingPageBase =
+      typeof landingPage === "string" &&
+      (landingPage.startsWith("https://") || landingPage.startsWith("http://"))
+        ? landingPage
+        : `https://${landingPage}`;
     const url = landingPage
-      ? `https://${landingPage}${encodeURIComponent(doi)}`
-      : `${this.configService.get<string>("publicURLprefix")}${encodeURIComponent(doi)}`;
+        ? `${landingPageBase}${encodeURIComponent(doi)}`
+        : `${this.configService.get<string>("publicURLprefix")}${encodeURIComponent(doi)}`;
 
     const descriptionsArray = [
       { description: abstract, descriptionType: "Abstract", lang: "en" },


### PR DESCRIPTION
## Description
Only add https:// if there is no URL scheme already.

## Motivation
If landingpage already has https:// there will be a duplicate like this `https://https://example.com`.

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->
