### PR TITLE
feat: proposal schema update

### DIFF
--- a/src/datasets/dto/update-dataset.dto.ts
+++ b/src/datasets/dto/update-dataset.dto.ts
@@ -163,7 +163,7 @@ export class UpdateDatasetDto extends OwnableDto {
     required: false,
     isArray: true,
     description:
-      "Array of tags associated with the meaning or contents of this dataset. Values should ideally come from defined vocabularies, taxonomies, ontologies or knowledge graphs.",
+      "Array of metadata entries associated with this dataset. Values should ideally come from defined vocabularies, taxonomies, ontologies or knowledge graphs.",
   })
   @IsOptional()
   @IsString({

--- a/src/proposals/dto/update-proposal.dto.ts
+++ b/src/proposals/dto/update-proposal.dto.ts
@@ -89,7 +89,7 @@ export class UpdateProposalDto extends OwnableDto {
   @IsOptional()
   @ValidateNested({ each: true })
   @Type(() => MeasurementPeriodClass)
-  readonly measurementPeriodList?: MeasurementPeriodClass[] = [];
+  readonly MeasurementPeriodList?: MeasurementPeriodClass[] = [];
 
   /**
    * JSON object containing the proposal metadata.

--- a/src/proposals/dto/update-proposal.dto.ts
+++ b/src/proposals/dto/update-proposal.dto.ts
@@ -1,4 +1,9 @@
-import { ApiTags, PartialType } from "@nestjs/swagger";
+import {
+  ApiProperty,
+  ApiTags,
+  getSchemaPath,
+  PartialType,
+} from "@nestjs/swagger";
 import { Type } from "class-transformer";
 import {
   IsArray,
@@ -11,12 +16,18 @@ import {
 } from "class-validator";
 import { OwnableDto } from "../../common/dto/ownable.dto";
 import { CreateMeasurementPeriodDto } from "./create-measurement-period.dto";
+import { MeasurementPeriodClass } from "../schemas/measurement-period.schema";
 
 @ApiTags("proposals")
 export class UpdateProposalDto extends OwnableDto {
   /**
    * Email of principal investigator.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Email of the Principal Investigator of the proposal.",
+  })
   @IsOptional()
   @IsEmail()
   readonly pi_email?: string;
@@ -24,6 +35,11 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * First name of principal investigator.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "First name of the Principal Investigator of the proposal.",
+  })
   @IsOptional()
   @IsString()
   readonly pi_firstname?: string;
@@ -31,6 +47,11 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * Last name of principal investigator.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Last name of the Principal Investigator of the proposal.",
+  })
   @IsOptional()
   @IsString()
   readonly pi_lastname?: string;
@@ -38,12 +59,22 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * Email of main proposer.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Email of the proposer of the proposal.",
+  })
   @IsEmail()
   readonly email: string;
 
   /**
    * First name of main proposer.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "First name of the proposer of the proposal.",
+  })
   @IsOptional()
   @IsString()
   readonly firstname?: string;
@@ -51,6 +82,11 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * Last name of main proposer.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Last name of the proposer of the proposal.",
+  })
   @IsOptional()
   @IsString()
   readonly lastname?: string;
@@ -58,12 +94,22 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * The title of the proposal.
    */
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: "Title of the proposal.",
+  })
   @IsString()
   readonly title: string;
 
   /**
    * The proposal abstract.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Abstract of the proposal.",
+  })
   @IsOptional()
   @IsString()
   readonly abstract?: string;
@@ -71,6 +117,12 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * The date when the data collection starts.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      "ISO Timestamp when the proposal is planned to or has actually started.",
+  })
   @IsOptional()
   @IsDateString()
   readonly startTime?: Date;
@@ -78,6 +130,12 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * The date when data collection finishes.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      "ISO Timestamp when the proposal is planned to or has actually ended.",
+  })
   @IsOptional()
   @IsDateString()
   readonly endTime?: Date;
@@ -85,6 +143,14 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * Embedded information used inside proposals to define which type of experiment has to be pursued, where (at which instrument) and when.
    */
+  @ApiProperty({
+    type: "array",
+    items: { $ref: getSchemaPath(MeasurementPeriodClass) },
+    required: false,
+    default: [],
+    description:
+      "List of measurement periods/visit scheduled for the proposal.",
+  })
   @IsArray()
   @IsOptional()
   @ValidateNested({ each: true })
@@ -94,6 +160,12 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * JSON object containing the proposal metadata.
    */
+  @ApiProperty({
+    type: Object,
+    required: false,
+    default: {},
+    description: "JSON object containing the proposal metadata.",
+  })
   @IsOptional()
   @IsObject()
   readonly metadata?: Record<string, unknown>;
@@ -101,6 +173,11 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * Parent proposal id.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Id of the parent proposal.",
+  })
   @IsOptional()
   @IsString()
   readonly parentProposalId?: string;
@@ -108,6 +185,11 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * Characterize type of proposal, use some of the configured values
    */
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: "Type of the proposal.",
+  })
   @IsOptional()
   @IsString()
   readonly type?: string;
@@ -115,10 +197,30 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * List of instrument IDs associated with the proposal.
    */
+  @ApiProperty({
+    type: [String],
+    required: false,
+    default: [],
+    description:
+      "Ids of the instruments that this proposal is associated with or scheduled on.",
+  })
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
   readonly instrumentIds?: string[];
+
+  @ApiProperty({
+    type: String,
+    required: false,
+    isArray: true,
+    description:
+      "Array of metadata entries associated with the proposal. Values should ideally come from defined vocabularies, taxonomies, ontologies or knowledge graphs.",
+  })
+  @IsOptional()
+  @IsString({
+    each: true,
+  })
+  readonly keywords?: string[];
 }
 
 export class PartialUpdateProposalDto extends PartialType(UpdateProposalDto) {}

--- a/src/proposals/dto/update-proposal.dto.ts
+++ b/src/proposals/dto/update-proposal.dto.ts
@@ -1,9 +1,4 @@
-import {
-  ApiProperty,
-  ApiTags,
-  getSchemaPath,
-  PartialType,
-} from "@nestjs/swagger";
+import { ApiTags, PartialType } from "@nestjs/swagger";
 import { Type } from "class-transformer";
 import {
   IsArray,
@@ -15,19 +10,13 @@ import {
   ValidateNested,
 } from "class-validator";
 import { OwnableDto } from "../../common/dto/ownable.dto";
-import { CreateMeasurementPeriodDto } from "./create-measurement-period.dto";
 import { MeasurementPeriodClass } from "../schemas/measurement-period.schema";
 
 @ApiTags("proposals")
 export class UpdateProposalDto extends OwnableDto {
   /**
-   * Email of principal investigator.
+   * Email of the Principal Investigator of the proposal.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Email of the Principal Investigator of the proposal.",
-  })
   @IsOptional()
   @IsEmail()
   readonly pi_email?: string;
@@ -35,11 +24,6 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * First name of principal investigator.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "First name of the Principal Investigator of the proposal.",
-  })
   @IsOptional()
   @IsString()
   readonly pi_firstname?: string;
@@ -47,11 +31,6 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * Last name of principal investigator.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Last name of the Principal Investigator of the proposal.",
-  })
   @IsOptional()
   @IsString()
   readonly pi_lastname?: string;
@@ -59,22 +38,12 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * Email of main proposer.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Email of the proposer of the proposal.",
-  })
   @IsEmail()
   readonly email: string;
 
   /**
    * First name of main proposer.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "First name of the proposer of the proposal.",
-  })
   @IsOptional()
   @IsString()
   readonly firstname?: string;
@@ -82,11 +51,6 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * Last name of main proposer.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Last name of the proposer of the proposal.",
-  })
   @IsOptional()
   @IsString()
   readonly lastname?: string;
@@ -94,78 +58,42 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * The title of the proposal.
    */
-  @ApiProperty({
-    type: String,
-    required: true,
-    description: "Title of the proposal.",
-  })
   @IsString()
   readonly title: string;
 
   /**
-   * The proposal abstract.
+   * Abstract of the proposal.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Abstract of the proposal.",
-  })
   @IsOptional()
   @IsString()
   readonly abstract?: string;
 
   /**
-   * The date when the data collection starts.
+   * ISO Timestamp when the proposal is planned to or has actually started.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description:
-      "ISO Timestamp when the proposal is planned to or has actually started.",
-  })
   @IsOptional()
   @IsDateString()
   readonly startTime?: Date;
 
   /**
-   * The date when data collection finishes.
+   * ISO Timestamp when the proposal is planned to or has actually ended.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description:
-      "ISO Timestamp when the proposal is planned to or has actually ended.",
-  })
   @IsOptional()
   @IsDateString()
   readonly endTime?: Date;
 
   /**
-   * Embedded information used inside proposals to define which type of experiment has to be pursued, where (at which instrument) and when.
+   * List of measurement periods/visits scheduled for the proposal.
    */
-  @ApiProperty({
-    type: "array",
-    items: { $ref: getSchemaPath(MeasurementPeriodClass) },
-    required: false,
-    default: [],
-    description:
-      "List of measurement periods/visit scheduled for the proposal.",
-  })
   @IsArray()
   @IsOptional()
   @ValidateNested({ each: true })
-  @Type(() => CreateMeasurementPeriodDto)
-  readonly MeasurementPeriodList?: CreateMeasurementPeriodDto[];
+  @Type(() => MeasurementPeriodClass)
+  readonly measurementPeriodList?: MeasurementPeriodClass[] = [];
 
   /**
    * JSON object containing the proposal metadata.
    */
-  @ApiProperty({
-    type: Object,
-    required: false,
-    default: {},
-    description: "JSON object containing the proposal metadata.",
-  })
   @IsOptional()
   @IsObject()
   readonly metadata?: Record<string, unknown>;
@@ -173,11 +101,6 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * Parent proposal id.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Id of the parent proposal.",
-  })
   @IsOptional()
   @IsString()
   readonly parentProposalId?: string;
@@ -185,37 +108,21 @@ export class UpdateProposalDto extends OwnableDto {
   /**
    * Characterize type of proposal, use some of the configured values
    */
-  @ApiProperty({
-    type: String,
-    required: true,
-    description: "Type of the proposal.",
-  })
   @IsOptional()
   @IsString()
   readonly type?: string;
 
   /**
-   * List of instrument IDs associated with the proposal.
+   * Ids of the instruments that this proposal is associated with or scheduled on.
    */
-  @ApiProperty({
-    type: [String],
-    required: false,
-    default: [],
-    description:
-      "Ids of the instruments that this proposal is associated with or scheduled on.",
-  })
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
   readonly instrumentIds?: string[];
 
-  @ApiProperty({
-    type: String,
-    required: false,
-    isArray: true,
-    description:
-      "Array of metadata entries associated with the proposal. Values should ideally come from defined vocabularies, taxonomies, ontologies or knowledge graphs.",
-  })
+  /*
+   * Array of metadata entries associated with the proposal. Values should ideally come from defined vocabularies, taxonomies, ontologies or knowledge graphs.
+   */
   @IsOptional()
   @IsString({
     each: true,

--- a/src/proposals/dto/update-proposal.dto.ts
+++ b/src/proposals/dto/update-proposal.dto.ts
@@ -10,7 +10,7 @@ import {
   ValidateNested,
 } from "class-validator";
 import { OwnableDto } from "../../common/dto/ownable.dto";
-import { MeasurementPeriodClass } from "../schemas/measurement-period.schema";
+import { CreateMeasurementPeriodDto } from "./create-measurement-period.dto";
 
 @ApiTags("proposals")
 export class UpdateProposalDto extends OwnableDto {
@@ -88,8 +88,8 @@ export class UpdateProposalDto extends OwnableDto {
   @IsArray()
   @IsOptional()
   @ValidateNested({ each: true })
-  @Type(() => MeasurementPeriodClass)
-  readonly MeasurementPeriodList?: MeasurementPeriodClass[] = [];
+  @Type(() => CreateMeasurementPeriodDto)
+  readonly MeasurementPeriodList?: CreateMeasurementPeriodDto[] = [];
 
   /**
    * JSON object containing the proposal metadata.

--- a/src/proposals/schemas/measurement-period.schema.ts
+++ b/src/proposals/schemas/measurement-period.schema.ts
@@ -11,7 +11,7 @@ export class MeasurementPeriodClass {
   @Prop({
     type: String,
   })
-  _id: string;
+  _id?: string;
 
   /**
    * Instrument or beamline identifier where measurement was pursued, e.g. /PSI/SLS/TOMCAT
@@ -35,7 +35,7 @@ export class MeasurementPeriodClass {
    * Additional information relevant for this measurement period, e.g. if different accounts were used for data taking.
    */
   @Prop({ type: String })
-  comment: string;
+  comment?: string;
 }
 
 export const MeasurementPeriodSchema = SchemaFactory.createForClass(

--- a/src/proposals/schemas/proposal.schema.ts
+++ b/src/proposals/schemas/proposal.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
-import { ApiHideProperty, ApiProperty, getSchemaPath } from "@nestjs/swagger";
+import { ApiHideProperty } from "@nestjs/swagger";
 import { Document } from "mongoose";
 
 import { OwnableClass } from "src/common/schemas/ownable.schema";
@@ -24,12 +24,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * Globally unique identifier of a proposal, eg. PID-prefix/internal-proposal-number. PID prefix is auto prepended.
    */
-  @ApiProperty({
-    type: String,
-    required: true,
-    description:
-      "Persistent Identifier for the proposal. It is suggested to use UUID.",
-  })
   @Prop({
     type: String,
     unique: true,
@@ -46,11 +40,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * Email of principal investigator.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Email of the Principal Investigator of the proposal.",
-  })
   @Prop({
     type: String,
     required: false,
@@ -61,11 +50,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * First name of principal investigator.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "First name of the Principal Investigator of the proposal.",
-  })
   @Prop({
     type: String,
     required: false,
@@ -75,11 +59,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * Last name of principal investigator.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Last name of the Principal Investigator of the proposal.",
-  })
   @Prop({
     type: String,
     required: false,
@@ -89,11 +68,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * Email of main proposer.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Email of the proposer of the proposal.",
-  })
   @Prop({
     type: String,
     required: true,
@@ -103,11 +77,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * First name of main proposer.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "First name of the proposer of the proposal.",
-  })
   @Prop({
     type: String,
     required: false,
@@ -117,11 +86,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * Last name of main proposer.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Last name of the proposer of the proposal.",
-  })
   @Prop({
     type: String,
     required: false,
@@ -131,11 +95,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * The title of the proposal.
    */
-  @ApiProperty({
-    type: String,
-    required: true,
-    description: "Title of the proposal.",
-  })
   @Prop({
     type: String,
     required: true,
@@ -145,11 +104,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * The proposal abstract.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Abstract of the proposal.",
-  })
   @Prop({
     type: String,
     required: false,
@@ -159,12 +113,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * The date when the data collection starts.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description:
-      "ISO Timestamp when the proposal is planned to or has actually started.",
-  })
   @Prop({
     type: Date,
     required: false,
@@ -172,14 +120,8 @@ export class ProposalClass extends OwnableClass {
   startTime?: Date;
 
   /**
-   * The date when data collection finishes.
+   * ISO Timestamp when the proposal is planned to or has actually ended.
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description:
-      "ISO Timestamp when the proposal is planned to or has actually ended.",
-  })
   @Prop({
     type: Date,
     required: false,
@@ -187,16 +129,8 @@ export class ProposalClass extends OwnableClass {
   endTime?: Date;
 
   /**
-   * Embedded information used inside proposals to define which type of experiment has to be pursued, where (at which instrument) and when.
+   * List of measurement periods/visit scheduled for the proposal
    */
-  @ApiProperty({
-    type: "array",
-    items: { $ref: getSchemaPath(MeasurementPeriodClass) },
-    required: false,
-    default: [],
-    description:
-      "List of measurement periods/visit scheduled for the proposal.",
-  })
   @Prop({
     type: [MeasurementPeriodSchema],
     required: false,
@@ -207,12 +141,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * JSON object containing the proposal metadata.
    */
-  @ApiProperty({
-    type: Object,
-    required: false,
-    default: {},
-    description: "JSON object containing the proposal metadata.",
-  })
   @Prop({
     type: Object,
     required: false,
@@ -223,11 +151,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * Parent proposal id
    */
-  @ApiProperty({
-    type: String,
-    required: false,
-    description: "Id of the parent proposal.",
-  })
   @Prop({
     type: String,
     required: false,
@@ -239,11 +162,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * Characterize type of proposal, use some of the configured values
    */
-  @ApiProperty({
-    type: String,
-    required: true,
-    description: "Type of the proposal.",
-  })
   @Prop({
     type: String,
     default: DEFAULT_PROPOSAL_TYPE,
@@ -253,13 +171,6 @@ export class ProposalClass extends OwnableClass {
   /**
    * List of instrument IDs associated with the proposal.
    */
-  @ApiProperty({
-    type: [String],
-    required: false,
-    default: [],
-    description:
-      "Ids of the instruments that this proposal is associated with or scheduled on.",
-  })
   @Prop({
     type: [String],
     default: [],
@@ -268,14 +179,8 @@ export class ProposalClass extends OwnableClass {
   instrumentIds?: string[];
 
   /**
-   * Number of datasets associated with the proposal.
+   * Number of Datasets associated or acquired under this proposal.
    */
-  @ApiProperty({
-    type: Number,
-    required: false,
-    description:
-      "Number of Datasets associated or acquired under this proposal.",
-  })
   @Prop({
     type: Number,
     default: 0,
@@ -283,12 +188,9 @@ export class ProposalClass extends OwnableClass {
   })
   numberOfDatasets?: number;
 
-  @ApiProperty({
-    type: [String],
-    required: false,
-    description:
-      "Array of tags associated with the meaning or contents of this dataset. Values should ideally come from defined vocabularies, taxonomies, ontologies or knowledge graphs.",
-  })
+  /*
+   * Array of tags associated with the meaning or contents of this dataset. Values should ideally come from defined vocabularies, taxonomies, ontologies or knowledge graphs.
+   */
   @Prop({
     type: [String],
     required: false,

--- a/src/proposals/schemas/proposal.schema.ts
+++ b/src/proposals/schemas/proposal.schema.ts
@@ -1,6 +1,6 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
-import { ApiHideProperty } from "@nestjs/swagger";
-import { Document, Schema as MongooseSchema } from "mongoose";
+import { ApiHideProperty, ApiProperty, getSchemaPath } from "@nestjs/swagger";
+import { Document } from "mongoose";
 
 import { OwnableClass } from "src/common/schemas/ownable.schema";
 import {
@@ -24,6 +24,12 @@ export class ProposalClass extends OwnableClass {
   /**
    * Globally unique identifier of a proposal, eg. PID-prefix/internal-proposal-number. PID prefix is auto prepended.
    */
+  @ApiProperty({
+    type: String,
+    required: true,
+    description:
+      "Persistent Identifier for the proposal. It is suggested to use UUID.",
+  })
   @Prop({
     type: String,
     unique: true,
@@ -40,6 +46,11 @@ export class ProposalClass extends OwnableClass {
   /**
    * Email of principal investigator.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Email of the Principal Investigator of the proposal.",
+  })
   @Prop({
     type: String,
     required: false,
@@ -50,6 +61,11 @@ export class ProposalClass extends OwnableClass {
   /**
    * First name of principal investigator.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "First name of the Principal Investigator of the proposal.",
+  })
   @Prop({
     type: String,
     required: false,
@@ -59,6 +75,11 @@ export class ProposalClass extends OwnableClass {
   /**
    * Last name of principal investigator.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Last name of the Principal Investigator of the proposal.",
+  })
   @Prop({
     type: String,
     required: false,
@@ -68,6 +89,11 @@ export class ProposalClass extends OwnableClass {
   /**
    * Email of main proposer.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Email of the proposer of the proposal.",
+  })
   @Prop({
     type: String,
     required: true,
@@ -77,6 +103,11 @@ export class ProposalClass extends OwnableClass {
   /**
    * First name of main proposer.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "First name of the proposer of the proposal.",
+  })
   @Prop({
     type: String,
     required: false,
@@ -86,6 +117,11 @@ export class ProposalClass extends OwnableClass {
   /**
    * Last name of main proposer.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Last name of the proposer of the proposal.",
+  })
   @Prop({
     type: String,
     required: false,
@@ -95,6 +131,11 @@ export class ProposalClass extends OwnableClass {
   /**
    * The title of the proposal.
    */
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: "Title of the proposal.",
+  })
   @Prop({
     type: String,
     required: true,
@@ -104,6 +145,11 @@ export class ProposalClass extends OwnableClass {
   /**
    * The proposal abstract.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Abstract of the proposal.",
+  })
   @Prop({
     type: String,
     required: false,
@@ -113,6 +159,12 @@ export class ProposalClass extends OwnableClass {
   /**
    * The date when the data collection starts.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      "ISO Timestamp when the proposal is planned to or has actually started.",
+  })
   @Prop({
     type: Date,
     required: false,
@@ -122,6 +174,12 @@ export class ProposalClass extends OwnableClass {
   /**
    * The date when data collection finishes.
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description:
+      "ISO Timestamp when the proposal is planned to or has actually ended.",
+  })
   @Prop({
     type: Date,
     required: false,
@@ -131,23 +189,48 @@ export class ProposalClass extends OwnableClass {
   /**
    * Embedded information used inside proposals to define which type of experiment has to be pursued, where (at which instrument) and when.
    */
+  @ApiProperty({
+    type: "array",
+    items: { $ref: getSchemaPath(MeasurementPeriodClass) },
+    required: false,
+    default: [],
+    description:
+      "List of measurement periods/visit scheduled for the proposal.",
+  })
   @Prop({
     type: [MeasurementPeriodSchema],
     required: false,
+    default: [],
   })
   MeasurementPeriodList?: MeasurementPeriodClass[];
 
   /**
    * JSON object containing the proposal metadata.
    */
-  @Prop({ type: MongooseSchema.Types.Mixed, required: false, default: {} })
-  metadata?: Record<string, unknown> = {};
+  @ApiProperty({
+    type: Object,
+    required: false,
+    default: {},
+    description: "JSON object containing the proposal metadata.",
+  })
+  @Prop({
+    type: Object,
+    required: false,
+    default: {},
+  })
+  metadata?: Record<string, unknown>;
 
   /**
    * Parent proposal id
    */
+  @ApiProperty({
+    type: String,
+    required: false,
+    description: "Id of the parent proposal.",
+  })
   @Prop({
     type: String,
+    required: false,
     default: null,
     ref: "Proposal",
   })
@@ -156,6 +239,11 @@ export class ProposalClass extends OwnableClass {
   /**
    * Characterize type of proposal, use some of the configured values
    */
+  @ApiProperty({
+    type: String,
+    required: true,
+    description: "Type of the proposal.",
+  })
   @Prop({
     type: String,
     default: DEFAULT_PROPOSAL_TYPE,
@@ -165,6 +253,13 @@ export class ProposalClass extends OwnableClass {
   /**
    * List of instrument IDs associated with the proposal.
    */
+  @ApiProperty({
+    type: [String],
+    required: false,
+    default: [],
+    description:
+      "Ids of the instruments that this proposal is associated with or scheduled on.",
+  })
   @Prop({
     type: [String],
     default: [],
@@ -175,12 +270,30 @@ export class ProposalClass extends OwnableClass {
   /**
    * Number of datasets associated with the proposal.
    */
+  @ApiProperty({
+    type: Number,
+    required: false,
+    description:
+      "Number of Datasets associated or acquired under this proposal.",
+  })
   @Prop({
     type: Number,
     default: 0,
     required: false,
   })
   numberOfDatasets?: number;
+
+  @ApiProperty({
+    type: [String],
+    required: false,
+    description:
+      "Array of tags associated with the meaning or contents of this dataset. Values should ideally come from defined vocabularies, taxonomies, ontologies or knowledge graphs.",
+  })
+  @Prop({
+    type: [String],
+    required: false,
+  })
+  keywords: string[];
 }
 
 export const ProposalSchema = SchemaFactory.createForClass(ProposalClass);

--- a/test/DatasetAuthorization.js
+++ b/test/DatasetAuthorization.js
@@ -190,7 +190,7 @@ describe("0300: DatasetAuthorization: Test access to dataset", () => {
   });
 
   it("0073: list of public datasets with pid filter should return 1", async () => {
-    const filter = { where: { pid: datasetPid1 } }
+    const filter = { where: { pid: datasetPid1 } };
     return request(appUrl)
       .get("/api/v3/Datasets")
       .set("Accept", "application/json")
@@ -204,7 +204,7 @@ describe("0300: DatasetAuthorization: Test access to dataset", () => {
   });
 
   it("0075: list of public datasets with pid filter should return 0", async () => {
-    const filter = { where: { pid: 'nonExistingPid' } }
+    const filter = { where: { pid: "nonExistingPid" } };
     return request(appUrl)
       .get("/api/v3/Datasets")
       .set("Accept", "application/json")


### PR DESCRIPTION
## Description
This PR adds the `keywords` field to the proposal schema and dto. It also updates both schema and dto with proper descriptions for the swagger interface

## Motivation
ESS is building a workflow to manage proposal and datasets which leverages the ability to add and remove keywords to proposals and datasets.

## Changes:
- Proposal schema: added keywords and descriptions
- Proposal DTO: added keywords and descriptions
- Dataset schema: fixed description for scientific metadata

## Tests included
- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

## Summary by Sourcery

Extend proposal metadata support with keywords and clarify API field descriptions.

New Features:
- Add optional keywords to proposal schemas and update DTOs to support proposal metadata tagging.

Bug Fixes:
- Correct the dataset scientific metadata description to accurately describe metadata entries.

Enhancements:
- Improve proposal and dataset field descriptions for the Swagger interface and refine proposal defaults and optional fields.