### PR TITLE
feat(publish): run validation on create

### DIFF
--- a/src/published-data/dto/update-published-data.v4.dto.ts
+++ b/src/published-data/dto/update-published-data.v4.dto.ts
@@ -52,7 +52,7 @@ export class UpdatePublishedDataV4Dto {
    */
   @IsObject()
   @IsOptional()
-  readonly metadata?: Record<string, unknown> = {};
+  readonly metadata?: Record<string, unknown>;
 }
 
 export class PartialUpdatePublishedDataV4Dto extends PartialType(

--- a/src/published-data/dto/update-published-data.v4.dto.ts
+++ b/src/published-data/dto/update-published-data.v4.dto.ts
@@ -52,7 +52,7 @@ export class UpdatePublishedDataV4Dto {
    */
   @IsObject()
   @IsOptional()
-  readonly metadata?: Record<string, unknown>;
+  readonly metadata?: Record<string, unknown> = {};
 }
 
 export class PartialUpdatePublishedDataV4Dto extends PartialType(

--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -101,6 +101,7 @@ export class PublishedDataV4Controller {
   async create(
     @Body() createPublishedDataDto: CreatePublishedDataV4Dto,
   ): Promise<PublishedData> {
+    await this.validatorService.validate(createPublishedDataDto);
     return this.publishedDataService.create(createPublishedDataDto);
   }
 
@@ -390,6 +391,7 @@ export class PublishedDataV4Controller {
       }
     }
 
+    await this.validatorService.validate(updatePublishedDataDto);
     return this.publishedDataService.update(
       { doi: id },
       updatePublishedDataDto,
@@ -715,6 +717,7 @@ export class PublishedDataV4Controller {
       );
     }
 
+    await this.validatorService.validate(data);
     await this.publishedDataService.update({ doi: id }, data);
 
     return returnValue;

--- a/src/published-data/published-data.v4.controller.ts
+++ b/src/published-data/published-data.v4.controller.ts
@@ -43,7 +43,10 @@ import { DatasetsV4Controller } from "src/datasets/datasets.v4.controller";
 import { DatasetClass } from "src/datasets/schemas/dataset.schema";
 import { ProposalsService } from "src/proposals/proposals.service";
 import { CreatePublishedDataV4Dto } from "./dto/create-published-data.v4.dto";
-import { PartialUpdatePublishedDataV4Dto } from "./dto/update-published-data.v4.dto";
+import {
+  PartialUpdatePublishedDataV4Dto,
+  UpdatePublishedDataV4Dto,
+} from "./dto/update-published-data.v4.dto";
 import {
   FormPopulateData,
   ICount,
@@ -101,6 +104,7 @@ export class PublishedDataV4Controller {
   async create(
     @Body() createPublishedDataDto: CreatePublishedDataV4Dto,
   ): Promise<PublishedData> {
+    await this.validatorService.validate(createPublishedDataDto);
     return this.publishedDataService.create(createPublishedDataDto);
   }
 
@@ -347,6 +351,19 @@ export class PublishedDataV4Controller {
     return publishedData;
   }
 
+  private async validateMergedUpdate(
+    publishedData: PublishedData,
+    update: PartialUpdatePublishedDataV4Dto,
+  ): Promise<UpdatePublishedDataV4Dto> {
+    const record = (
+      publishedData as PublishedDataDocument
+    ).toObject<PublishedData>();
+    const merged: UpdatePublishedDataV4Dto = { ...record, ...update };
+    await this.validatorService.validate(merged);
+
+    return merged;
+  }
+
   // PATCH /publisheddata/:id
   @UseGuards(AuthenticatedPoliciesGuard)
   @CheckPolicies("publisheddata", (ability: AppAbility) =>
@@ -396,10 +413,12 @@ export class PublishedDataV4Controller {
       }
     }
 
-    return this.publishedDataService.update(
-      { doi: id },
+    const merged = await this.validateMergedUpdate(
+      publishedData,
       updatePublishedDataDto,
     );
+
+    return this.publishedDataService.update({ doi: id }, merged);
   }
 
   // POST /publisheddata/:id/publish
@@ -712,16 +731,18 @@ export class PublishedDataV4Controller {
 
     const OAIServerUri = this.configService.get<string>("oaiProviderRoute");
 
+    const merged = await this.validateMergedUpdate(publishedData, data);
+
     let returnValue = null;
     if (OAIServerUri) {
       returnValue = await this.publishedDataService.resyncOAIPublication(
         id,
-        { ...publishedData, ...data },
+        merged,
         OAIServerUri,
       );
     }
 
-    await this.publishedDataService.update({ doi: id }, data);
+    await this.publishedDataService.update({ doi: id }, merged);
 
     return returnValue;
   }

--- a/test/PublishedDataV4.js
+++ b/test/PublishedDataV4.js
@@ -469,11 +469,11 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
   });
 
   describe("Ajv extensions are executed on create/save", () => {
-    const { metadata, ...strippedPublishedData } = publishedData;
+    const strippedPublishedData = { ...publishedData, metadata: {} };
     const expectedPublicationYear = new Date().getFullYear();
     let id;
 
-    it("should set 'metadata.publicationYear' on create", async () => {
+    it("should set 'metadata.publicationYear' on create", () => {
       return request(appUrl)
         .post("/api/v4/PublishedData")
         .send(strippedPublishedData)
@@ -490,7 +490,7 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
         });
     });
 
-    it("should set 'metadata.publicationYear' on patch", async () => {
+    it("should set 'metadata.publicationYear' on patch", () => {
       return request(appUrl)
         .patch(`/api/v4/PublishedData/${id}`)
         .send(strippedPublishedData)
@@ -507,7 +507,7 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
     });
 
     it("should set 'metadata.publicationYear' on resync", async () => {
-      request(appUrl)
+      await request(appUrl)
         .post(`/api/v4/PublishedData/${id}/resync`)
         .send(strippedPublishedData)
         .set("Accept", "application/json")

--- a/test/PublishedDataV4.js
+++ b/test/PublishedDataV4.js
@@ -467,4 +467,65 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
       .expect(TestData.NotFoundStatusCode)
       .expect("Content-Type", /json/);
   });
+
+  describe("Ajv extensions are executed on create/save", () => {
+    const { metadata, ...strippedPublishedData } = publishedData;
+    const expectedPublicationYear = new Date().getFullYear();
+    let id;
+
+    it("should set 'metadata.publicationYear' on create", async () => {
+      return request(appUrl)
+        .post("/api/v4/PublishedData")
+        .send(strippedPublishedData)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("metadata");
+          res.body.metadata.should.have
+            .property("publicationYear")
+            .and.equal(expectedPublicationYear);
+          id = encodeURIComponent(res.body.doi);
+        });
+    });
+
+    it("should set 'metadata.publicationYear' on patch", async () => {
+      return request(appUrl)
+        .patch(`/api/v4/PublishedData/${id}`)
+        .send(strippedPublishedData)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryValidStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("metadata");
+          res.body.metadata.should.have
+            .property("publicationYear")
+            .and.equal(expectedPublicationYear);
+        });
+    });
+
+    it("should set 'metadata.publicationYear' on resync", async () => {
+      request(appUrl)
+        .post(`/api/v4/PublishedData/${id}/resync`)
+        .send(strippedPublishedData)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode);
+
+      return request(appUrl)
+        .get(`/api/v4/PublishedData/${id}`)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryValidStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("metadata");
+          res.body.metadata.should.have
+            .property("publicationYear")
+            .and.equal(expectedPublicationYear);
+        });
+    });
+  });
 });

--- a/test/PublishedDataV4.js
+++ b/test/PublishedDataV4.js
@@ -467,4 +467,105 @@ describe("1600: PublishedDataV4: Test of access to published data v4 endpoints",
       .expect(TestData.NotFoundStatusCode)
       .expect("Content-Type", /json/);
   });
+
+  describe("Ajv extensions are executed on create/save", () => {
+    const strippedPublishedData = { ...publishedData, metadata: {} };
+    const expectedPublicationYear = new Date().getFullYear();
+    let id;
+
+    it("should set 'metadata.publicationYear' on create", () => {
+      return request(appUrl)
+        .post("/api/v4/PublishedData")
+        .send(strippedPublishedData)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("metadata");
+          res.body.metadata.should.have
+            .property("publicationYear")
+            .and.equal(expectedPublicationYear);
+          id = encodeURIComponent(res.body.doi);
+        });
+    });
+
+    it("should set 'metadata.publicationYear' on full update", () => {
+      return request(appUrl)
+        .patch(`/api/v4/PublishedData/${id}`)
+        .send(strippedPublishedData)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryValidStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("metadata");
+          res.body.metadata.should.have
+            .property("publicationYear")
+            .and.equal(expectedPublicationYear);
+        });
+    });
+
+    it("should set 'metadata.publicationYear' on partial update", () => {
+      return request(appUrl)
+        .patch(`/api/v4/PublishedData/${id}`)
+        .send({ title: "New title", metadata: {} })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryValidStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("title").and.equal("New title");
+          res.body.should.have.property("metadata");
+          res.body.metadata.should.have
+            .property("publicationYear")
+            .and.equal(expectedPublicationYear);
+        });
+    });
+
+    it("should set 'metadata.publicationYear' on full resync", async () => {
+      await request(appUrl)
+        .post(`/api/v4/PublishedData/${id}/resync`)
+        .send(strippedPublishedData)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode);
+
+      return request(appUrl)
+        .get(`/api/v4/PublishedData/${id}`)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryValidStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("metadata");
+          res.body.metadata.should.have
+            .property("publicationYear")
+            .and.equal(expectedPublicationYear);
+        });
+    });
+
+    it("should set 'metadata.publicationYear' on partial resync", async () => {
+      await request(appUrl)
+        .post(`/api/v4/PublishedData/${id}/resync`)
+        .send({ title: "New resync title", metadata: {} })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode);
+
+      return request(appUrl)
+        .get(`/api/v4/PublishedData/${id}`)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryValidStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("title").and.equal("New resync title");
+          res.body.should.have.property("metadata");
+          res.body.metadata.should.have
+            .property("publicationYear")
+            .and.equal(expectedPublicationYear);
+        });
+    });
+  });
 });


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
Runs ajv validation during creation and update of PublishedData records, ignoring any validation error that may occur.
## Motivation
<!-- Background on use case, changes needed -->
We use ajv validation process to auto-fill some properties, for instance the full name of a creator is derived from the given and the family names.

This caused some confusion to our users. The frontend uses `metadata.creators[].name` to display the list of creators but the full names are not computed on creation/updates.

In combination with #2749, it would also allow us to keep metadata accurate (e.g. computing the full size of the published data if the dataset list changes)

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Run metadata validation across published-data creation, updates, and resynchronization to keep derived fields accurate.

New Features:
- Run AJV validation during published-data creation and updates so derived metadata fields are populated consistently.
- Apply validation to full and partial resync operations as well as standard updates.

Enhancements:
- Merge existing records with partial updates before validation to preserve complete published-data metadata.

Tests:
- Add endpoint coverage verifying derived publication-year metadata during create, update, partial update, and resync flows.