### PR TITLE
chore: add toClassOnly on v3 output transforms

### DIFF
--- a/src/common/utils/deep-mapper.util.ts
+++ b/src/common/utils/deep-mapper.util.ts
@@ -10,10 +10,10 @@ function getDeep<T, U>(
   fieldsMap: Partial<Record<keyof U & string, string>>,
 ): T[keyof T] | unknown | null {
   if (!source) return null;
-  if (!fieldsMap[key]) return get(source, key);
-  if (get(source, key)) return get(source, key);
-  if (!fieldsMap[key].includes("[]")) return get(source, fieldsMap[key]);
-  const keysList = fieldsMap[key].split("[]");
+  const path = fieldsMap[key];
+  if (!path) return get(source, key);
+  if (!path.includes("[]")) return get(source, path);
+  const keysList = path.split("[]");
   const initialValue = get(source, trim(keysList[0], "."));
   if (!initialValue) return;
   return keysList.slice(1).reduce((acc, currKey) => {

--- a/src/jobs/dto/output-job-v3.dto.ts
+++ b/src/jobs/dto/output-job-v3.dto.ts
@@ -25,7 +25,9 @@ export class OutputJobV3Dto {
    * The email of the person initiating the job request.
    */
   @Expose()
-  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key))
+  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key), {
+    toClassOnly: true,
+  })
   emailJobInitiator?: string;
 
   /**
@@ -38,42 +40,53 @@ export class OutputJobV3Dto {
    * Time when job is created. Format according to chapter 5.6 internet date/time format in RFC 3339. This is handled automatically by mongoose with timestamps flag.
    */
   @Expose()
-  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key))
+  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key), {
+    toClassOnly: true,
+  })
   creationTime: Date;
 
   /**
    * Time when job should be executed. If not specified then the Job will be executed asap. Format according to chapter 5.6 internet date/time format in RFC 3339.
    */
   @Expose()
-  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key))
+  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key), {
+    toClassOnly: true,
+  })
   executionTime?: Date;
 
   /**
    * Object of key-value pairs defining job input parameters, e.g. 'destinationPath' for retrieve jobs or 'tapeCopies' for archive jobs.
    */
   @Expose()
-  @Transform(({ obj }) => {
-    return {
-      username: _.get(obj, jobV3toV4FieldMap["jobParams.username"]),
-      ..._.omitBy(obj?.jobParams, (_, key) =>
-        Object.values(jobV3toV4FieldMap).includes(`jobParams.${key}`),
-      ),
-    };
-  })
+  @Transform(
+    ({ obj }) => {
+      return {
+        username: _.get(obj, jobV3toV4FieldMap["jobParams.username"]),
+        ..._.omitBy(obj?.jobParams, (_, key) =>
+          Object.values(jobV3toV4FieldMap).includes(`jobParams.${key}`),
+        ),
+      };
+    },
+    { toClassOnly: true },
+  )
   jobParams: Record<string, unknown>;
 
   /**
    * Defines current status of job lifecycle.
    */
   @Expose()
-  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key))
+  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key), {
+    toClassOnly: true,
+  })
   jobStatusMessage?: string;
 
   /**
    * Array of objects with keys: pid, files. The value for the pid key defines the dataset ID, the value for the files key is an array of file names. This array is either an empty array, implying that all files within the dataset are selected, or an explicit list of dataset-relative file paths, which should be selected.
    */
   @Expose()
-  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key))
+  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key), {
+    toClassOnly: true,
+  })
   datasetList: DatasetListDto[];
 
   /**


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Not having the toClassOnly made classtransformer second pass retrasform back the fields. This worked only because the deep getter had a fallback where a top level field with a nested mapper took precedence.

This PR removes the stray precedence assumption and fixes the downstream back conversion.


## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Restrict v3 output field transformations to class conversion and make deep mapping honor explicit field paths.

Bug Fixes:
- Prevent v3 output DTO transformations from being reapplied during downstream conversion.
- Correct deep field mapping to consistently resolve configured mapped paths instead of relying on top-level field precedence.