### PR TITLE
feat: add job option to send email to policy managers

### DIFF
--- a/src/config/job-config/actions/emailaction/emailaction.interface.ts
+++ b/src/config/job-config/actions/emailaction/emailaction.interface.ts
@@ -4,7 +4,17 @@ export const actionType = "email";
 
 export interface EmailJobActionOptions extends JobActionOptions {
   actionType: typeof actionType;
-  to: string;
+  /**
+   * Handlebars template for the recipient address(es). Combined with the
+   * policy managers when toPolicyManagers is also set - at least one of
+   * the two must be set.
+   */
+  to?: string;
+  /**
+   * Append the Policy.manager emails for the datasets' ownerGroup to the
+   * recipients. At least one of "to"/toPolicyManagers must be set.
+   */
+  toPolicyManagers?: boolean;
   from?: string;
   subject: string;
   bodyTemplateFile: string;
@@ -22,9 +32,11 @@ export function isEmailJobActionOptions(
   }
 
   const opts = options as EmailJobActionOptions;
+  const hasTo = typeof opts.to === "string" && opts.to.length > 0;
+  const hasToPolicyManagers = opts.toPolicyManagers === true;
   return (
     opts.actionType === actionType &&
-    typeof opts.to === "string" &&
+    (hasTo || hasToPolicyManagers) &&
     (opts.from === undefined || typeof opts.from === "string") &&
     typeof opts.subject === "string" &&
     typeof opts.bodyTemplateFile === "string" &&

--- a/src/config/job-config/actions/emailaction/emailaction.service.ts
+++ b/src/config/job-config/actions/emailaction/emailaction.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from "@nestjs/common";
+import { ModuleRef } from "@nestjs/core";
 import {
   JobActionCreator,
   JobActionOptions,
@@ -10,7 +11,10 @@ import { MailService } from "src/common/mail.service";
 
 @Injectable()
 export class EmailJobActionCreator implements JobActionCreator<JobDto> {
-  constructor(private mailService: MailService) {}
+  constructor(
+    private mailService: MailService,
+    private moduleRef: ModuleRef,
+  ) {}
 
   public create<Options extends JobActionOptions>(options: Options) {
     if (!isEmailJobActionOptions(options)) {
@@ -18,6 +22,6 @@ export class EmailJobActionCreator implements JobActionCreator<JobDto> {
         `Invalid options for email action: ${JSON.stringify(options)}`,
       );
     }
-    return new EmailJobAction(this.mailService, options);
+    return new EmailJobAction(this.mailService, this.moduleRef, options);
   }
 }

--- a/src/config/job-config/actions/emailaction/emailaction.spec.ts
+++ b/src/config/job-config/actions/emailaction/emailaction.spec.ts
@@ -9,10 +9,15 @@
  *
  */
 import { EmailJobAction } from "./emailaction";
-import { EmailJobActionOptions } from "./emailaction.interface";
+import {
+  EmailJobActionOptions,
+  isEmailJobActionOptions,
+} from "./emailaction.interface";
 import { JobClass } from "../../../../jobs/schemas/job.schema";
 import { MailService } from "src/common/mail.service";
 import { MailerService } from "@nestjs-modules/mailer";
+import { ModuleRef } from "@nestjs/core";
+import { PoliciesService } from "src/policies/policies.service";
 import { DatasetClass } from "src/datasets/schemas/dataset.schema";
 import { CreateJobDto } from "src/jobs/dto/create-job.dto";
 import { registerHelpers } from "../../handlebar-utils";
@@ -26,6 +31,11 @@ const snapshotDir = (...parts: string[]) =>
   path.join(__dirname, "__snapshots__", parts.join("_") + ".snap.html");
 // initialize helpers, since app.module.ts is not loaded in this test
 registerHelpers();
+
+// unused by tests that configure a static "to" template
+const unusedModuleRef = {
+  resolve: jest.fn(),
+} as unknown as ModuleRef;
 
 const mockDataset: DatasetClass = {
   _id: "testId/12345",
@@ -144,6 +154,44 @@ function jobToCreateDto(job: JobClass): CreateJobDto {
   };
 }
 
+describe("isEmailJobActionOptions", () => {
+  const base = {
+    actionType: "email",
+    subject: "Job {{job.id}}",
+    bodyTemplateFile: "some-template.html",
+  };
+
+  it("accepts a config with only 'to'", () => {
+    expect(
+      isEmailJobActionOptions({ ...base, to: "recipient@example.com" }),
+    ).toBe(true);
+  });
+
+  it("accepts a config with only 'toPolicyManagers'", () => {
+    expect(isEmailJobActionOptions({ ...base, toPolicyManagers: true })).toBe(
+      true,
+    );
+  });
+
+  it("rejects a config with neither 'to' nor 'toPolicyManagers'", () => {
+    expect(isEmailJobActionOptions({ ...base })).toBe(false);
+  });
+
+  it("rejects a config with an empty 'to' and no 'toPolicyManagers'", () => {
+    expect(isEmailJobActionOptions({ ...base, to: "" })).toBe(false);
+  });
+
+  it("accepts a config with both 'to' and 'toPolicyManagers' (appended)", () => {
+    expect(
+      isEmailJobActionOptions({
+        ...base,
+        to: "recipient@example.com",
+        toPolicyManagers: true,
+      }),
+    ).toBe(true);
+  });
+});
+
 describe("EmailJobAction", () => {
   const config: EmailJobActionOptions = {
     actionType: "email",
@@ -158,7 +206,7 @@ describe("EmailJobAction", () => {
     sendMail: jest.fn(),
   } as unknown as MailService;
 
-  const action = new EmailJobAction(mailService, config);
+  const action = new EmailJobAction(mailService, unusedModuleRef, config);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -211,7 +259,7 @@ describe("EmailJobAction", () => {
       new Error("Email sending failed"),
     );
 
-    const actionIgnore = new EmailJobAction(mailService, {
+    const actionIgnore = new EmailJobAction(mailService, unusedModuleRef, {
       ...config,
       ignoreErrors: true,
     });
@@ -245,7 +293,7 @@ describe("EmailJobAction with default sender", () => {
     sendMail: jest.fn(),
   } as unknown as MailerService;
 
-  const action = new EmailJobAction(mailService, config);
+  const action = new EmailJobAction(mailService, unusedModuleRef, config);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -301,7 +349,7 @@ describe("Email Template", () => {
       bodyTemplateFile:
         "src/common/email-templates/job-template-simplified.html",
     };
-    const action = new EmailJobAction(mailService, config);
+    const action = new EmailJobAction(mailService, unusedModuleRef, config);
 
     const context = {
       request: jobToCreateDto(mockJob),
@@ -354,7 +402,7 @@ describe("Email Template", () => {
         subject: "Job {{ job.id }}",
         bodyTemplateFile: "src/common/email-templates/job-template.html",
       };
-      const action = new EmailJobAction(mailService, config);
+      const action = new EmailJobAction(mailService, unusedModuleRef, config);
 
       const job: JobClass = {
         ...mockJob,
@@ -408,4 +456,194 @@ describe("Email Template", () => {
       );
     },
   );
+});
+
+describe("EmailJobAction with toPolicyManagers", () => {
+  const config: EmailJobActionOptions = {
+    actionType: "email",
+    toPolicyManagers: true,
+    subject: "Job {{job.id}}",
+    bodyTemplateFile:
+      "src/common/email-templates/test-minimal-template.spec.html",
+  };
+
+  const mailService = {
+    sendMail: jest.fn(),
+  } as unknown as MailService;
+
+  const policiesService = {
+    findOne: jest.fn(),
+  } as unknown as PoliciesService;
+
+  const moduleRef = {
+    resolve: jest.fn().mockResolvedValue(policiesService),
+  } as unknown as ModuleRef;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (moduleRef.resolve as jest.Mock).mockResolvedValue(policiesService);
+  });
+
+  it("should send to the ownerGroup's policy managers", async () => {
+    (policiesService.findOne as jest.Mock).mockResolvedValue({
+      ownerGroup: "group1",
+      manager: ["manager1@example.com", "manager2@example.com"],
+    });
+
+    const action = new EmailJobAction(mailService, moduleRef, config);
+    const job = { id: "12345", type: "testemail" } as JobClass;
+    const context = {
+      request: job,
+      job,
+      env: {},
+      datasets: [
+        { ...mockDataset, ownerGroup: "group1" },
+        { ...mockDataset, ownerGroup: "group1" },
+      ],
+    };
+    await action.perform(context);
+
+    expect(policiesService.findOne).toHaveBeenCalledWith({
+      ownerGroup: "group1",
+    });
+    expect(mailService.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "manager1@example.com,manager2@example.com",
+      }),
+    );
+  });
+
+  it("should throw when datasets span more than one ownerGroup", async () => {
+    const action = new EmailJobAction(mailService, moduleRef, config);
+    const job = { id: "12345", type: "testemail" } as JobClass;
+    const context = {
+      request: job,
+      job,
+      env: {},
+      datasets: [
+        { ...mockDataset, ownerGroup: "group1" },
+        { ...mockDataset, ownerGroup: "group2" },
+      ],
+    };
+
+    await expect(action.perform(context)).rejects.toThrow(/single ownerGroup/);
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("should ignore the multiple-ownerGroup error when ignoreErrors is set", async () => {
+    const action = new EmailJobAction(mailService, moduleRef, {
+      ...config,
+      ignoreErrors: true,
+    });
+    const job = { id: "12345", type: "testemail" } as JobClass;
+    const context = {
+      request: job,
+      job,
+      env: {},
+      datasets: [
+        { ...mockDataset, ownerGroup: "group1" },
+        { ...mockDataset, ownerGroup: "group2" },
+      ],
+    };
+
+    await expect(action.perform(context)).resolves.toBeUndefined();
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("should skip sending when the ownerGroup has no policy managers configured", async () => {
+    (policiesService.findOne as jest.Mock).mockResolvedValue(null);
+
+    const action = new EmailJobAction(mailService, moduleRef, config);
+    const job = { id: "12345", type: "testemail" } as JobClass;
+    const context = {
+      request: job,
+      job,
+      env: {},
+      datasets: [{ ...mockDataset, ownerGroup: "group1" }],
+    };
+
+    await expect(action.perform(context)).resolves.toBeUndefined();
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("should not query policies or send mail when there are no datasets", async () => {
+    const action = new EmailJobAction(mailService, moduleRef, config);
+    const job = { id: "12345", type: "testemail" } as JobClass;
+    const context = { request: job, job, env: {}, datasets: [] };
+
+    await action.perform(context);
+
+    expect(policiesService.findOne).not.toHaveBeenCalled();
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("should append policy managers to a static 'to' when both are configured", async () => {
+    (policiesService.findOne as jest.Mock).mockResolvedValue({
+      ownerGroup: "group1",
+      manager: ["manager1@example.com"],
+    });
+
+    const action = new EmailJobAction(mailService, moduleRef, {
+      ...config,
+      to: "requester@example.com",
+    });
+    const job = { id: "12345", type: "testemail" } as JobClass;
+    const context = {
+      request: job,
+      job,
+      env: {},
+      datasets: [{ ...mockDataset, ownerGroup: "group1" }],
+    };
+    await action.perform(context);
+
+    expect(mailService.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: "requester@example.com,manager1@example.com",
+      }),
+    );
+  });
+
+  it("should still send to the static 'to' when the ownerGroup has no policy managers configured", async () => {
+    (policiesService.findOne as jest.Mock).mockResolvedValue(null);
+
+    const action = new EmailJobAction(mailService, moduleRef, {
+      ...config,
+      to: "requester@example.com",
+    });
+    const job = { id: "12345", type: "testemail" } as JobClass;
+    const context = {
+      request: job,
+      job,
+      env: {},
+      datasets: [{ ...mockDataset, ownerGroup: "group1" }],
+    };
+    await action.perform(context);
+
+    expect(mailService.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "requester@example.com" }),
+    );
+  });
+
+  it("should still send to the static 'to' when policy manager resolution fails and ignoreErrors is set", async () => {
+    const action = new EmailJobAction(mailService, moduleRef, {
+      ...config,
+      to: "requester@example.com",
+      ignoreErrors: true,
+    });
+    const job = { id: "12345", type: "testemail" } as JobClass;
+    const context = {
+      request: job,
+      job,
+      env: {},
+      datasets: [
+        { ...mockDataset, ownerGroup: "group1" },
+        { ...mockDataset, ownerGroup: "group2" },
+      ],
+    };
+    await action.perform(context);
+
+    expect(mailService.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "requester@example.com" }),
+    );
+  });
 });

--- a/src/config/job-config/actions/emailaction/emailaction.ts
+++ b/src/config/job-config/actions/emailaction/emailaction.ts
@@ -5,7 +5,8 @@
  */
 import { readFileSync } from "fs";
 import { compileJobTemplate, TemplateJob } from "../../handlebar-utils";
-import { Logger } from "@nestjs/common";
+import { HttpStatus, Logger } from "@nestjs/common";
+import { ModuleRef } from "@nestjs/core";
 import {
   JobAction,
   JobDto,
@@ -14,12 +15,15 @@ import {
 import { ISendMailOptions } from "@nestjs-modules/mailer";
 import { actionType, EmailJobActionOptions } from "./emailaction.interface";
 import { MailService } from "src/common/mail.service";
+import { PoliciesService } from "src/policies/policies.service";
+import { makeHttpException } from "src/common/utils";
 
 /**
  * Send an email following a job
  */
 export class EmailJobAction implements JobAction<JobDto> {
-  private toTemplate: TemplateJob;
+  private toTemplate?: TemplateJob;
+  private toPolicyManagers = false;
   private from?: string = undefined;
   private subjectTemplate: TemplateJob;
   private bodyTemplate: TemplateJob;
@@ -31,6 +35,7 @@ export class EmailJobAction implements JobAction<JobDto> {
 
   constructor(
     private mailService: MailService,
+    private moduleRef: ModuleRef,
     options: EmailJobActionOptions,
   ) {
     Logger.log("EmailJobAction parameters are valid.", "EmailJobAction");
@@ -38,7 +43,12 @@ export class EmailJobAction implements JobAction<JobDto> {
     if (options["from"]) {
       this.from = options.from as string;
     }
-    this.toTemplate = compileJobTemplate(options.to);
+    if (options.to) {
+      this.toTemplate = compileJobTemplate(options.to);
+    }
+    if (options.toPolicyManagers) {
+      this.toPolicyManagers = true;
+    }
     this.subjectTemplate = compileJobTemplate(options.subject);
 
     const templateFile = readFileSync(
@@ -52,17 +62,84 @@ export class EmailJobAction implements JobAction<JobDto> {
     }
   }
 
+  private async resolvePolicyManagerRecipients(
+    context: JobPerformContext<JobDto>,
+  ): Promise<string | undefined> {
+    if (context.datasets.length === 0) return undefined;
+
+    const ownerGroups = new Set(
+      context.datasets.map((dataset) => dataset.ownerGroup),
+    );
+    if (ownerGroups.size > 1)
+      throw new Error(
+        `EmailJobAction (toPolicyManagers) only supports datasets from a single ownerGroup, got: ${[...ownerGroups].join(", ")}`,
+      );
+    const [ownerGroup] = ownerGroups;
+
+    const policiesService = await this.moduleRef.resolve(
+      PoliciesService,
+      undefined,
+      { strict: false },
+    );
+    if (policiesService === undefined) {
+      const msg =
+        "Unable to resolve PoliciesService. This indicates an unexpected server state.";
+      Logger.error(msg, "EmailJobAction");
+      throw makeHttpException(msg, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    const policy = await policiesService.findOne({ ownerGroup });
+    const recipients = policy?.manager ?? [];
+    if (recipients.length === 0) {
+      Logger.warn(
+        `(Job ${context.job.id}) EmailJobAction: no policy managers configured for ownerGroup '${ownerGroup}', skipping notification.`,
+        "EmailJobAction",
+      );
+      return undefined;
+    }
+    return recipients.join(",");
+  }
+
+  private async resolveRecipients(
+    context: JobPerformContext<JobDto>,
+  ): Promise<string | undefined> {
+    const recipients: string[] = [];
+    if (this.toTemplate) {
+      const templateTo = this.toTemplate(context);
+      if (templateTo) recipients.push(templateTo);
+    }
+    if (this.toPolicyManagers) {
+      try {
+        const policyManagerTo =
+          await this.resolvePolicyManagerRecipients(context);
+        if (policyManagerTo) recipients.push(policyManagerTo);
+      } catch (err) {
+        Logger.error(
+          `(Job ${context.job.id}) EmailJobAction: Unable to resolve policy manager recipients: ${err}`,
+          "EmailJobAction",
+        );
+        if (!this.ignoreErrors) {
+          throw err;
+        }
+      }
+    }
+    return recipients.length > 0 ? recipients.join(",") : undefined;
+  }
+
   async perform(context: JobPerformContext<JobDto>) {
     Logger.log(
       `(Job ${context.job.id}) Performing EmailJobAction`,
       "EmailJobAction",
     );
 
+    const to = await this.resolveRecipients(context);
+    if (!to) return;
+
     let mail: ISendMailOptions;
     try {
       // Fill templates
       mail = {
-        to: this.toTemplate(context),
+        to,
         subject: this.subjectTemplate(context),
         html: this.bodyTemplate(context),
       };

--- a/src/config/job-config/jobconfig.spec.ts
+++ b/src/config/job-config/jobconfig.spec.ts
@@ -6,6 +6,7 @@ import { actionType as logActionType } from "./actions/logaction/logaction.inter
 import { actionType as validateActionType } from "./actions/validateaction/validateaction.interface";
 import { actionType as urlActionType } from "./actions/urlaction/urlaction.interface";
 import { actionType as rabbitmqActionType } from "./actions/rabbitmqaction/rabbitmqaction.interface";
+import { actionType as emailActionType } from "./actions/emailaction/emailaction.interface";
 import {
   CREATE_JOB_ACTION_CREATORS,
   UPDATE_JOB_ACTION_CREATORS,
@@ -19,6 +20,7 @@ const creatorsMock = {
   [validateActionType]: actionCreatorMock,
   [urlActionType]: actionCreatorMock,
   [rabbitmqActionType]: actionCreatorMock,
+  [emailActionType]: actionCreatorMock,
 };
 const creatorProviders = [
   {

--- a/test/JobsPolicyEmail.js
+++ b/test/JobsPolicyEmail.js
@@ -1,0 +1,160 @@
+"use strict";
+const utils = require("./LoginUtils");
+const { TestData } = require("./TestData");
+
+let accessTokenAdminIngestor = null,
+  datasetPidGroup1 = null,
+  datasetPidNoPolicy = null,
+  jobIdGroup1 = null,
+  encodedJobIdGroup1 = null,
+  jobIdNoPolicy = null,
+  encodedJobIdNoPolicy = null;
+
+const policyGroup1 = {
+  ...TestData.PolicyCorrect,
+  ownerGroup: "policyemailtest-group1",
+  manager: ["manager1@example.com"],
+};
+
+const jobPolicyEmail = {
+  type: "policy_email_test",
+};
+
+describe("1196: Jobs: Test EmailJobAction toPolicyManagers notifies the ownerGroup's policy managers", () => {
+  before(async () => {
+    await Promise.all([
+      db.collection("Policy").deleteMany({}),
+      db.collection("Dataset").deleteMany({}),
+      db.collection("Job").deleteMany({}),
+    ]);
+
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+  });
+
+  after(async () => {
+    await Promise.all([
+      db.collection("Policy").deleteMany({}),
+      db.collection("Dataset").deleteMany({}),
+      db.collection("Job").deleteMany({}),
+    ]);
+  });
+
+  it("0010: Add a policy for group1", async () => {
+    return request(appUrl)
+      .post("/api/v3/Policies")
+      .send(policyGroup1)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/);
+  });
+
+  it("0020: Add dataset owned by group1", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "policyemailtest-group1",
+      accessGroups: [],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        datasetPidGroup1 = res.body["pid"];
+      });
+  });
+
+  it("0030: Add dataset owned by a group with no policy", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "policyemailtest-nopolicy",
+      accessGroups: [],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        datasetPidNoPolicy = res.body["pid"];
+      });
+  });
+
+  it("0040: Add a policy_email_test job for the group1 dataset", async () => {
+    const newJob = {
+      ...jobPolicyEmail,
+      contactEmail: "requester@example.com",
+      jobParams: {
+        datasetList: [{ pid: datasetPidGroup1, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        jobIdGroup1 = res.body["id"];
+        encodedJobIdGroup1 = encodeURIComponent(jobIdGroup1);
+      });
+  });
+
+  it("0050: Add a policy_email_test job for the dataset with no policy", async () => {
+    const newJob = {
+      ...jobPolicyEmail,
+      contactEmail: "requester@example.com",
+      jobParams: {
+        datasetList: [{ pid: datasetPidNoPolicy, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        jobIdNoPolicy = res.body["id"];
+        encodedJobIdNoPolicy = encodeURIComponent(jobIdNoPolicy);
+      });
+  });
+
+  it("0060: Patching the group1 job resolves the policy manager and sends the notification without failing the request", async () => {
+    return request(appUrl)
+      .patch(`/api/v4/Jobs/${encodedJobIdGroup1}`)
+      .send({
+        statusMessage: "update status of a job",
+        statusCode: "job finished/blocked/etc",
+      })
+      .set("Accept", "application/json")
+      .expect(TestData.SuccessfulPatchStatusCode)
+      .expect("Content-Type", /json/);
+  });
+
+  it("0070: Patching the no-policy job still succeeds (the action skips notification and ignoreErrors is set)", async () => {
+    return request(appUrl)
+      .patch(`/api/v4/Jobs/${encodedJobIdNoPolicy}`)
+      .send({
+        statusMessage: "update status of a job",
+        statusCode: "job finished/blocked/etc",
+      })
+      .set("Accept", "application/json")
+      .expect(TestData.SuccessfulPatchStatusCode)
+      .expect("Content-Type", /json/);
+  });
+});

--- a/test/config/jobconfig.yaml
+++ b/test/config/jobconfig.yaml
@@ -32,6 +32,17 @@ jobs:
       auth: "#datasetPolicyDelete"
     update:
       auth: "admin"
+  - jobType: policy_email_test
+    create:
+      auth: "#all"
+    update:
+      auth: "#all"
+      actions:
+        - actionType: email
+          toPolicyManagers: true
+          ignoreErrors: true
+          subject: "Job {{job.id}} update"
+          bodyTemplateFile: src/common/email-templates/test-minimal-template.spec.html
   - jobType: user_access
     create:
       auth: user5.1


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Add job option to append to email receivers policy managers. Similar PRs will later follow for archive and retrieve, where a discussion on the schema could be necessary

## Motivation
As the policy contains ownerGroup common settings, it should control notification defaults. For now managers are used, but dedicated fields might be better later. The reason it is not implemented here is because this might fall into a broader schema review where jobType hardcoding is removed from the schema

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Enable email job notifications to include policy managers for the datasets' owner group.

New Features:
- Allow email job actions to notify policy managers associated with dataset owner groups, optionally alongside explicitly configured recipients.

Enhancements:
- Validate email actions with either a static recipient or policy-manager notifications and handle missing, ambiguous, or unavailable policy recipients according to the action's error policy.

Tests:
- Add unit and integration coverage for recipient validation, policy-manager resolution, mixed recipients, owner-group constraints, missing policies, and ignored resolution errors.