### PR TITLE
feat: add PI from proposal guard for job auth

### DIFF
--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -229,6 +229,29 @@ export class DatasetsService {
     return datasets;
   }
 
+  async findDeleteAuthorizedDatasetPids(
+    datasetPids: string[],
+    email: string,
+  ): Promise<string[]> {
+    const pipeline: PipelineStage[] = [
+      { $match: { pid: { $in: datasetPids } } },
+      {
+        $lookup: {
+          from: "Policy",
+          localField: "ownerGroup",
+          foreignField: "ownerGroup",
+          as: "linkedPolicy",
+        },
+      },
+      { $match: { "linkedPolicy.dataDeleteEmails": email } },
+      { $project: { _id: 0, pid: 1 } },
+    ];
+    const results = await this.datasetModel
+      .aggregate<{ pid: string }>(pipeline)
+      .exec();
+    return results.map((result) => result.pid);
+  }
+
   async findAllComplete(
     filter: IDatasetFilters<DatasetDocument, IDatasetFields>,
     applyDefaults = true,

--- a/src/jobs/jobs.controller.utils.ts
+++ b/src/jobs/jobs.controller.utils.ts
@@ -19,6 +19,8 @@ import { CreateJobAuth } from "src/jobs/types/jobs-auth.enum";
 import { JobClass, JobDocument } from "./schemas/job.schema";
 import { IFacets, IFilters } from "src/common/interfaces/common.interface";
 import { DatasetsService } from "src/datasets/datasets.service";
+import { ProposalsService } from "src/proposals/proposals.service";
+import { IProposalFields } from "src/proposals/interfaces/proposal-filters.interface";
 import { JobsConfigSchema } from "./types/jobs-config-schema.enum";
 import { OrigDatablocksService } from "src/origdatablocks/origdatablocks.service";
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
@@ -57,6 +59,7 @@ export class JobsControllerUtils {
   constructor(
     private readonly jobsService: JobsService,
     private readonly datasetsService: DatasetsService,
+    private readonly proposalsService: ProposalsService,
     private readonly origDatablocksService: OrigDatablocksService,
     private caslAbilityFactory: CaslAbilityFactory,
     private readonly usersService: UsersService,
@@ -422,6 +425,17 @@ export class JobsControllerUtils {
         pid: { $in: datasetList.map((x) => x.pid) },
       },
     };
+    if (
+      jobConfiguration.create.auth ===
+      CreateJobAuth.DatasetPrincipalInvestigator
+    ) {
+      await this.checkPrincipalInvestigatorAccess(
+        datasetsWhere,
+        datasetList,
+        user,
+      );
+      return;
+    }
     const isPrivilegedUser = this.isPrivilegedUser(user);
     const baseGroups = isPrivilegedUser
       ? (jobUser?.currentGroups ?? [])
@@ -455,6 +469,57 @@ export class JobsControllerUtils {
     if (numberOfDatasetsWithAccess.count < datasetList.length)
       throw new ForbiddenException(
         "User does not have access to all datasets, cannot create job.",
+      );
+  }
+
+  /**
+   * Check that the user is the Principal Investigator (pi_email on the
+   * linked Proposal) of every dataset in `datasetList`.
+   */
+  private async checkPrincipalInvestigatorAccess(
+    datasetsWhere: { where: Condition<DatasetClass> },
+    datasetList: DatasetListDto[],
+    user: JWTUser,
+  ) {
+    if (!user) throw new UnauthorizedException("User not authenticated");
+    if (!user.email)
+      throw new ForbiddenException(
+        "User has no email registered, cannot verify Principal Investigator authorization.",
+      );
+    const datasets = await this.datasetsService.findAll({
+      ...datasetsWhere,
+      fields: { proposalIds: 1 },
+    });
+    if (datasets.length < datasetList.length)
+      throw new ForbiddenException(
+        "User does not have access to all datasets, cannot create job.",
+      );
+    const proposalIds = [
+      ...new Set(datasets.flatMap((dataset) => dataset.proposalIds ?? [])),
+    ];
+    const proposals =
+      proposalIds.length > 0
+        ? await this.proposalsService.findAll({
+            where: { proposalId: { $in: proposalIds } },
+            fields: {
+              proposalId: 1,
+              pi_email: 1,
+            } as unknown as IProposalFields,
+          })
+        : [];
+    const piProposalIds = new Set(
+      proposals
+        .filter((proposal) => proposal.pi_email === user.email)
+        .map((proposal) => proposal.proposalId),
+    );
+    const isPiForAllDatasets = datasets.every((dataset) =>
+      (dataset.proposalIds ?? []).some((proposalId) =>
+        piProposalIds.has(proposalId),
+      ),
+    );
+    if (!isPiForAllDatasets)
+      throw new ForbiddenException(
+        "User is not the Principal Investigator for all datasets, cannot create job.",
       );
   }
 

--- a/src/jobs/jobs.controller.utils.ts
+++ b/src/jobs/jobs.controller.utils.ts
@@ -422,6 +422,10 @@ export class JobsControllerUtils {
         pid: { $in: datasetList.map((x) => x.pid) },
       },
     };
+    if (jobConfiguration.create.auth === CreateJobAuth.DatasetPolicyDelete) {
+      await this.checkDatasetDeleteAccess(datasetList, user);
+      return;
+    }
     const isPrivilegedUser = this.isPrivilegedUser(user);
     const baseGroups = isPrivilegedUser
       ? (jobUser?.currentGroups ?? [])
@@ -453,6 +457,32 @@ export class JobsControllerUtils {
     const numberOfDatasetsWithAccess =
       await this.datasetsService.count(datasetsWhere);
     if (numberOfDatasetsWithAccess.count < datasetList.length)
+      throw new ForbiddenException(
+        "User does not have access to all datasets, cannot create job.",
+      );
+  }
+
+  /**
+   * Check that the user is listed in dataDeleteEmails on the Policy for
+   * every dataset's ownerGroup in `datasetList`. See
+   * DatasetsService.findDeleteAuthorizedDatasetPids.
+   */
+  private async checkDatasetDeleteAccess(
+    datasetList: DatasetListDto[],
+    user: JWTUser,
+  ) {
+    if (!user) throw new UnauthorizedException("User not authenticated");
+    if (!user.email)
+      throw new ForbiddenException(
+        "User has no email registered, cannot verify dataset delete authorization.",
+      );
+    const uniqueDatasetIds = [...new Set(datasetList.map((x) => x.pid))];
+    const eligibleDatasetIds =
+      await this.datasetsService.findDeleteAuthorizedDatasetPids(
+        uniqueDatasetIds,
+        user.email,
+      );
+    if (eligibleDatasetIds.length < uniqueDatasetIds.length)
       throw new ForbiddenException(
         "User does not have access to all datasets, cannot create job.",
       );

--- a/src/jobs/jobs.module.ts
+++ b/src/jobs/jobs.module.ts
@@ -6,6 +6,7 @@ import { JobsControllerUtils } from "./jobs.controller.utils";
 import { MongooseModule } from "@nestjs/mongoose";
 import { JobClass, JobSchema } from "./schemas/job.schema";
 import { DatasetsModule } from "src/datasets/datasets.module";
+import { ProposalsModule } from "src/proposals/proposals.module";
 import { PoliciesModule } from "src/policies/policies.module";
 import { OrigDatablocksModule } from "src/origdatablocks/origdatablocks.module";
 import { UsersModule } from "src/users/users.module";
@@ -22,6 +23,7 @@ import { ConfigModule } from "@nestjs/config";
     CommonModule,
     CoreJobActionCreators,
     DatasetsModule,
+    ProposalsModule,
     UsersModule,
     CaslModule,
     MongooseModule.forFeatureAsync([

--- a/src/jobs/types/jobs-auth.enum.ts
+++ b/src/jobs/types/jobs-auth.enum.ts
@@ -11,6 +11,9 @@ export enum CreateJobAuth {
   // User belongs to dataset's ownerGroup for all `datasetIds`.
   // Equivalent to write access to all datasets in the request
   DatasetOwner = "#datasetOwner",
+  // User's email is listed in dataDeleteEmails on the Policy for the
+  // ownerGroup of every dataset in `datasetIds`.
+  DatasetPolicyDelete = "#datasetPolicyDelete",
   // User belongs to either ADMIN_GROUP or CREATE_JOB_PRIVILEGED_GROUP
   // Equivalent to jobs admin only
   JobAdmin = "#jobAdmin",

--- a/src/jobs/types/jobs-auth.enum.ts
+++ b/src/jobs/types/jobs-auth.enum.ts
@@ -11,6 +11,9 @@ export enum CreateJobAuth {
   // User belongs to dataset's ownerGroup for all `datasetIds`.
   // Equivalent to write access to all datasets in the request
   DatasetOwner = "#datasetOwner",
+  // User is the Principal Investigator (pi_email on the linked Proposal)
+  // of the proposal(s) associated with all `datasetIds`.
+  DatasetPrincipalInvestigator = "#datasetPi",
   // User belongs to either ADMIN_GROUP or CREATE_JOB_PRIVILEGED_GROUP
   // Equivalent to jobs admin only
   JobAdmin = "#jobAdmin",

--- a/src/policies/dto/update-policy.dto.ts
+++ b/src/policies/dto/update-policy.dto.ts
@@ -13,6 +13,10 @@ export class UpdatePolicyDto extends OwnableDto {
   @IsOptional()
   readonly manager: string[];
 
+  @IsArray()
+  @IsOptional()
+  readonly dataDeleteEmails: string[];
+
   @IsString()
   @IsOptional()
   readonly tapeRedundancy: string;

--- a/src/policies/policies.service.spec.ts
+++ b/src/policies/policies.service.spec.ts
@@ -13,6 +13,7 @@ class UsersServiceMock {}
 const mockPolicy: Policy = {
   _id: "testId",
   manager: ["test@email.com"],
+  dataDeleteEmails: [],
   tapeRedundancy: "low",
   autoArchive: true,
   autoArchiveDelay: 7,

--- a/src/policies/policies.service.ts
+++ b/src/policies/policies.service.ts
@@ -249,6 +249,7 @@ export class PoliciesService implements OnModuleInit {
         : defaultManager
           ? defaultManager
           : [""],
+      dataDeleteEmails: [],
       tapeRedundancy: tapeRedundancy ? tapeRedundancy : "low",
       autoArchive: false,
       autoArchiveDelay: 7,

--- a/src/policies/schemas/policy.schema.ts
+++ b/src/policies/schemas/policy.schema.ts
@@ -27,6 +27,13 @@ export class Policy extends OwnableClass {
 
   @ApiProperty({
     description:
+      "Emails of users authorized to request deletion (e.g. Principal Investigator or Data Steward job actions) of datasets owned by this ownerGroup. Not populated automatically - must be set explicitly.",
+  })
+  @Prop({ type: [String] })
+  dataDeleteEmails: string[];
+
+  @ApiProperty({
+    description:
       "Defines the level of redundancy in storage to minimize loss of data. Allowed values are low, medium, high. Low could e.g. mean one tape copy only, medium could mean two tape copies and high two geo-redundant tape copies",
   })
   @Prop({ type: String, default: "low" })

--- a/src/proposals/proposals.service.spec.ts
+++ b/src/proposals/proposals.service.spec.ts
@@ -6,6 +6,7 @@ import { ProposalsService } from "./proposals.service";
 import { ProposalClass } from "./schemas/proposal.schema";
 import { MetadataKeysService } from "src/metadata-keys/metadatakeys.service";
 import { ProposalLookupKeysEnum } from "./types/proposal-lookup";
+import { IProposalFields } from "./interfaces/proposal-filters.interface";
 
 class MetadataKeysServiceMock {
   insertManyFromSource = jest.fn().mockResolvedValue([]);
@@ -83,8 +84,20 @@ describe("ProposalsService", () => {
         limits: { limit: 5, skip: 0 },
       });
 
-      expect(model.find).toHaveBeenCalledWith({ proposalId: "ABCDEF" });
+      expect(model.find).toHaveBeenCalledWith({ proposalId: "ABCDEF" }, {});
       expect(result).toEqual([mockProposal]);
+    });
+
+    it("should pass filter.fields through to find() as the projection", async () => {
+      await service.findAll({
+        where: { proposalId: "ABCDEF" },
+        fields: { proposalId: 1, pi_email: 1 } as unknown as IProposalFields,
+      });
+
+      expect(model.find).toHaveBeenCalledWith(
+        { proposalId: "ABCDEF" },
+        { proposalId: 1, pi_email: 1 },
+      );
     });
 
     it("should apply default limits when not provided", async () => {

--- a/src/proposals/proposals.service.ts
+++ b/src/proposals/proposals.service.ts
@@ -9,7 +9,13 @@ import {
 import { REQUEST } from "@nestjs/core";
 import { Request } from "express";
 import { InjectModel } from "@nestjs/mongoose";
-import { FilterQuery, Model, PipelineStage, QueryOptions } from "mongoose";
+import {
+  FilterQuery,
+  Model,
+  PipelineStage,
+  ProjectionType,
+  QueryOptions,
+} from "mongoose";
 import { IFacets, IFilters } from "src/common/interfaces/common.interface";
 import {
   createFullfacetPipeline,
@@ -197,10 +203,12 @@ export class ProposalsService {
     filter: IFilters<ProposalDocument, IProposalFields>,
   ): Promise<ProposalClass[]> {
     const whereFilter: FilterQuery<ProposalDocument> = filter.where ?? {};
+    const fieldsProjection = (filter.fields ??
+      {}) as ProjectionType<ProposalDocument>;
     const { limit, skip, sort } = parseLimitFilters(filter.limits);
 
     return this.proposalModel
-      .find(whereFilter)
+      .find(whereFilter, fieldsProjection)
       .limit(limit)
       .skip(skip)
       .sort(sort)

--- a/test/JobsDatasetPi.js
+++ b/test/JobsDatasetPi.js
@@ -1,0 +1,374 @@
+"use strict";
+const utils = require("./LoginUtils");
+const { TestData } = require("./TestData");
+
+let accessTokenAdminIngestor = null,
+  accessTokenUser1 = null,
+  accessTokenUser51 = null,
+  accessTokenAdmin = null,
+  datasetPidGroup1 = null,
+  datasetPidGroup5 = null,
+  datasetPidNoPolicy = null,
+  datasetPidEmptyPolicy = null;
+
+const policyGroup1 = {
+  ...TestData.PolicyCorrect,
+  ownerGroup: "pitest-group1",
+  dataDeleteEmails: ["user1@your.site"],
+};
+
+const policyGroup5 = {
+  ...TestData.PolicyCorrect,
+  ownerGroup: "pitest-group5",
+  dataDeleteEmails: ["user5.1@your.site"],
+};
+
+const policyEmptyGroup = {
+  ...TestData.PolicyCorrect,
+  ownerGroup: "pitest-emptypolicy",
+};
+
+const jobDatasetPi = {
+  type: "dataset_delete_access",
+};
+
+describe("1195: Jobs: Test New Job Model Authorization for dataset_delete_access jobs type", () => {
+  before(async () => {
+    await Promise.all([
+      db.collection("Policy").deleteMany({}),
+      db.collection("Dataset").deleteMany({}),
+      db.collection("Job").deleteMany({}),
+    ]);
+
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenUser51 = await utils.getToken(appUrl, {
+      username: "user5.1",
+      password: TestData.Accounts["user5.1"]["password"],
+    });
+
+    accessTokenAdmin = await utils.getToken(appUrl, {
+      username: "admin",
+      password: TestData.Accounts["admin"]["password"],
+    });
+  });
+
+  after(async () => {
+    await Promise.all([
+      db.collection("Policy").deleteMany({}),
+      db.collection("Dataset").deleteMany({}),
+      db.collection("Job").deleteMany({}),
+    ]);
+  });
+
+  it("0010: Add a policy for group1 with user1 in dataDeleteEmails", async () => {
+    return request(appUrl)
+      .post("/api/v3/Policies")
+      .send(policyGroup1)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("dataDeleteEmails")
+          .and.be.eql(["user1@your.site"]);
+      });
+  });
+
+  it("0020: Add a policy for group5 with user5.1 in dataDeleteEmails", async () => {
+    return request(appUrl)
+      .post("/api/v3/Policies")
+      .send(policyGroup5)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("dataDeleteEmails")
+          .and.be.eql(["user5.1@your.site"]);
+      });
+  });
+
+  it("0030: Add a policy for a group with no dataDeleteEmails set", async () => {
+    return request(appUrl)
+      .post("/api/v3/Policies")
+      .send(policyEmptyGroup)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("dataDeleteEmails").and.be.eql([]);
+      });
+  });
+
+  it("0040: Add dataset owned by group1", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "pitest-group1",
+      accessGroups: [],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidGroup1 = res.body["pid"];
+      });
+  });
+
+  it("0050: Add dataset owned by group5", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "pitest-group5",
+      accessGroups: [],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidGroup5 = res.body["pid"];
+      });
+  });
+
+  it("0060: Add dataset owned by a group with no policy at all", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "pitest-nopolicy",
+      accessGroups: [],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidNoPolicy = res.body["pid"];
+      });
+  });
+
+  it("0070: Add dataset owned by a group whose policy has no dataDeleteEmails", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "pitest-emptypolicy",
+      accessGroups: [],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidEmptyPolicy = res.body["pid"];
+      });
+  });
+
+  it("0080: Add a new job as a user listed in the ownerGroup's policy dataDeleteEmails", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "user1",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [{ pid: datasetPidGroup1, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("type").and.be.string;
+        res.body.should.have.property("ownerGroup").and.be.equal("group1");
+        res.body.should.have.property("ownerUser").and.be.equal("user1");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
+      });
+  });
+
+  it("0090: Add a new job as a user not listed in the ownerGroup's policy, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "user5.1",
+      ownerGroup: "group5",
+      jobParams: {
+        datasetList: [{ pid: datasetPidGroup1, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser51}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal(
+            "User does not have access to all datasets, cannot create job.",
+          );
+      });
+  });
+
+  it("0100: Add a new job as user1 for a dataset owned by group1, and user5.1 for one owned by group5, spanning both groups user1 is not authorized for group5", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "user1",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [
+          { pid: datasetPidGroup1, files: [] },
+          { pid: datasetPidGroup5, files: [] },
+        ],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal(
+            "User does not have access to all datasets, cannot create job.",
+          );
+      });
+  });
+
+  it("0110: Add a new job for a dataset with no linked policy, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "user1",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [{ pid: datasetPidNoPolicy, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal(
+            "User does not have access to all datasets, cannot create job.",
+          );
+      });
+  });
+
+  it("0120: Add a new job for a dataset whose policy has no dataDeleteEmails, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "user1",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [{ pid: datasetPidEmptyPolicy, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal(
+            "User does not have access to all datasets, cannot create job.",
+          );
+      });
+  });
+
+  it("0130: Add a new job as an unauthenticated user, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      jobParams: {
+        datasetList: [{ pid: datasetPidGroup1, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .expect(TestData.UnauthorizedStatusCode)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+      });
+  });
+
+  it("0140: Add a new job as a user from ADMIN_GROUPS for a dataset they are not listed as an authorized deleter of, which should be allowed", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "admin",
+      ownerGroup: "admin",
+      jobParams: {
+        datasetList: [{ pid: datasetPidGroup1, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
+      });
+  });
+});

--- a/test/JobsDatasetPi.js
+++ b/test/JobsDatasetPi.js
@@ -1,0 +1,464 @@
+"use strict";
+const utils = require("./LoginUtils");
+const { TestData } = require("./TestData");
+
+let accessTokenAdminIngestor = null,
+  accessTokenProposalIngestor = null,
+  accessTokenUser1 = null,
+  accessTokenUser51 = null,
+  accessTokenAdmin = null,
+  proposalPi1 = null,
+  proposalPi51 = null,
+  proposalNoPiEmail = null,
+  datasetPidPi1 = null,
+  datasetPidPi51 = null,
+  datasetPidMultiPi = null,
+  datasetPidNoProposal = null,
+  datasetPidUnassignedProposal = null;
+
+const proposalOwnedByPi1 = {
+  ...TestData.ProposalCorrectMin,
+  proposalId: "pitest0001",
+  pi_email: "user1@your.site",
+  ownerGroup: "group1",
+};
+
+const proposalOwnedByPi51 = {
+  ...TestData.ProposalCorrectMin,
+  proposalId: "pitest0002",
+  pi_email: "user5.1@your.site",
+  ownerGroup: "group5",
+};
+
+const proposalWithoutPiEmail = {
+  ...TestData.ProposalCorrectMin,
+  proposalId: "pitest0003",
+  ownerGroup: "group1",
+};
+
+const jobDatasetPi = {
+  type: "pi_access",
+};
+
+describe("1195: Jobs: Test New Job Model Authorization for pi_access jobs type", () => {
+  before(async () => {
+    db.collection("Proposal").deleteMany({});
+    db.collection("Dataset").deleteMany({});
+    db.collection("Job").deleteMany({});
+
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenProposalIngestor = await utils.getToken(appUrl, {
+      username: "proposalIngestor",
+      password: TestData.Accounts["proposalIngestor"]["password"],
+    });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenUser51 = await utils.getToken(appUrl, {
+      username: "user5.1",
+      password: TestData.Accounts["user5.1"]["password"],
+    });
+
+    accessTokenAdmin = await utils.getToken(appUrl, {
+      username: "admin",
+      password: TestData.Accounts["admin"]["password"],
+    });
+  });
+
+  after(() => {
+    db.collection("Proposal").deleteMany({});
+    db.collection("Dataset").deleteMany({});
+    db.collection("Job").deleteMany({});
+  });
+
+  it("0010: Add a proposal with pi_email set to user1's email", async () => {
+    return request(appUrl)
+      .post("/api/v3/Proposals")
+      .send(proposalOwnedByPi1)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenProposalIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("proposalId").and.be.string;
+        res.body.should.have
+          .property("pi_email")
+          .and.be.equal("user1@your.site");
+        proposalPi1 = res.body["proposalId"];
+      });
+  });
+
+  it("0020: Add a proposal with pi_email set to user5.1's email", async () => {
+    return request(appUrl)
+      .post("/api/v3/Proposals")
+      .send(proposalOwnedByPi51)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenProposalIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("proposalId").and.be.string;
+        res.body.should.have
+          .property("pi_email")
+          .and.be.equal("user5.1@your.site");
+        proposalPi51 = res.body["proposalId"];
+      });
+  });
+
+  it("0030: Add a proposal without a pi_email", async () => {
+    return request(appUrl)
+      .post("/api/v3/Proposals")
+      .send(proposalWithoutPiEmail)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenProposalIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("proposalId").and.be.string;
+        res.body.should.not.have.property("pi_email");
+        proposalNoPiEmail = res.body["proposalId"];
+      });
+  });
+
+  it("0040: Add dataset owned by proposal with pi_email set to user1", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "group1",
+      accessGroups: [],
+      proposalId: proposalPi1,
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidPi1 = res.body["pid"];
+      });
+  });
+
+  it("0050: Add dataset owned by proposal with pi_email set to user5.1", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "group5",
+      accessGroups: [],
+      proposalId: proposalPi51,
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidPi51 = res.body["pid"];
+      });
+  });
+
+  it("0060: Add dataset linked to both proposals (multiple PIs)", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "group1",
+      accessGroups: [],
+      proposalId: proposalPi1,
+    };
+
+    const createdDataset = await request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/);
+    createdDataset.body.should.have.property("pid").and.be.string;
+    datasetPidMultiPi = createdDataset.body["pid"];
+
+    return request(appUrl)
+      .patch(`/api/v4/datasets/${encodeURIComponent(datasetPidMultiPi)}`)
+      .send({ proposalIds: [proposalPi1, proposalPi51] })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulPatchStatusCode)
+      .expect("Content-Type", /json/);
+  });
+
+  it("0070: Add dataset with no linked proposal at all", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "group1",
+      accessGroups: [],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidNoProposal = res.body["pid"];
+      });
+  });
+
+  it("0080: Add dataset linked to a proposal that has no pi_email", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "group1",
+      accessGroups: [],
+      proposalId: proposalNoPiEmail,
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidUnassignedProposal = res.body["pid"];
+      });
+  });
+
+  it("0090: Add a new job as the dataset's Principal Investigator (user1) in '#datasetPi' configuration", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "user1",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [{ pid: datasetPidPi1, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("type").and.be.string;
+        res.body.should.have.property("ownerGroup").and.be.equal("group1");
+        res.body.should.have.property("ownerUser").and.be.equal("user1");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
+      });
+  });
+
+  it("0100: Add a new job as a user who is not the Principal Investigator of the dataset, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "user5.1",
+      ownerGroup: "group5",
+      jobParams: {
+        datasetList: [{ pid: datasetPidPi1, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser51}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal(
+            "User is not the Principal Investigator for all datasets, cannot create job.",
+          );
+      });
+  });
+
+  it("0110: Add a new job as user1 for a dataset linked to multiple proposals, one of which has user1 as PI", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "user1",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [{ pid: datasetPidMultiPi, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
+      });
+  });
+
+  it("0120: Add a new job as user5.1 for the same multi-proposal dataset, since user5.1 is PI on one of the linked proposals", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "user5.1",
+      ownerGroup: "group5",
+      jobParams: {
+        datasetList: [{ pid: datasetPidMultiPi, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser51}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
+      });
+  });
+
+  it("0130: Add a new job as user1 spanning a dataset they are PI of and one they are not, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "user1",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [
+          { pid: datasetPidPi1, files: [] },
+          { pid: datasetPidPi51, files: [] },
+        ],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal(
+            "User is not the Principal Investigator for all datasets, cannot create job.",
+          );
+      });
+  });
+
+  it("0140: Add a new job for a dataset with no linked proposal, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "user1",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [{ pid: datasetPidNoProposal, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal(
+            "User is not the Principal Investigator for all datasets, cannot create job.",
+          );
+      });
+  });
+
+  it("0150: Add a new job for a dataset linked to a proposal with no pi_email, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "user1",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [{ pid: datasetPidUnassignedProposal, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal(
+            "User is not the Principal Investigator for all datasets, cannot create job.",
+          );
+      });
+  });
+
+  it("0160: Add a new job as an unauthenticated user, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      jobParams: {
+        datasetList: [{ pid: datasetPidPi1, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .expect(TestData.UnauthorizedStatusCode)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+      });
+  });
+
+  it("0170: Add a new job as a user from ADMIN_GROUPS for a dataset they are not the Principal Investigator of, which should be allowed", async () => {
+    const newJob = {
+      ...jobDatasetPi,
+      ownerUser: "admin",
+      ownerGroup: "admin",
+      jobParams: {
+        datasetList: [{ pid: datasetPidPi1, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
+      });
+  });
+});

--- a/test/config/jobconfig.yaml
+++ b/test/config/jobconfig.yaml
@@ -27,6 +27,11 @@ jobs:
       auth: "#datasetOwner"
     update:
       auth: "#jobOwnerUser"
+  - jobType: dataset_delete_access
+    create:
+      auth: "#datasetPolicyDelete"
+    update:
+      auth: "admin"
   - jobType: user_access
     create:
       auth: user5.1

--- a/test/config/jobconfig.yaml
+++ b/test/config/jobconfig.yaml
@@ -27,6 +27,11 @@ jobs:
       auth: "#datasetOwner"
     update:
       auth: "#jobOwnerUser"
+  - jobType: pi_access
+    create:
+      auth: "#datasetPi"
+    update:
+      auth: "admin"
   - jobType: user_access
     create:
       auth: user5.1


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This PR adds a new permission token to the job config, the `#datasetPi`. This is used to allow job submission to user's who belong to all selected datasets' proposals' pi_email. If not the submission returns 403.

The pi in the proposal is preferred to the pi in the dataset since anyone can set the pi in the dataset, while proposals creation is bound to a controlled set of accounts. 

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Authorize dataset deletion jobs using controlled policy-level data deletion permissions across all selected datasets.

New Features:
- Add the `#datasetPolicyDelete` job authorization token, allowing dataset deletion jobs only for users listed in the associated policies’ `dataDeleteEmails`.

Enhancements:
- Support policy-level authorization for jobs spanning multiple datasets and preserve privileged-user access.
- Allow proposal queries to return field projections needed for proposal-based authorization.

Tests:
- Add integration coverage for authorized, unauthorized, multi-dataset, missing-policy, unauthenticated, and privileged job submissions.