### PR TITLE
fix: move oauth mock test env variables to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,6 +136,12 @@ jobs:
           ES_PASSWORD: duo-password
           MEM_LIMIT: 4G
           STACK_VERSION: 8.8.2
+          OIDC_ISSUER: http://localhost:8080/local-test
+          OIDC_CLIENT_ID: scicat-client-test
+          OIDC_CLIENT_SECRET: secret
+          OIDC_SCOPE: openid profile email
+          OIDC_ADDITIONAL_AUTHORIZED_PARTIES: additional-authorized-client-test-1, additional-authorized-client-test-2
+
         # Start mongo container and app before running api tests
         run: |
           cp CI/ESS/docker-compose.api.yaml docker-compose.yaml

--- a/test/config/.env
+++ b/test/config/.env
@@ -1,9 +1,3 @@
-OIDC_ISSUER=http://localhost:8080/local-test
-OIDC_CLIENT_ID=scicat-client-test
-OIDC_CLIENT_SECRET=secret
-OIDC_SCOPE=openid profile email
-OIDC_ADDITIONAL_AUTHORIZED_PARTIES=additional-authorized-client-test-1, additional-authorized-client-test-2
-
 ADMIN_GROUPS=admin,adminingestor
 CREATE_DATASET_GROUPS=group1,group2,group3
 CREATE_DATASET_PRIVILEGED_GROUPS=datasetIngestor,group3


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
moved oauth env variables from `test/config/.env` to `.github/workflows/test.yml`
## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->
