### PR TITLE
fix: link proposals to ds by ownergroup

### DIFF
--- a/migrations/20260831150000-backfill-dataset-proposalids-from-ownergroup.js
+++ b/migrations/20260831150000-backfill-dataset-proposalids-from-ownergroup.js
@@ -6,80 +6,106 @@
  * more than one proposal.
  *
  * A broad/shared ownerGroup could otherwise match an unreasonable number of
- * unrelated proposals, so groups matching more than
- * MAX_PROPOSALS_PER_OWNER_GROUP proposals are skipped and logged instead of
- * writing a huge proposalIds array.
+ * unrelated proposals, so a dataset whose ownerGroup matches more than
+ * MAX_PROPOSALS_PER_OWNER_GROUP proposals only gets linked to the first
+ * MAX_PROPOSALS_PER_OWNER_GROUP of them, and the truncation is logged,
+ * instead of writing an unbounded proposalIds array.
  */
 
 const MAX_PROPOSALS_PER_OWNER_GROUP = 100;
+const CHUNK_SIZE = 1000;
+
+function warnTruncatedProposals(warnedOwnerGroups, ownerGroup, proposalCount) {
+  if (warnedOwnerGroups.has(ownerGroup)) return;
+
+  warnedOwnerGroups.add(ownerGroup);
+  console.warn(
+    `ownerGroup "${ownerGroup}" matches ${proposalCount} proposals; ` +
+      `only linking the first ${MAX_PROPOSALS_PER_OWNER_GROUP}.`,
+  );
+}
+
+// Returns the Proposal docs matching ownerGroup (capped at
+// MAX_PROPOSALS_PER_OWNER_GROUP), or null if there are none.
+async function getMatchingProposals(db, ownerGroup, warnedOwnerGroups) {
+  const proposalCount = await db
+    .collection("Proposal")
+    .countDocuments({ ownerGroup });
+
+  if (proposalCount === 0) return null;
+
+  if (proposalCount > MAX_PROPOSALS_PER_OWNER_GROUP) {
+    warnTruncatedProposals(warnedOwnerGroups, ownerGroup, proposalCount);
+  }
+
+  return db
+    .collection("Proposal")
+    .find({ ownerGroup }, { projection: { proposalId: 1 } })
+    .limit(MAX_PROPOSALS_PER_OWNER_GROUP)
+    .toArray();
+}
+
+// Pulls the proposalIds out of the matched proposals and, in the same pass,
+// tallies how many datasets each one is about to be linked to in this chunk.
+function extractProposalIdsAndTally(proposals, proposalIncrements) {
+  const proposalIds = [];
+  for (const proposal of proposals) {
+    proposalIds.push(proposal.proposalId);
+    proposalIncrements.set(
+      proposal.proposalId,
+      (proposalIncrements.get(proposal.proposalId) || 0) + 1,
+    );
+  }
+  return proposalIds;
+}
+
+function buildProposalIdsUpdateOp(datasetId, proposalIds) {
+  return {
+    updateOne: {
+      filter: {
+        _id: datasetId,
+        $or: [
+          { proposalIds: { $exists: false } },
+          { proposalIds: { $size: 0 } },
+        ],
+      },
+      update: { $set: { proposalIds } },
+    },
+  };
+}
+
+async function flushChunk(db, datasetOps, proposalIncrements) {
+  if (datasetOps.length === 0) return { modifiedCount: 0, unModifiedCount: 0 };
+
+  const bulkWriteResult = await db
+    .collection("Dataset")
+    .bulkWrite(datasetOps, { ordered: false });
+
+  if (proposalIncrements.size > 0) {
+    await db.collection("Proposal").bulkWrite(
+      [...proposalIncrements.entries()].map(([proposalId, count]) => ({
+        updateOne: {
+          filter: { proposalId },
+          update: { $inc: { numberOfDatasets: count } },
+        },
+      })),
+      { ordered: false },
+    );
+  }
+
+  return {
+    modifiedCount: bulkWriteResult.modifiedCount,
+    unModifiedCount: datasetOps.length - bulkWriteResult.modifiedCount,
+  };
+}
 
 module.exports = {
   async up(db) {
-    const BATCH_SIZE = 10000;
     let modifiedCount = 0;
     let unModifiedCount = 0;
-    let batch = [];
+    let datasetOps = [];
+    let proposalIncrements = new Map();
     const warnedOwnerGroups = new Set();
-
-    const flushBatch = async () => {
-      if (batch.length === 0) return;
-
-      const ownerGroups = [
-        ...new Set(batch.map((dataset) => dataset.ownerGroup)),
-      ];
-      const proposalIdsByOwnerGroup = new Map();
-      const tooManyOwnerGroups = new Set();
-      for await (const proposal of db
-        .collection("Proposal")
-        .find(
-          { ownerGroup: { $in: ownerGroups } },
-          { projection: { ownerGroup: 1, proposalId: 1 } },
-        )) {
-        if (!proposal.ownerGroup || !proposal.proposalId) continue;
-        if (tooManyOwnerGroups.has(proposal.ownerGroup)) continue;
-
-        const existing = proposalIdsByOwnerGroup.get(proposal.ownerGroup) || [];
-        existing.push(proposal.proposalId);
-
-        if (existing.length > MAX_PROPOSALS_PER_OWNER_GROUP) {
-          proposalIdsByOwnerGroup.delete(proposal.ownerGroup);
-          tooManyOwnerGroups.add(proposal.ownerGroup);
-          if (!warnedOwnerGroups.has(proposal.ownerGroup)) {
-            warnedOwnerGroups.add(proposal.ownerGroup);
-            console.warn(
-              `Skipping proposalIds backfill for ownerGroup "${proposal.ownerGroup}": ` +
-                `more than ${MAX_PROPOSALS_PER_OWNER_GROUP} matching proposals.`,
-            );
-          }
-          continue;
-        }
-
-        proposalIdsByOwnerGroup.set(proposal.ownerGroup, existing);
-      }
-
-      const bulkOps = [];
-      for (const dataset of batch) {
-        const proposalIds = proposalIdsByOwnerGroup.get(dataset.ownerGroup);
-        if (!proposalIds || proposalIds.length === 0) continue;
-
-        bulkOps.push({
-          updateOne: {
-            filter: { _id: dataset._id },
-            update: { $set: { proposalIds } },
-          },
-        });
-      }
-
-      if (bulkOps.length > 0) {
-        const bulkWriteResult = await db
-          .collection("Dataset")
-          .bulkWrite(bulkOps, { ordered: false });
-        modifiedCount += bulkWriteResult.modifiedCount;
-        unModifiedCount += bulkOps.length - bulkWriteResult.modifiedCount;
-      }
-
-      batch = [];
-    };
 
     for await (const dataset of db.collection("Dataset").find(
       {
@@ -91,10 +117,25 @@ module.exports = {
       },
       { projection: { ownerGroup: 1 } },
     )) {
-      batch.push(dataset);
+      const proposals = await getMatchingProposals(
+        db,
+        dataset.ownerGroup,
+        warnedOwnerGroups,
+      );
+      if (!proposals) continue;
 
-      if (batch.length === BATCH_SIZE) {
-        await flushBatch();
+      const proposalIds = extractProposalIdsAndTally(
+        proposals,
+        proposalIncrements,
+      );
+      datasetOps.push(buildProposalIdsUpdateOp(dataset._id, proposalIds));
+
+      if (datasetOps.length === CHUNK_SIZE) {
+        const result = await flushChunk(db, datasetOps, proposalIncrements);
+        modifiedCount += result.modifiedCount;
+        unModifiedCount += result.unModifiedCount;
+        datasetOps = [];
+        proposalIncrements = new Map();
         console.log(
           "migrating, count, unModifiedCount: ",
           modifiedCount,
@@ -102,7 +143,10 @@ module.exports = {
         );
       }
     }
-    await flushBatch();
+
+    const finalResult = await flushChunk(db, datasetOps, proposalIncrements);
+    modifiedCount += finalResult.modifiedCount;
+    unModifiedCount += finalResult.unModifiedCount;
 
     console.log(
       "FINISHED: count, unModifiedCount: ",

--- a/migrations/20260831150000-backfill-dataset-proposalids-from-ownergroup.js
+++ b/migrations/20260831150000-backfill-dataset-proposalids-from-ownergroup.js
@@ -1,0 +1,118 @@
+/**
+ *
+ * Backfills proposalIds on raw Datasets that don't have one set yet, by
+ * matching the dataset's ownerGroup against Proposal.ownerGroup. Since
+ * ownerGroup is not unique on Proposal, a dataset can end up linked to
+ * more than one proposal.
+ *
+ * A broad/shared ownerGroup could otherwise match an unreasonable number of
+ * unrelated proposals, so groups matching more than
+ * MAX_PROPOSALS_PER_OWNER_GROUP proposals are skipped and logged instead of
+ * writing a huge proposalIds array.
+ */
+
+const MAX_PROPOSALS_PER_OWNER_GROUP = 100;
+
+module.exports = {
+  async up(db) {
+    const BATCH_SIZE = 10000;
+    let modifiedCount = 0;
+    let unModifiedCount = 0;
+    let batch = [];
+    const warnedOwnerGroups = new Set();
+
+    const flushBatch = async () => {
+      if (batch.length === 0) return;
+
+      const ownerGroups = [
+        ...new Set(batch.map((dataset) => dataset.ownerGroup)),
+      ];
+      const proposalIdsByOwnerGroup = new Map();
+      const tooManyOwnerGroups = new Set();
+      for await (const proposal of db
+        .collection("Proposal")
+        .find(
+          { ownerGroup: { $in: ownerGroups } },
+          { projection: { ownerGroup: 1, proposalId: 1 } },
+        )) {
+        if (!proposal.ownerGroup || !proposal.proposalId) continue;
+        if (tooManyOwnerGroups.has(proposal.ownerGroup)) continue;
+
+        const existing = proposalIdsByOwnerGroup.get(proposal.ownerGroup) || [];
+        existing.push(proposal.proposalId);
+
+        if (existing.length > MAX_PROPOSALS_PER_OWNER_GROUP) {
+          proposalIdsByOwnerGroup.delete(proposal.ownerGroup);
+          tooManyOwnerGroups.add(proposal.ownerGroup);
+          if (!warnedOwnerGroups.has(proposal.ownerGroup)) {
+            warnedOwnerGroups.add(proposal.ownerGroup);
+            console.warn(
+              `Skipping proposalIds backfill for ownerGroup "${proposal.ownerGroup}": ` +
+                `more than ${MAX_PROPOSALS_PER_OWNER_GROUP} matching proposals.`,
+            );
+          }
+          continue;
+        }
+
+        proposalIdsByOwnerGroup.set(proposal.ownerGroup, existing);
+      }
+
+      const bulkOps = [];
+      for (const dataset of batch) {
+        const proposalIds = proposalIdsByOwnerGroup.get(dataset.ownerGroup);
+        if (!proposalIds || proposalIds.length === 0) continue;
+
+        bulkOps.push({
+          updateOne: {
+            filter: { _id: dataset._id },
+            update: { $set: { proposalIds } },
+          },
+        });
+      }
+
+      if (bulkOps.length > 0) {
+        const bulkWriteResult = await db
+          .collection("Dataset")
+          .bulkWrite(bulkOps, { ordered: false });
+        modifiedCount += bulkWriteResult.modifiedCount;
+        unModifiedCount += bulkOps.length - bulkWriteResult.modifiedCount;
+      }
+
+      batch = [];
+    };
+
+    for await (const dataset of db.collection("Dataset").find(
+      {
+        type: "raw",
+        $or: [
+          { proposalIds: { $exists: false } },
+          { proposalIds: { $size: 0 } },
+        ],
+      },
+      { projection: { ownerGroup: 1 } },
+    )) {
+      batch.push(dataset);
+
+      if (batch.length === BATCH_SIZE) {
+        await flushBatch();
+        console.log(
+          "migrating, count, unModifiedCount: ",
+          modifiedCount,
+          unModifiedCount,
+        );
+      }
+    }
+    await flushBatch();
+
+    console.log(
+      "FINISHED: count, unModifiedCount: ",
+      modifiedCount,
+      unModifiedCount,
+    );
+  },
+
+  async down(_db, _client) {
+    // No path backward: we can't tell an auto-filled proposalIds value
+    // apart from one a user set manually after this migration ran.
+  },
+};

--- a/src/datasets/datasets.service.spec.ts
+++ b/src/datasets/datasets.service.spec.ts
@@ -32,6 +32,7 @@ class MetadataKeysServiceMock {
 class ProposalsServiceMock {
   incrementNumberOfDatasets = jest.fn().mockResolvedValue(undefined);
   findAll = jest.fn().mockResolvedValue([]);
+  count = jest.fn().mockResolvedValue({ count: 0 });
 }
 
 const mockDataset: DatasetClass = {
@@ -194,6 +195,7 @@ describe("DatasetsService", () => {
       route: { path: "/datasets" },
     } as unknown as Request;
 
+    proposalsService.count.mockResolvedValueOnce({ count: 2 });
     proposalsService.findAll.mockResolvedValueOnce([
       { proposalId: "20210101.1" },
       { proposalId: "20210101.2" },
@@ -201,13 +203,17 @@ describe("DatasetsService", () => {
 
     const result = await service.create(dto);
 
+    expect(proposalsService.count).toHaveBeenCalledWith({
+      where: { ownerGroup: mockDataset.ownerGroup },
+    });
     expect(proposalsService.findAll).toHaveBeenCalledWith({
       where: { ownerGroup: mockDataset.ownerGroup },
+      limits: { limit: 100 },
     });
     expect(result.proposalIds).toEqual(["20210101.1", "20210101.2"]);
   });
 
-  it("should skip proposalIds auto-fill when ownerGroup matches too many proposals", async () => {
+  it("should truncate proposalIds auto-fill when ownerGroup matches too many proposals", async () => {
     const dtoData = { ...mockDataset, type: "raw", proposalIds: [] };
     const dto = plainToInstance(CreateDatasetDto, dtoData);
 
@@ -216,17 +222,19 @@ describe("DatasetsService", () => {
       route: { path: "/datasets" },
     } as unknown as Request;
 
-    const tooManyProposals = Array.from({ length: 101 }, (_, i) => ({
+    const cappedProposals = Array.from({ length: 100 }, (_, i) => ({
       proposalId: `20210101.${i}`,
     }));
-    proposalsService.findAll.mockResolvedValueOnce(tooManyProposals);
+    proposalsService.count.mockResolvedValueOnce({ count: 101 });
+    proposalsService.findAll.mockResolvedValueOnce(cappedProposals);
 
     const result = await service.create(dto);
 
     expect(proposalsService.findAll).toHaveBeenCalledWith({
       where: { ownerGroup: mockDataset.ownerGroup },
+      limits: { limit: 100 },
     });
-    expect(result.proposalIds).toEqual([]);
+    expect(result.proposalIds).toHaveLength(100);
   });
 
   it("should not look up proposals for a raw dataset that already has proposalIds set", async () => {
@@ -309,6 +317,7 @@ describe("DatasetsService", () => {
         exec: jest.fn().mockResolvedValue(patchedWithProposals),
       });
 
+    proposalsService.count.mockResolvedValueOnce({ count: 1 });
     proposalsService.findAll.mockResolvedValueOnce([
       { proposalId: "20260101.1" },
     ]);
@@ -319,6 +328,7 @@ describe("DatasetsService", () => {
 
     expect(proposalsService.findAll).toHaveBeenCalledWith({
       where: { ownerGroup: existing.ownerGroup },
+      limits: { limit: 100 },
     });
     // the proposalIds backfill is a second, atomically-guarded update, not
     // merged into the caller's own patch
@@ -337,6 +347,9 @@ describe("DatasetsService", () => {
       expect.anything(),
     );
     expect(result?.proposalIds).toEqual(["20260101.1"]);
+    expect(proposalsService.incrementNumberOfDatasets).toHaveBeenCalledWith([
+      "20260101.1",
+    ]);
   });
 
   it("should not clobber a concurrently-set proposalIds when the guarded backfill no longer matches", async () => {
@@ -358,6 +371,7 @@ describe("DatasetsService", () => {
       // no longer matches and the conditional update returns null
       .mockReturnValueOnce({ exec: jest.fn().mockResolvedValue(null) });
 
+    proposalsService.count.mockResolvedValueOnce({ count: 1 });
     proposalsService.findAll.mockResolvedValueOnce([
       { proposalId: "20260101.1" },
     ]);
@@ -368,6 +382,7 @@ describe("DatasetsService", () => {
 
     expect(model.findOneAndUpdate).toHaveBeenCalledTimes(2);
     expect(result).toEqual(existing);
+    expect(proposalsService.incrementNumberOfDatasets).not.toHaveBeenCalled();
   });
 
   it("should not look up proposals on patch when the dataset already has proposalIds", async () => {

--- a/src/datasets/datasets.service.spec.ts
+++ b/src/datasets/datasets.service.spec.ts
@@ -31,6 +31,7 @@ class MetadataKeysServiceMock {
 
 class ProposalsServiceMock {
   incrementNumberOfDatasets = jest.fn().mockResolvedValue(undefined);
+  findAll = jest.fn().mockResolvedValue([]);
 }
 
 const mockDataset: DatasetClass = {
@@ -114,6 +115,7 @@ mockDatasetModel.collection = { name: "Dataset" };
 describe("DatasetsService", () => {
   let service: DatasetsService;
   let model: Model<DatasetClass>;
+  let proposalsService: ProposalsServiceMock;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -140,6 +142,7 @@ describe("DatasetsService", () => {
 
     service = await module.resolve<DatasetsService>(DatasetsService);
     model = module.get<Model<DatasetClass>>(getModelToken("DatasetClass"));
+    proposalsService = module.get<ProposalsServiceMock>(ProposalsService);
   });
 
   it("should be defined", () => {
@@ -182,6 +185,80 @@ describe("DatasetsService", () => {
     ).toBe("Already Encoded");
   });
 
+  it("should populate proposalIds from matching proposals' ownerGroup for a raw dataset with no proposalIds set", async () => {
+    const dtoData = { ...mockDataset, type: "raw", proposalIds: [] };
+    const dto = plainToInstance(CreateDatasetDto, dtoData);
+
+    (service as unknown as { request: Request }).request = {
+      user: { username: "tester" },
+      route: { path: "/datasets" },
+    } as unknown as Request;
+
+    proposalsService.findAll.mockResolvedValueOnce([
+      { proposalId: "20210101.1" },
+      { proposalId: "20210101.2" },
+    ]);
+
+    const result = await service.create(dto);
+
+    expect(proposalsService.findAll).toHaveBeenCalledWith({
+      where: { ownerGroup: mockDataset.ownerGroup },
+    });
+    expect(result.proposalIds).toEqual(["20210101.1", "20210101.2"]);
+  });
+
+  it("should skip proposalIds auto-fill when ownerGroup matches too many proposals", async () => {
+    const dtoData = { ...mockDataset, type: "raw", proposalIds: [] };
+    const dto = plainToInstance(CreateDatasetDto, dtoData);
+
+    (service as unknown as { request: Request }).request = {
+      user: { username: "tester" },
+      route: { path: "/datasets" },
+    } as unknown as Request;
+
+    const tooManyProposals = Array.from({ length: 101 }, (_, i) => ({
+      proposalId: `20210101.${i}`,
+    }));
+    proposalsService.findAll.mockResolvedValueOnce(tooManyProposals);
+
+    const result = await service.create(dto);
+
+    expect(proposalsService.findAll).toHaveBeenCalledWith({
+      where: { ownerGroup: mockDataset.ownerGroup },
+    });
+    expect(result.proposalIds).toEqual([]);
+  });
+
+  it("should not look up proposals for a raw dataset that already has proposalIds set", async () => {
+    const dtoData = { ...mockDataset, type: "raw" };
+    const dto = plainToInstance(CreateDatasetDto, dtoData);
+
+    (service as unknown as { request: Request }).request = {
+      user: { username: "tester" },
+      route: { path: "/datasets" },
+    } as unknown as Request;
+
+    const result = await service.create(dto);
+
+    expect(proposalsService.findAll).not.toHaveBeenCalled();
+    expect(result.proposalIds).toEqual(mockDataset.proposalIds);
+  });
+
+  it("should not look up proposals for a derived dataset", async () => {
+    const dtoData = { ...mockDataset, type: "derived", proposalIds: [] };
+    const dto = plainToInstance(CreateDatasetDto, dtoData);
+
+    (service as unknown as { request: Request }).request = {
+      user: { username: "tester" },
+      route: { path: "/datasets" },
+    } as unknown as Request;
+
+    const result = await service.create(dto);
+
+    expect(proposalsService.findAll).not.toHaveBeenCalled();
+    expect(result.proposalIds).toEqual([]);
+  });
+
   it("should throw NotFoundException if no document is found", async () => {
     const updateDto = { datasetName: "Updated Name" };
     model.findOne = jest
@@ -204,6 +281,111 @@ describe("DatasetsService", () => {
     await expect(
       service.findByIdAndUpdate("testId", updateDto, unmodifiedSince),
     ).rejects.toThrow(PreconditionFailedException);
+  });
+
+  it("should backfill proposalIds on patch when a raw dataset still has none", async () => {
+    const existing = { ...mockDataset, type: "raw", proposalIds: [] };
+    model.findOne = jest
+      .fn()
+      .mockReturnValue({ exec: jest.fn().mockResolvedValue(existing) });
+
+    const patchedNoProposals = {
+      ...existing,
+      toObject: jest.fn().mockReturnValue(existing),
+    };
+    const patchedWithProposals = {
+      ...existing,
+      proposalIds: ["20260101.1"],
+      toObject: jest
+        .fn()
+        .mockReturnValue({ ...existing, proposalIds: ["20260101.1"] }),
+    };
+    model.findOneAndUpdate = jest
+      .fn()
+      .mockReturnValueOnce({
+        exec: jest.fn().mockResolvedValue(patchedNoProposals),
+      })
+      .mockReturnValueOnce({
+        exec: jest.fn().mockResolvedValue(patchedWithProposals),
+      });
+
+    proposalsService.findAll.mockResolvedValueOnce([
+      { proposalId: "20260101.1" },
+    ]);
+
+    const result = await service.findByIdAndUpdate("testId", {
+      datasetName: "Updated",
+    });
+
+    expect(proposalsService.findAll).toHaveBeenCalledWith({
+      where: { ownerGroup: existing.ownerGroup },
+    });
+    // the proposalIds backfill is a second, atomically-guarded update, not
+    // merged into the caller's own patch
+    expect(model.findOneAndUpdate).toHaveBeenCalledTimes(2);
+    expect(model.findOneAndUpdate).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        pid: "testId",
+        type: "raw",
+        $or: [
+          { proposalIds: { $exists: false } },
+          { proposalIds: { $size: 0 } },
+        ],
+      }),
+      { $set: { proposalIds: ["20260101.1"] } },
+      expect.anything(),
+    );
+    expect(result?.proposalIds).toEqual(["20260101.1"]);
+  });
+
+  it("should not clobber a concurrently-set proposalIds when the guarded backfill no longer matches", async () => {
+    const existing = { ...mockDataset, type: "raw", proposalIds: [] };
+    model.findOne = jest
+      .fn()
+      .mockReturnValue({ exec: jest.fn().mockResolvedValue(existing) });
+
+    const patchedNoProposals = {
+      ...existing,
+      toObject: jest.fn().mockReturnValue(existing),
+    };
+    model.findOneAndUpdate = jest
+      .fn()
+      .mockReturnValueOnce({
+        exec: jest.fn().mockResolvedValue(patchedNoProposals),
+      })
+      // a concurrent write already set proposalIds, so the guarded filter
+      // no longer matches and the conditional update returns null
+      .mockReturnValueOnce({ exec: jest.fn().mockResolvedValue(null) });
+
+    proposalsService.findAll.mockResolvedValueOnce([
+      { proposalId: "20260101.1" },
+    ]);
+
+    const result = await service.findByIdAndUpdate("testId", {
+      datasetName: "Updated",
+    });
+
+    expect(model.findOneAndUpdate).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(existing);
+  });
+
+  it("should not look up proposals on patch when the dataset already has proposalIds", async () => {
+    model.findOne = jest
+      .fn()
+      .mockReturnValue({ exec: jest.fn().mockResolvedValue(mockDataset) });
+
+    const patched = {
+      ...mockDataset,
+      toObject: jest.fn().mockReturnValue(mockDataset),
+    };
+    model.findOneAndUpdate = jest
+      .fn()
+      .mockReturnValue({ exec: jest.fn().mockResolvedValue(patched) });
+
+    await service.findByIdAndUpdate("testId", { datasetName: "Updated" });
+
+    expect(proposalsService.findAll).not.toHaveBeenCalled();
   });
 
   describe("updateDatasetSizeAndFiles", () => {

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -184,22 +184,26 @@ export class DatasetsService {
     if (type !== DatasetType.Raw || (proposalIds?.length ?? 0) > 0)
       return undefined;
 
-    const matchingProposals = await this.proposalService.findAll({
+    const { count: matchingProposalsCount } = await this.proposalService.count({
       where: { ownerGroup },
     });
 
-    if (matchingProposals.length === 0) {
+    if (matchingProposalsCount === 0) {
       return undefined;
     }
 
-    if (matchingProposals.length > MAX_PROPOSALS_PER_OWNER_GROUP) {
+    if (matchingProposalsCount > MAX_PROPOSALS_PER_OWNER_GROUP) {
       Logger.warn(
-        `Skipping proposalIds auto-fill for ownerGroup "${ownerGroup}": ` +
-          `${matchingProposals.length} matching proposals exceed the ${MAX_PROPOSALS_PER_OWNER_GROUP} cap.`,
+        `ownerGroup "${ownerGroup}" matches ${matchingProposalsCount} proposals; ` +
+          `only linking the first ${MAX_PROPOSALS_PER_OWNER_GROUP}.`,
         DatasetsService.name,
       );
-      return undefined;
     }
+
+    const matchingProposals = await this.proposalService.findAll({
+      where: { ownerGroup },
+      limits: { limit: MAX_PROPOSALS_PER_OWNER_GROUP },
+    });
 
     return matchingProposals.map((proposal) => proposal.proposalId);
   }
@@ -232,7 +236,13 @@ export class DatasetsService {
       )
       .exec();
 
-    return (datasetWithProposalIds as T | null) ?? dataset;
+    if (!datasetWithProposalIds) {
+      return dataset;
+    }
+
+    await this.proposalService.incrementNumberOfDatasets(proposalIds);
+
+    return datasetWithProposalIds as T;
   }
 
   async create(createDatasetDto: CreateDatasetDto): Promise<DatasetDocument> {

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -62,6 +62,7 @@ import {
   DATASET_LOOKUP_FIELDS,
   DatasetLookupKeysEnum,
 } from "./types/dataset-lookup";
+import { DatasetType } from "./types/dataset-type.enum";
 import { ProposalsService } from "src/proposals/proposals.service";
 import { MetadataKeysService } from "src/metadata-keys/metadatakeys.service";
 import { OpensearchService } from "src/opensearch/opensearch.service";
@@ -74,6 +75,9 @@ import { DATASET_OPENSEARCH_PROJECTION } from "../opensearch/utils/dataset-opens
 import { withOCCFilter } from "./utils/occ-util";
 import { Datablock } from "src/datablocks/schemas/datablock.schema";
 import { OrigDatablock } from "src/origdatablocks/schemas/origdatablock.schema";
+
+const MAX_PROPOSALS_PER_OWNER_GROUP = 100;
+
 @Injectable({ scope: Scope.REQUEST })
 export class DatasetsService {
   private readonly osDefaultIndex: string;
@@ -172,6 +176,65 @@ export class DatasetsService {
     return { scopes, relations };
   }
 
+  private async resolveMissingProposalIds(
+    type: string,
+    ownerGroup: string,
+    proposalIds?: string[],
+  ): Promise<string[] | undefined> {
+    if (type !== DatasetType.Raw || (proposalIds?.length ?? 0) > 0)
+      return undefined;
+
+    const matchingProposals = await this.proposalService.findAll({
+      where: { ownerGroup },
+    });
+
+    if (matchingProposals.length === 0) {
+      return undefined;
+    }
+
+    if (matchingProposals.length > MAX_PROPOSALS_PER_OWNER_GROUP) {
+      Logger.warn(
+        `Skipping proposalIds auto-fill for ownerGroup "${ownerGroup}": ` +
+          `${matchingProposals.length} matching proposals exceed the ${MAX_PROPOSALS_PER_OWNER_GROUP} cap.`,
+        DatasetsService.name,
+      );
+      return undefined;
+    }
+
+    return matchingProposals.map((proposal) => proposal.proposalId);
+  }
+
+  private async backfillProposalIds<T extends DatasetDocument>(
+    id: string,
+    dataset: T,
+  ): Promise<T> {
+    const proposalIds = await this.resolveMissingProposalIds(
+      dataset.type,
+      dataset.ownerGroup,
+      dataset.proposalIds,
+    );
+    if (!proposalIds) {
+      return dataset;
+    }
+
+    const datasetWithProposalIds = await this.datasetModel
+      .findOneAndUpdate(
+        {
+          pid: id,
+          type: DatasetType.Raw,
+          $or: [
+            { proposalIds: { $exists: false } },
+            { proposalIds: { $size: 0 } },
+          ],
+        },
+        { $set: { proposalIds } },
+        { new: true },
+      )
+      .exec();
+
+    return (datasetWithProposalIds as T | null) ?? dataset;
+  }
+
   async create(createDatasetDto: CreateDatasetDto): Promise<DatasetDocument> {
     const username = (this.request.user as JWTUser).username;
     // Add version to the datasets based on the apiVersion extracted from the route path or use default one
@@ -179,6 +242,15 @@ export class DatasetsService {
       createDatasetDto,
       this.request.route.path || this.configService.get("versions.api"),
     );
+
+    const proposalIds = await this.resolveMissingProposalIds(
+      createDatasetDto.type,
+      createDatasetDto.ownerGroup,
+      createDatasetDto.proposalIds,
+    );
+    if (proposalIds)
+      (createDatasetDto as { proposalIds?: string[] }).proposalIds =
+        proposalIds;
 
     const createdDataset = new this.datasetModel(
       // insert created and updated fields
@@ -522,7 +594,7 @@ export class DatasetsService {
     // https://stackoverflow.com/questions/57324321/mongoose-overwriting-data-in-mongodb-with-default-values-in-subdocuments
     let queryFilter: FilterQuery<DatasetDocument> = { pid: id };
     queryFilter = withOCCFilter(queryFilter, unmodifiedSince);
-    const patchedDataset = await this.datasetModel
+    let patchedDataset = await this.datasetModel
       .findOneAndUpdate(
         queryFilter,
         addUpdatedByField(
@@ -541,6 +613,11 @@ export class DatasetsService {
       throw new PreconditionFailedException(
         `Dataset #${id} has been modified on the server since ${unmodifiedSince.toUTCString()}.`,
       );
+    }
+
+    // Auto-fill proposalIds only when this patch didn't touch the field itself.
+    if (!("proposalIds" in updateDatasetDto)) {
+      patchedDataset = await this.backfillProposalIds(id, patchedDataset);
     }
 
     if (this.opensearchService) {

--- a/test/RawDataset.js
+++ b/test/RawDataset.js
@@ -532,6 +532,115 @@ describe("1900: RawDataset: Raw Datasets", () => {
       });
   });
 
+  it("0141: auto-fills proposalId of a new raw dataset from a proposal sharing its ownerGroup", async () => {
+    const autofillOwnerGroup = faker.string.alphanumeric(10);
+    const newProposal = {
+      ...TestData.ProposalCorrectComplete,
+      proposalId: faker.string.numeric(8),
+      ownerGroup: autofillOwnerGroup,
+    };
+
+    const proposalRes = await request(appUrl)
+      .post("/api/v3/Proposals")
+      .send(newProposal)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessProposalToken}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/);
+
+    const autofillProposalId = proposalRes.body["proposalId"];
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { proposalId, ...rawDatasetWithoutProposal } = TestData.RawCorrect;
+    const datasetRes = await request(appUrl)
+      .post("/api/v3/Datasets")
+      .send({
+        ...rawDatasetWithoutProposal,
+        ownerGroup: autofillOwnerGroup,
+        sourceFolder: "/data/autofill-on-create/",
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/);
+
+    datasetRes.body.should.have
+      .property("proposalId")
+      .and.be.equal(autofillProposalId);
+
+    await request(appUrl)
+      .delete("/api/v3/datasets/" + encodeURIComponent(datasetRes.body["pid"]))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.SuccessfulDeleteStatusCode);
+
+    await request(appUrl)
+      .delete("/api/v3/Proposals/" + encodeURIComponent(autofillProposalId))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.SuccessfulDeleteStatusCode);
+  });
+
+  it("0142: backfills proposalId on patch once a proposal sharing the dataset's ownerGroup is created afterwards", async () => {
+    const autofillOwnerGroup = faker.string.alphanumeric(10);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { proposalId, ...rawDatasetWithoutProposal } = TestData.RawCorrect;
+    const datasetRes = await request(appUrl)
+      .post("/api/v3/Datasets")
+      .send({
+        ...rawDatasetWithoutProposal,
+        ownerGroup: autofillOwnerGroup,
+        sourceFolder: "/data/autofill-on-patch/",
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/);
+
+    // no proposal shares this ownerGroup yet, so nothing to link
+    datasetRes.body.should.not.have.property("proposalId");
+
+    const newProposal = {
+      ...TestData.ProposalCorrectComplete,
+      proposalId: faker.string.numeric(8),
+      ownerGroup: autofillOwnerGroup,
+    };
+    const proposalRes = await request(appUrl)
+      .post("/api/v3/Proposals")
+      .send(newProposal)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessProposalToken}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/);
+
+    const autofillProposalId = proposalRes.body["proposalId"];
+
+    const patchRes = await request(appUrl)
+      .patch("/api/v3/datasets/" + encodeURIComponent(datasetRes.body["pid"]))
+      .send(TestData.PatchComment)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulPatchStatusCode)
+      .expect("Content-Type", /json/);
+
+    patchRes.body.should.have
+      .property("proposalId")
+      .and.be.equal(autofillProposalId);
+
+    await request(appUrl)
+      .delete("/api/v3/datasets/" + encodeURIComponent(datasetRes.body["pid"]))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.SuccessfulDeleteStatusCode);
+
+    await request(appUrl)
+      .delete("/api/v3/Proposals/" + encodeURIComponent(autofillProposalId))
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
+      .expect(TestData.SuccessfulDeleteStatusCode);
+  });
+
   it("0150: should fail to update comment of the dataset", async () => {
     return request(appUrl)
       .patch("/api/v3/datasets/" + pid)


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
This feature is ported from the old backend from [here](https://github.com/SciCatProject/backend-v3/blob/master/common/models/raw-dataset.js#L40)

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Automatically associate raw datasets with matching proposals by owner group while safely backfilling existing records and maintaining proposal dataset counts.

New Features:
- Automatically link raw datasets to proposals sharing their owner group when proposal IDs are missing, both during creation and subsequent updates.
- Add a migration to backfill proposal links for existing raw datasets and update proposal dataset counts.

Bug Fixes:
- Prevent automatic linking from overwriting explicitly supplied proposal IDs or concurrent updates.
- Limit owner-group-based links to 100 proposals to avoid unbounded associations.

Tests:
- Add unit and integration coverage for proposal linking on creation, patch backfills, capped matches, dataset types, existing links, and concurrent updates.