### PR TITLE
feat: remove types hardcoding from policy and add v4

### DIFF
--- a/migrations/20260901122200-consolidate-policy-notifications-into-jobpolicies.js
+++ b/migrations/20260901122200-consolidate-policy-notifications-into-jobpolicies.js
@@ -1,0 +1,43 @@
+const policyV3toV4FieldMap =
+  require("../dist/policies/dto/policy.obsolete.dto").policyV3toV4FieldMap;
+
+const FIELD_MAPPINGS = Object.entries(policyV3toV4FieldMap).map(
+  ([legacy, target]) => ({ legacy, target }),
+);
+
+
+module.exports = {
+  async up(db) {
+    await db.collection("Policy").updateMany(
+      { $or: FIELD_MAPPINGS.map(({ legacy }) => ({ [legacy]: { $exists: true } })) },
+      [
+        {
+          $set: Object.fromEntries(
+            FIELD_MAPPINGS.map(({ legacy, target }) => [
+              target,
+              { $ifNull: [`$${target}`, `$${legacy}`] },
+            ]),
+          ),
+        },
+        { $unset: FIELD_MAPPINGS.map(({ legacy }) => legacy) },
+      ],
+    );
+  },
+
+  async down(db) {
+    await db.collection("Policy").updateMany(
+      { $or: FIELD_MAPPINGS.map(({ target }) => ({ [target]: { $exists: true } })) },
+      [
+        {
+          $set: Object.fromEntries(
+            FIELD_MAPPINGS.map(({ legacy, target }) => [
+              legacy,
+              { $ifNull: [`$${legacy}`, `$${target}`] },
+            ]),
+          ),
+        },
+        { $unset: FIELD_MAPPINGS.map(({ target }) => target) },
+      ],
+    );
+  },
+};

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -390,7 +390,7 @@ export const parseOrderLimits = (
   if (!limits.order) return limitFilters;
   const sort: Record<string, "asc" | "desc"> = {};
   const [field, direction] = limits.order.split(":");
-  if (direction === "asc" || direction === "desc") sort[field] = direction;
+  sort[field] = direction === "desc" ? "desc" : "asc";
   limitFilters.sort = sort;
   return omit(limitFilters, "order");
 };

--- a/src/datasets/datasets.module.ts
+++ b/src/datasets/datasets.module.ts
@@ -72,7 +72,9 @@ import { OpensearchModule } from "src/opensearch/opensearch.module";
             });
             let av: string;
             if (policy) {
-              av = policy.tapeRedundancy || "low";
+              av =
+                (policy.jobPolicies?.archive as { tapeRedundancy?: string })
+                  ?.tapeRedundancy || "low";
             } else {
               const regexLiteral = /(?<=AV\=)(.*?)(?=\,)/g;
               av = (regexLiteral.exec(this.classification ?? "") || ["low"])[0];

--- a/src/policies/dto/create-policy-v4.dto.ts
+++ b/src/policies/dto/create-policy-v4.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsArray, IsObject, IsOptional } from "class-validator";
+import { OwnableDto } from "src/common/dto/ownable.dto";
+import { JobPolicy } from "../schemas/job-policy.schema";
+
+export class CreatePolicyV4Dto extends OwnableDto {
+  @ApiProperty({
+    required: false,
+    description:
+      "Defines the emails of users that can modify the policy parameters",
+  })
+  @IsArray()
+  @IsOptional()
+  readonly manager?: string[];
+
+  @ApiProperty({
+    type: JobPolicy,
+    required: false,
+    description:
+      "Per-job-type policy settings for this ownerGroup, keyed by job type.",
+  })
+  @IsObject()
+  @IsOptional()
+  readonly jobPolicies?: Record<string, JobPolicy>;
+}

--- a/src/policies/dto/policy.obsolete.dto.ts
+++ b/src/policies/dto/policy.obsolete.dto.ts
@@ -1,0 +1,151 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Expose, Transform } from "class-transformer";
+import { OwnableDto } from "src/common/dto/ownable.dto";
+import { createDeepMapper } from "src/common/utils/deep-mapper.util";
+import { Policy } from "../schemas/policy.schema";
+
+export const policyV3toV4FieldMap: Partial<
+  Record<keyof PolicyObsoleteDto & string, string>
+> = {
+  archiveEmailNotification: "jobPolicies.archive.emailNotification",
+  archiveEmailsToBeNotified: "jobPolicies.archive.emailTo",
+  tapeRedundancy: "jobPolicies.archive.tapeRedundancy",
+  autoArchive: "jobPolicies.archive.autoArchive",
+  autoArchiveDelay: "jobPolicies.archive.autoArchiveDelay",
+  embargoPeriod: "jobPolicies.archive.embargoPeriod",
+  retrieveEmailNotification: "jobPolicies.retrieve.emailNotification",
+  retrieveEmailsToBeNotified: "jobPolicies.retrieve.emailTo",
+};
+
+export const mapPolicyV3toV4Field = createDeepMapper<Policy, PolicyObsoleteDto>(
+  policyV3toV4FieldMap,
+);
+
+export class PolicyObsoleteDto extends OwnableDto {
+  @ApiProperty()
+  @Expose()
+  declare readonly ownerGroup: string;
+
+  @ApiProperty({ type: [String] })
+  @Expose()
+  declare readonly accessGroups?: string[];
+
+  @ApiProperty()
+  @Expose()
+  declare readonly instrumentGroup?: string;
+
+  @ApiProperty()
+  @Expose()
+  _id: string;
+
+  @ApiProperty()
+  @Expose()
+  id: string;
+
+  @ApiProperty()
+  @Expose()
+  createdBy: string;
+
+  @ApiProperty()
+  @Expose()
+  updatedBy: string;
+
+  @ApiProperty()
+  @Expose()
+  isPublished: boolean;
+
+  @ApiProperty({
+    description:
+      "Defines the emails of users that can modify the policy parameters",
+  })
+  @Expose()
+  manager: string[];
+
+  @ApiProperty({
+    description:
+      "Defines the level of redundancy in storage to minimize loss of data. Allowed values are low, medium, high. Low could e.g. mean one tape copy only, medium could mean two tape copies and high two geo-redundant tape copies",
+  })
+  @Expose()
+  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? "low", {
+    toClassOnly: true,
+  })
+  tapeRedundancy: string;
+
+  @ApiProperty({
+    description:
+      "Flag to indicate that a dataset should be automatically archived after ingest. If false then archive delay is ignored",
+  })
+  @Expose()
+  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? true, {
+    toClassOnly: true,
+  })
+  autoArchive: boolean;
+
+  @ApiProperty({
+    description:
+      "Number of days after dataset creation that (remaining) datasets are archived automatically",
+  })
+  @Expose()
+  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? 7, {
+    toClassOnly: true,
+  })
+  autoArchiveDelay: number;
+
+  @ApiProperty({
+    description:
+      "Flag is true when an email notification should be sent to archiveEmailsToBeNotified upon an archive job creation",
+  })
+  @Expose()
+  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? false, {
+    toClassOnly: true,
+  })
+  archiveEmailNotification: boolean;
+
+  @ApiProperty({
+    description:
+      "Array of additional email addresses that should be notified up an archive job creation",
+  })
+  @Expose()
+  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? [], {
+    toClassOnly: true,
+  })
+  archiveEmailsToBeNotified: string[];
+
+  @ApiProperty({
+    description:
+      "Flag is true when an email notification should be sent to retrieveEmailsToBeNotified upon a retrieval job creation",
+  })
+  @Expose()
+  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? false, {
+    toClassOnly: true,
+  })
+  retrieveEmailNotification: boolean;
+
+  @ApiProperty({
+    description:
+      "Array of additional email addresses that should be notified up a retrieval job creation",
+  })
+  @Expose()
+  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? [], {
+    toClassOnly: true,
+  })
+  retrieveEmailsToBeNotified: string[];
+
+  @ApiProperty({
+    description:
+      "Number of years after dataset creation before the dataset becomes public",
+  })
+  @Expose()
+  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? 3, {
+    toClassOnly: true,
+  })
+  embargoPeriod: number;
+
+  @ApiProperty()
+  @Expose()
+  createdAt: Date;
+
+  @ApiProperty()
+  @Expose()
+  updatedAt: Date;
+}

--- a/src/policies/dto/update-policy-v4.dto.ts
+++ b/src/policies/dto/update-policy-v4.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from "@nestjs/swagger";
+import { CreatePolicyV4Dto } from "./create-policy-v4.dto";
+
+export class UpdatePolicyV4Dto extends PartialType(CreatePolicyV4Dto) {}

--- a/src/policies/interfaces/policy-filters.interface.ts
+++ b/src/policies/interfaces/policy-filters.interface.ts
@@ -3,6 +3,7 @@ import { PolicyDocument } from "../schemas/policy.schema";
 
 export interface IPolicyFilter {
   where?: FilterQuery<PolicyDocument>;
+  fields?: string[];
   order?: string;
   skip?: number;
   limit?: number;

--- a/src/policies/interfaces/policy-filters.interface.ts
+++ b/src/policies/interfaces/policy-filters.interface.ts
@@ -7,3 +7,13 @@ export interface IPolicyFilter {
   skip?: number;
   limit?: number;
 }
+
+export interface IPolicyFilterV4 {
+  where?: FilterQuery<PolicyDocument>;
+  fields?: string[];
+  limits?: {
+    limit?: number;
+    skip?: number;
+    order?: string;
+  };
+}

--- a/src/policies/pipes/filter.pipe.ts
+++ b/src/policies/pipes/filter.pipe.ts
@@ -1,0 +1,13 @@
+import { FilterPipe, WherePipe } from "src/common/pipes/filter.pipe";
+import { Policy } from "../schemas/policy.schema";
+import { policyV3toV4FieldMap } from "../dto/policy.obsolete.dto";
+
+export const V3_FILTER_PIPE = [
+  new FilterPipe<Policy>({ apiToDBMap: policyV3toV4FieldMap }),
+];
+
+export const V3_WHERE_PIPE = new WherePipe<Policy>({
+  apiToDBMap: policyV3toV4FieldMap,
+});
+
+export const V4_FILTER_PIPE = [new FilterPipe<Policy>()];

--- a/src/policies/pipes/filter.pipe.ts
+++ b/src/policies/pipes/filter.pipe.ts
@@ -15,8 +15,8 @@ export class NestPolicyLimitsPipe implements PipeTransform<
   transform(value: { filter?: IPolicyFilter }): { filter?: IPolicyFilterV4 } {
     if (!value?.filter) return value as { filter?: IPolicyFilterV4 };
 
-    const { where, order, skip, limit } = value.filter;
-    return { filter: { where, limits: { order, skip, limit } } };
+    const { where, fields, order, skip, limit } = value.filter;
+    return { filter: { where, fields, limits: { order, skip, limit } } };
   }
 }
 

--- a/src/policies/pipes/filter.pipe.ts
+++ b/src/policies/pipes/filter.pipe.ts
@@ -1,13 +1,30 @@
+import { Injectable, PipeTransform } from "@nestjs/common";
 import { FilterPipe, WherePipe } from "src/common/pipes/filter.pipe";
 import { Policy } from "../schemas/policy.schema";
 import { policyV3toV4FieldMap } from "../dto/policy.obsolete.dto";
+import {
+  IPolicyFilter,
+  IPolicyFilterV4,
+} from "../interfaces/policy-filters.interface";
+
+@Injectable()
+export class NestPolicyLimitsPipe implements PipeTransform<
+  { filter?: IPolicyFilter },
+  { filter?: IPolicyFilterV4 }
+> {
+  transform(value: { filter?: IPolicyFilter }): { filter?: IPolicyFilterV4 } {
+    if (!value?.filter) return value as { filter?: IPolicyFilterV4 };
+
+    const { where, order, skip, limit } = value.filter;
+    return { filter: { where, limits: { order, skip, limit } } };
+  }
+}
 
 export const V3_FILTER_PIPE = [
   new FilterPipe<Policy>({ apiToDBMap: policyV3toV4FieldMap }),
+  new NestPolicyLimitsPipe(),
 ];
 
 export const V3_WHERE_PIPE = new WherePipe<Policy>({
   apiToDBMap: policyV3toV4FieldMap,
 });
-
-export const V4_FILTER_PIPE = [new FilterPipe<Policy>()];

--- a/src/policies/pipes/legacy-notification.pipe.ts
+++ b/src/policies/pipes/legacy-notification.pipe.ts
@@ -1,0 +1,20 @@
+import { Injectable, PipeTransform } from "@nestjs/common";
+import { createDeepSetter } from "src/common/utils/deep-mapper.util";
+import { PartialUpdatePolicyDto } from "../dto/update-policy.dto";
+import { policyV3toV4FieldMap } from "../dto/policy.obsolete.dto";
+import { Policy } from "../schemas/policy.schema";
+
+const dtoV3toV4 = createDeepSetter<PartialUpdatePolicyDto, Partial<Policy>>(
+  policyV3toV4FieldMap,
+);
+
+@Injectable()
+export class V3ToV4MigrationPipe<S, T> implements PipeTransform {
+  constructor(private readonly mapper: (source: S) => T) {}
+
+  transform(value: S): T {
+    return this.mapper(value);
+  }
+}
+
+export const LEGACY_NOTIFICATION_PIPE = new V3ToV4MigrationPipe(dtoV3toV4);

--- a/src/policies/policies.controller.ts
+++ b/src/policies/policies.controller.ts
@@ -29,9 +29,8 @@ import { AppAbility, CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { Action } from "src/casl/action.enum";
 import { Policy, PolicyDocument } from "./schemas/policy.schema";
 import { FilterQuery } from "mongoose";
-import { IPolicyFilter } from "./interfaces/policy-filters.interface";
+import { IPolicyFilterV4 } from "./interfaces/policy-filters.interface";
 import { UpdateWherePolicyDto } from "./dto/update-where-policy.dto";
-import { IFilters } from "src/common/interfaces/common.interface";
 import { CountApiResponse } from "src/common/types";
 import { Filter } from "src/datasets/decorators/filter.decorator";
 import { restrictToOwnPolicies } from "./utils/policy-access-filter.util";
@@ -76,7 +75,7 @@ export class PoliciesController {
   async findAll(
     @Req() request: Request,
     @Filter(...V3_FILTER_PIPE)
-    queryFilter: { filter?: IFilters<PolicyDocument, IPolicyFilter> },
+    queryFilter: { filter?: IPolicyFilterV4 },
   ): Promise<Policy[]> {
     const mergedFilters = restrictToOwnPolicies(
       this.caslAbilityFactory,

--- a/src/policies/policies.controller.ts
+++ b/src/policies/policies.controller.ts
@@ -1,4 +1,5 @@
 import {
+  ClassSerializerInterceptor,
   Controller,
   Get,
   Post,
@@ -7,15 +8,20 @@ import {
   Param,
   Delete,
   UseGuards,
+  UseInterceptors,
   Query,
   HttpCode,
   HttpStatus,
   Req,
+  SerializeOptions,
 } from "@nestjs/common";
 import { Request } from "express";
 import { PoliciesService } from "./policies.service";
 import { CreatePolicyDto } from "./dto/create-policy.dto";
 import { PartialUpdatePolicyDto } from "./dto/update-policy.dto";
+import { PolicyObsoleteDto } from "./dto/policy.obsolete.dto";
+import { LEGACY_NOTIFICATION_PIPE } from "./pipes/legacy-notification.pipe";
+import { V3_FILTER_PIPE, V3_WHERE_PIPE } from "./pipes/filter.pipe";
 import { ApiBearerAuth, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { PoliciesGuard } from "src/casl/guards/policies.guard";
 import { CheckPolicies } from "src/casl/decorators/check-policies.decorator";
@@ -26,52 +32,33 @@ import { FilterQuery } from "mongoose";
 import { IPolicyFilter } from "./interfaces/policy-filters.interface";
 import { UpdateWherePolicyDto } from "./dto/update-where-policy.dto";
 import { IFilters } from "src/common/interfaces/common.interface";
-import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
-import { FilterPipe } from "src/common/pipes/filter.pipe";
 import { CountApiResponse } from "src/common/types";
 import { Filter } from "src/datasets/decorators/filter.decorator";
+import { restrictToOwnPolicies } from "./utils/policy-access-filter.util";
 
 @ApiBearerAuth()
 @ApiTags("policies")
 @Controller("policies")
+@UseInterceptors(ClassSerializerInterceptor)
 export class PoliciesController {
   constructor(
     private readonly policiesService: PoliciesService,
     private caslAbilityFactory: CaslAbilityFactory,
   ) {}
 
-  updateMergedFiltersForList(
-    request: Request,
-    mergedFilters: IFilters<PolicyDocument, IPolicyFilter>,
-  ): IFilters<PolicyDocument, IPolicyFilter> {
-    const user: JWTUser = request.user as JWTUser;
-
-    if (user) {
-      const ability = this.caslAbilityFactory.policyAccess(user);
-      // these actions are not defined in casl
-      const canViewAll = ability.can(Action.ListAll, Policy);
-      const canViewTheirOwn = ability.can(Action.ListOwn, Policy);
-      if (!canViewAll && canViewTheirOwn) {
-        if (!mergedFilters.where) {
-          mergedFilters.where = {};
-        }
-        mergedFilters.where["$or"] = [
-          { ownerGroup: { $in: user.currentGroups } },
-          { accessGroups: { $in: user.currentGroups } },
-          { isPublished: true },
-        ];
-      }
-    }
-
-    return mergedFilters;
-  }
   @UseGuards(PoliciesGuard)
   @CheckPolicies("policies", (ability: AppAbility) =>
     ability.can(Action.Create, Policy),
   )
+  @SerializeOptions({ type: PolicyObsoleteDto, excludeExtraneousValues: true })
   @Post()
-  async create(@Body() createPolicyDto: CreatePolicyDto): Promise<Policy> {
-    return this.policiesService.create(createPolicyDto);
+  async create(
+    @Body(LEGACY_NOTIFICATION_PIPE)
+    createPolicyDto: CreatePolicyDto,
+  ): Promise<Policy> {
+    return this.policiesService.create(
+      createPolicyDto as unknown as Partial<Policy>,
+    );
   }
 
   @UseGuards(PoliciesGuard)
@@ -85,15 +72,17 @@ export class PoliciesController {
     required: false,
     example: '{"order":"ownerGroup:desc","skip":0,"limit":25}',
   })
+  @SerializeOptions({ type: PolicyObsoleteDto, excludeExtraneousValues: true })
   async findAll(
     @Req() request: Request,
-    @Filter(new FilterPipe())
+    @Filter(...V3_FILTER_PIPE)
     queryFilter: { filter?: IFilters<PolicyDocument, IPolicyFilter> },
   ): Promise<Policy[]> {
-    const mergedFilters = this.updateMergedFiltersForList(
+    const mergedFilters = restrictToOwnPolicies(
+      this.caslAbilityFactory,
       request,
       queryFilter.filter ?? {},
-    ) as IFilters<PolicyDocument, IPolicyFilter>;
+    );
 
     return this.policiesService.findAll(mergedFilters);
   }
@@ -115,9 +104,10 @@ export class PoliciesController {
     description:
       "Return the number of datasets in the following format: { count: integer }",
   })
-  async count(@Query("where") where?: string) {
-    const parsedWhere: FilterQuery<PolicyDocument> = JSON.parse(where ?? "{}");
-    return this.policiesService.count(parsedWhere);
+  async count(
+    @Query("where", V3_WHERE_PIPE) where?: FilterQuery<PolicyDocument>,
+  ) {
+    return this.policiesService.count(where ?? {});
   }
 
   @UseGuards(PoliciesGuard)
@@ -129,7 +119,7 @@ export class PoliciesController {
   async updateWhere(@Body() updateWherePolicyDto: UpdateWherePolicyDto) {
     return this.policiesService.updateWhere(
       updateWherePolicyDto.ownerGroupList,
-      updateWherePolicyDto.data,
+      LEGACY_NOTIFICATION_PIPE.transform(updateWherePolicyDto.data),
     );
   }
 
@@ -138,6 +128,7 @@ export class PoliciesController {
     ability.can(Action.Read, Policy),
   )
   @Get(":id")
+  @SerializeOptions({ type: PolicyObsoleteDto, excludeExtraneousValues: true })
   async findOne(@Param("id") id: string): Promise<Policy | null> {
     return this.policiesService.findOne({ _id: id });
   }
@@ -146,18 +137,24 @@ export class PoliciesController {
   @CheckPolicies("policies", (ability: AppAbility) =>
     ability.can(Action.Update, Policy),
   )
+  @SerializeOptions({ type: PolicyObsoleteDto, excludeExtraneousValues: true })
   @Patch(":id")
   async update(
     @Param("id") id: string,
-    @Body() updatePolicyDto: PartialUpdatePolicyDto,
+    @Body(LEGACY_NOTIFICATION_PIPE)
+    updatePolicyDto: PartialUpdatePolicyDto,
   ): Promise<Policy | null> {
-    return this.policiesService.update({ _id: id }, updatePolicyDto);
+    return this.policiesService.update(
+      { _id: id },
+      updatePolicyDto as unknown as Partial<Policy>,
+    );
   }
 
   @UseGuards(PoliciesGuard)
   @CheckPolicies("policies", (ability: AppAbility) =>
     ability.can(Action.Delete, Policy),
   )
+  @SerializeOptions({ type: PolicyObsoleteDto, excludeExtraneousValues: true })
   @Delete(":id")
   async remove(@Param("id") id: string): Promise<unknown> {
     return this.policiesService.remove({ _id: id });

--- a/src/policies/policies.module.ts
+++ b/src/policies/policies.module.ts
@@ -10,12 +10,13 @@ import {
   GenericHistorySchema,
 } from "../common/schemas/generic-history.schema";
 import { PoliciesController } from "./policies.controller";
+import { PoliciesV4Controller } from "./policies.v4.controller";
 import { PoliciesService } from "./policies.service";
 import { Policy, PolicySchema } from "./schemas/policy.schema";
 import { applyHistoryPluginOnce } from "src/common/mongoose/plugins/history.plugin.util";
 
 @Module({
-  controllers: [PoliciesController],
+  controllers: [PoliciesController, PoliciesV4Controller],
   imports: [
     AuthModule,
     CaslModule,

--- a/src/policies/policies.service.spec.ts
+++ b/src/policies/policies.service.spec.ts
@@ -13,14 +13,14 @@ class UsersServiceMock {}
 const mockPolicy: Policy = {
   _id: "testId",
   manager: ["test@email.com"],
-  tapeRedundancy: "low",
-  autoArchive: true,
-  autoArchiveDelay: 7,
-  archiveEmailNotification: true,
-  archiveEmailsToBeNotified: [],
-  retrieveEmailNotification: true,
-  retrieveEmailsToBeNotified: [],
-  embargoPeriod: 3,
+  jobPolicies: {
+    archive: {
+      emailTo: [],
+      tapeRedundancy: "low",
+      autoArchive: true,
+      autoArchiveDelay: 7,
+    },
+  },
   ownerGroup: "testOwnerGroup",
   accessGroups: ["testAccessGroup"],
   instrumentGroup: "testInstrument",

--- a/src/policies/policies.service.ts
+++ b/src/policies/policies.service.ts
@@ -10,11 +10,7 @@ import {
 import { ConfigService } from "@nestjs/config";
 import { InjectModel } from "@nestjs/mongoose";
 import { FilterQuery, Model } from "mongoose";
-import { CreatePolicyDto } from "./dto/create-policy.dto";
-import {
-  PartialUpdatePolicyDto,
-  UpdatePolicyDto,
-} from "./dto/update-policy.dto";
+import { LEGACY_NOTIFICATION_PIPE } from "./pipes/legacy-notification.pipe";
 import { Policy, PolicyDocument } from "./schemas/policy.schema";
 import { Request } from "express";
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
@@ -84,7 +80,7 @@ export class PoliciesService implements OnModuleInit {
   }
 
   async create(
-    createPolicyDto: CreatePolicyDto,
+    createPolicyDto: Partial<Policy>,
     policyUsername: string | null = null,
   ): Promise<Policy> {
     const username = policyUsername
@@ -128,25 +124,51 @@ export class PoliciesService implements OnModuleInit {
     return this.policyModel.findOne(filter).exec();
   }
 
+  // Turns a nested object into Mongo dot-path leaf keys (e.g.
+  // {jobPolicies: {archive: {emailTo: [...]}}} ->
+  // {"jobPolicies.archive.emailTo": [...]}), so a patch touching one field
+  // doesn't $set-clobber its untouched siblings. Top-level scalar/array
+  // fields (ownerGroup, manager, ...) come out as bare keys, unprefixed.
+  // Arrays are left as leaf values, not recursed into.
+  private flattenToDotPaths(
+    obj: Record<string, unknown>,
+    prefix = "",
+  ): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(obj)) {
+      const path = prefix ? `${prefix}.${key}` : key;
+      if (
+        value !== null &&
+        typeof value === "object" &&
+        !Array.isArray(value)
+      ) {
+        Object.assign(
+          result,
+          this.flattenToDotPaths(value as Record<string, unknown>, path),
+        );
+      } else {
+        result[path] = value;
+      }
+    }
+    return result;
+  }
+
   async update(
     filter: FilterQuery<PolicyDocument>,
-    updatePolicyDto: PartialUpdatePolicyDto,
+    updatePolicyDto: Partial<Policy>,
   ): Promise<Policy | null> {
     const username = (this.request.user as JWTUser).username;
+    const setFields = {
+      ...this.flattenToDotPaths(updatePolicyDto),
+      updatedBy: username,
+      updatedAt: new Date(),
+    };
+
     return this.policyModel
       .findOneAndUpdate(
         filter,
-        {
-          $set: {
-            ...updatePolicyDto,
-            updatedBy: username,
-            updatedAt: new Date(),
-          },
-        },
-        {
-          new: true,
-          runValidators: true,
-        },
+        { $set: setFields },
+        { new: true, runValidators: true },
       )
       .exec();
   }
@@ -157,7 +179,7 @@ export class PoliciesService implements OnModuleInit {
     return await this.policyModel.findOneAndDelete(filter).exec();
   }
 
-  async updateWhere(ownerGroupList: string, data: UpdatePolicyDto) {
+  async updateWhere(ownerGroupList: string, data: Partial<Policy>) {
     if (!ownerGroupList) {
       throw new InternalServerErrorException(
         "Invalid ownerGroupList parameter",
@@ -181,6 +203,8 @@ export class PoliciesService implements OnModuleInit {
       throw new NotFoundException();
     }
 
+    const setFields = this.flattenToDotPaths(data);
+
     await Promise.all(
       ownerGroups.map(async (ownerGroup) => {
         const email = userIdentity ? userIdentity.profile.email : user.email;
@@ -195,7 +219,11 @@ export class PoliciesService implements OnModuleInit {
           try {
             // allow all functional users
             return await this.policyModel
-              .updateOne({ ownerGroup }, data, {})
+              .updateOne(
+                { ownerGroup },
+                { $set: setFields },
+                { runValidators: true },
+              )
               .exec();
           } catch (error) {
             throw new InternalServerErrorException(error);
@@ -214,7 +242,11 @@ export class PoliciesService implements OnModuleInit {
 
           try {
             return await this.policyModel
-              .updateOne({ ownerGroup }, data, {})
+              .updateOne(
+                { ownerGroup },
+                { $set: setFields },
+                { runValidators: true },
+              )
               .exec();
           } catch (error) {
             throw new InternalServerErrorException(error);
@@ -241,7 +273,7 @@ export class PoliciesService implements OnModuleInit {
     Logger.log("Adding default policy", "PoliciesService.addDefaultPolicy");
 
     const defaultManager = this.configService.get<string[]>("defaultManager");
-    const defaultPolicy: CreatePolicyDto = {
+    const defaultPolicy = LEGACY_NOTIFICATION_PIPE.transform({
       ownerGroup,
       accessGroups,
       manager: ownerEmail
@@ -257,7 +289,7 @@ export class PoliciesService implements OnModuleInit {
       archiveEmailsToBeNotified: [],
       retrieveEmailsToBeNotified: [],
       embargoPeriod: 3,
-    };
+    });
 
     try {
       await this.create(defaultPolicy, policyUsername);

--- a/src/policies/policies.service.ts
+++ b/src/policies/policies.service.ts
@@ -15,7 +15,7 @@ import { Policy, PolicyDocument } from "./schemas/policy.schema";
 import { Request } from "express";
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
 import { UsersService } from "src/users/users.service";
-import { IPolicyFilter } from "./interfaces/policy-filters.interface";
+import { IPolicyFilterV4 } from "./interfaces/policy-filters.interface";
 import { addCreatedByFields, parseLimitFilters } from "src/common/utils";
 import { REQUEST } from "@nestjs/core";
 
@@ -97,18 +97,15 @@ export class PoliciesService implements OnModuleInit {
     return createdPolicy.save();
   }
 
-  async findAll(filter: IPolicyFilter): Promise<Policy[]> {
+  async findAll(filter: IPolicyFilterV4): Promise<Policy[]> {
     const whereFilter: FilterQuery<PolicyDocument> = filter.where ?? {};
-
-    const limits = {
-      limit: filter.limit as number,
-      skip: filter.skip as number,
-      order: filter.order as string,
-    };
-    const { limit, skip, sort } = parseLimitFilters(limits);
+    const fieldsProjection = filter.fields?.length
+      ? Object.fromEntries(filter.fields.map((field) => [field, 1]))
+      : {};
+    const { limit, skip, sort } = parseLimitFilters(filter.limits ?? {});
 
     return this.policyModel
-      .find(whereFilter)
+      .find(whereFilter, fieldsProjection)
       .limit(limit)
       .skip(skip)
       .sort(sort)

--- a/src/policies/policies.v4.controller.ts
+++ b/src/policies/policies.v4.controller.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Body,
   Controller,
   Get,
@@ -6,6 +7,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
   UseGuards,
 } from "@nestjs/common";
@@ -15,14 +17,11 @@ import { PoliciesGuard } from "src/casl/guards/policies.guard";
 import { CheckPolicies } from "src/casl/decorators/check-policies.decorator";
 import { AppAbility, CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { Action } from "src/casl/action.enum";
-import { IFilters } from "src/common/interfaces/common.interface";
-import { Filter } from "src/datasets/decorators/filter.decorator";
 import { PoliciesService } from "./policies.service";
-import { Policy, PolicyDocument } from "./schemas/policy.schema";
+import { Policy } from "./schemas/policy.schema";
 import { CreatePolicyV4Dto } from "./dto/create-policy-v4.dto";
 import { UpdatePolicyV4Dto } from "./dto/update-policy-v4.dto";
-import { IPolicyFilter } from "./interfaces/policy-filters.interface";
-import { V4_FILTER_PIPE } from "./pipes/filter.pipe";
+import { IPolicyFilterV4 } from "./interfaces/policy-filters.interface";
 import { restrictToOwnPolicies } from "./utils/policy-access-filter.util";
 
 @ApiBearerAuth()
@@ -52,17 +51,26 @@ export class PoliciesV4Controller {
     name: "filter",
     description: "Database filters to apply when retrieving all policies",
     required: false,
-    example: '{"order":"ownerGroup:desc","skip":0,"limit":25}',
+    type: String,
+    example:
+      '{"where":{"ownerGroup":"group1"},"fields":["ownerGroup","manager"],"limits":{"limit":25,"skip":0,"order":"ownerGroup:desc"}}',
   })
   async findAll(
     @Req() request: Request,
-    @Filter(...V4_FILTER_PIPE)
-    queryFilter: { filter?: IFilters<PolicyDocument, IPolicyFilter> },
+    @Query("filter") queryFilter?: string,
   ): Promise<Policy[]> {
+    let parsedFilter: IPolicyFilterV4;
+    try {
+      parsedFilter = JSON.parse(queryFilter ?? "{}");
+    } catch (err) {
+      throw new BadRequestException(
+        `Invalid JSON in filter: ${(err as Error).message}`,
+      );
+    }
     const mergedFilters = restrictToOwnPolicies(
       this.caslAbilityFactory,
       request,
-      queryFilter.filter ?? {},
+      parsedFilter,
     );
 
     return this.policiesService.findAll(mergedFilters);

--- a/src/policies/policies.v4.controller.ts
+++ b/src/policies/policies.v4.controller.ts
@@ -1,0 +1,112 @@
+import {
+  Body,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import { ApiBearerAuth, ApiParam, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { Request } from "express";
+import { PoliciesGuard } from "src/casl/guards/policies.guard";
+import { CheckPolicies } from "src/casl/decorators/check-policies.decorator";
+import { AppAbility, CaslAbilityFactory } from "src/casl/casl-ability.factory";
+import { Action } from "src/casl/action.enum";
+import { IFilters } from "src/common/interfaces/common.interface";
+import { Filter } from "src/datasets/decorators/filter.decorator";
+import { PoliciesService } from "./policies.service";
+import { Policy, PolicyDocument } from "./schemas/policy.schema";
+import { CreatePolicyV4Dto } from "./dto/create-policy-v4.dto";
+import { UpdatePolicyV4Dto } from "./dto/update-policy-v4.dto";
+import { IPolicyFilter } from "./interfaces/policy-filters.interface";
+import { V4_FILTER_PIPE } from "./pipes/filter.pipe";
+import { restrictToOwnPolicies } from "./utils/policy-access-filter.util";
+
+@ApiBearerAuth()
+@ApiTags("policies v4")
+@Controller({ path: "policies", version: "4" })
+export class PoliciesV4Controller {
+  constructor(
+    private readonly policiesService: PoliciesService,
+    private caslAbilityFactory: CaslAbilityFactory,
+  ) {}
+
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("policies", (ability: AppAbility) =>
+    ability.can(Action.Create, Policy),
+  )
+  @Post()
+  async create(@Body() createPolicyDto: CreatePolicyV4Dto): Promise<Policy> {
+    return this.policiesService.create(createPolicyDto as Partial<Policy>);
+  }
+
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("policies", (ability: AppAbility) =>
+    ability.can(Action.Read, Policy),
+  )
+  @Get()
+  @ApiQuery({
+    name: "filter",
+    description: "Database filters to apply when retrieving all policies",
+    required: false,
+    example: '{"order":"ownerGroup:desc","skip":0,"limit":25}',
+  })
+  async findAll(
+    @Req() request: Request,
+    @Filter(...V4_FILTER_PIPE)
+    queryFilter: { filter?: IFilters<PolicyDocument, IPolicyFilter> },
+  ): Promise<Policy[]> {
+    const mergedFilters = restrictToOwnPolicies(
+      this.caslAbilityFactory,
+      request,
+      queryFilter.filter ?? {},
+    );
+
+    return this.policiesService.findAll(mergedFilters);
+  }
+
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("policies", (ability: AppAbility) =>
+    ability.can(Action.Read, Policy),
+  )
+  @Get(":id")
+  @ApiParam({
+    name: "id",
+    description: "Id of the policy to return",
+    type: String,
+  })
+  async findOne(@Param("id") id: string): Promise<Policy | null> {
+    const policy = await this.policiesService.findOne({ _id: id });
+    if (!policy) {
+      throw new NotFoundException(`Policy not found for id: ${id}`);
+    }
+    return policy;
+  }
+
+  @UseGuards(PoliciesGuard)
+  @CheckPolicies("policies", (ability: AppAbility) =>
+    ability.can(Action.Update, Policy),
+  )
+  @Patch(":id")
+  @ApiParam({
+    name: "id",
+    description: "Id of the policy to update",
+    type: String,
+  })
+  async update(
+    @Param("id") id: string,
+    @Body() updatePolicyDto: UpdatePolicyV4Dto,
+  ): Promise<Policy | null> {
+    const updated = await this.policiesService.update(
+      { _id: id },
+      updatePolicyDto as Partial<Policy>,
+    );
+    if (!updated) {
+      throw new NotFoundException(`Policy not found for id: ${id}`);
+    }
+    return updated;
+  }
+}

--- a/src/policies/schemas/job-policy.schema.ts
+++ b/src/policies/schemas/job-policy.schema.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class JobPolicy {
+  @ApiProperty({
+    required: false,
+    description: "Email recipients for notifications related to this job type.",
+  })
+  emailTo?: string[];
+
+  @ApiProperty({
+    required: false,
+    description:
+      "Indicates whether email notifications are enabled for this job type.",
+  })
+  emailNotification?: boolean;
+
+  [key: string]: unknown;
+}

--- a/src/policies/schemas/policy.schema.ts
+++ b/src/policies/schemas/policy.schema.ts
@@ -1,8 +1,9 @@
 import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
 import { ApiProperty } from "@nestjs/swagger";
-import { Document } from "mongoose";
+import { Document, Schema as MongooseSchema } from "mongoose";
 import { OwnableClass } from "src/common/schemas/ownable.schema";
 import { v4 as uuidv4 } from "uuid";
+import { JobPolicy } from "./job-policy.schema";
 
 export type PolicyDocument = Policy & Document;
 
@@ -26,60 +27,16 @@ export class Policy extends OwnableClass {
   manager: string[];
 
   @ApiProperty({
+    type: JobPolicy,
+    required: false,
     description:
-      "Defines the level of redundancy in storage to minimize loss of data. Allowed values are low, medium, high. Low could e.g. mean one tape copy only, medium could mean two tape copies and high two geo-redundant tape copies",
+      "Per-job-type policy settings for this ownerGroup (e.g. notification recipients), keyed by job type.",
   })
-  @Prop({ type: String, default: "low" })
-  tapeRedundancy: string;
-
-  @ApiProperty({
-    description:
-      "Flag to indicate that a dataset should be automatically archived after ingest. If false then archive delay is ignored",
+  @Prop({
+    type: MongooseSchema.Types.Mixed,
+    required: false,
   })
-  @Prop({ type: Boolean, default: true })
-  autoArchive: boolean;
-
-  @ApiProperty({
-    description:
-      "Number of days after dataset creation that (remaining) datasets are archived automatically",
-  })
-  @Prop({ type: Number, default: 7 })
-  autoArchiveDelay: number;
-
-  @ApiProperty({
-    description:
-      "Flag is true when an email notification should be sent to archiveEmailsToBeNotified upon an archive job creation",
-  })
-  @Prop({ type: Boolean, default: false })
-  archiveEmailNotification: boolean;
-
-  @ApiProperty({
-    description:
-      "Array of additional email addresses that should be notified up an archive job creation",
-  })
-  @Prop({ type: [String] })
-  archiveEmailsToBeNotified: string[];
-
-  @ApiProperty({
-    description:
-      "Flag is true when an email notification should be sent to retrieveEmailsToBeNotified upon a retrieval job creation",
-  })
-  @Prop({ type: Boolean, default: false })
-  retrieveEmailNotification: boolean;
-
-  @ApiProperty({
-    description:
-      "Array of additional email addresses that should be notified up a retrieval job creation",
-  })
-  @Prop({ type: [String] })
-  retrieveEmailsToBeNotified: string[];
-
-  @ApiProperty({
-    description:
-      "Number of years after dataset creation before the dataset becomes public",
-  })
-  @Prop({ type: Number, default: 3 })
-  embargoPeriod: number;
+  jobPolicies?: Record<string, JobPolicy>;
 }
 
 export const PolicySchema = SchemaFactory.createForClass(Policy);

--- a/src/policies/utils/policy-access-filter.util.ts
+++ b/src/policies/utils/policy-access-filter.util.ts
@@ -2,17 +2,16 @@ import { Request } from "express";
 import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
 import { Action } from "src/casl/action.enum";
 import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
-import { IFilters } from "src/common/interfaces/common.interface";
-import { IPolicyFilter } from "../interfaces/policy-filters.interface";
-import { Policy, PolicyDocument } from "../schemas/policy.schema";
+import { IPolicyFilterV4 } from "../interfaces/policy-filters.interface";
+import { Policy } from "../schemas/policy.schema";
 
 // Users who can list their own policies but not all of them are restricted
 // to policies for a group they belong to, or ones already public.
 export function restrictToOwnPolicies(
   caslAbilityFactory: CaslAbilityFactory,
   request: Request,
-  mergedFilters: IFilters<PolicyDocument, IPolicyFilter>,
-): IFilters<PolicyDocument, IPolicyFilter> {
+  mergedFilters: IPolicyFilterV4,
+): IPolicyFilterV4 {
   const user = request.user as JWTUser;
   if (!user) return mergedFilters;
 

--- a/src/policies/utils/policy-access-filter.util.ts
+++ b/src/policies/utils/policy-access-filter.util.ts
@@ -1,0 +1,34 @@
+import { Request } from "express";
+import { JWTUser } from "src/auth/interfaces/jwt-user.interface";
+import { Action } from "src/casl/action.enum";
+import { CaslAbilityFactory } from "src/casl/casl-ability.factory";
+import { IFilters } from "src/common/interfaces/common.interface";
+import { IPolicyFilter } from "../interfaces/policy-filters.interface";
+import { Policy, PolicyDocument } from "../schemas/policy.schema";
+
+// Users who can list their own policies but not all of them are restricted
+// to policies for a group they belong to, or ones already public.
+export function restrictToOwnPolicies(
+  caslAbilityFactory: CaslAbilityFactory,
+  request: Request,
+  mergedFilters: IFilters<PolicyDocument, IPolicyFilter>,
+): IFilters<PolicyDocument, IPolicyFilter> {
+  const user = request.user as JWTUser;
+  if (!user) return mergedFilters;
+
+  const ability = caslAbilityFactory.policyAccess(user);
+  const canViewAll = ability.can(Action.ListAll, Policy);
+  const canViewTheirOwn = ability.can(Action.ListOwn, Policy);
+  if (!canViewAll && canViewTheirOwn) {
+    if (!mergedFilters.where) {
+      mergedFilters.where = {};
+    }
+    mergedFilters.where["$or"] = [
+      { ownerGroup: { $in: user.currentGroups } },
+      { accessGroups: { $in: user.currentGroups } },
+      { isPublished: true },
+    ];
+  }
+
+  return mergedFilters;
+}

--- a/test/Policy.js
+++ b/test/Policy.js
@@ -281,4 +281,24 @@ describe("1302: Policy: v3 order/skip/limit tests", () => {
         res.body[0].ownerGroup.should.equal("v3-order-test-a");
       });
   });
+
+  it("0170: fields (flat v3 shape) restricts the returned fields", async () => {
+    return request(appUrl)
+      .get("/api/v3/Policies")
+      .query({
+        filter: JSON.stringify({
+          where: { ownerGroup: { $in: groups } },
+          fields: ["ownerGroup"],
+          limit: 1,
+        }),
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .then((res) => {
+        res.body.should.have.length(1);
+        res.body[0].should.have.property("ownerGroup");
+        res.body[0].should.not.have.property("manager");
+      });
+  });
 });

--- a/test/Policy.js
+++ b/test/Policy.js
@@ -67,7 +67,7 @@ describe("1300: Policy: Simple Policy tests", () => {
       .send(testdataset)
       .set("Accept", "application/json")
       .set({ Authorization: `Bearer ${accessTokenUser1}` })
-      .expect(TestData.CreationForbiddenStatusCode)
+      .expect(TestData.CreationForbiddenStatusCode);
   });
 
   it("0040: should delete this policy", async () => {
@@ -213,6 +213,72 @@ describe("1301: Policy: v3 jobPolicies mapping tests", () => {
         res.body.embargoPeriod.should.equal(5);
         // untouched sibling from 0110 must still survive
         res.body.autoArchiveDelay.should.equal(21);
+      });
+  });
+});
+
+describe("1302: Policy: v3 order/skip/limit tests", () => {
+  const groups = ["v3-order-test-a", "v3-order-test-b", "v3-order-test-c"];
+
+  before(async () => {
+    await db.collection("Policy").deleteMany({ ownerGroup: /^v3-order-test/ });
+
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    for (const ownerGroup of groups) {
+      await request(appUrl)
+        .post("/api/v3/Policies")
+        .send({ ...testdataset, ownerGroup })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode);
+    }
+  });
+
+  after(async () => {
+    await db.collection("Policy").deleteMany({ ownerGroup: /^v3-order-test/ });
+  });
+
+  it("0150: order/skip/limit (flat v3 shape) apply a descending sort with a cap", async () => {
+    return request(appUrl)
+      .get("/api/v3/Policies")
+      .query({
+        filter: JSON.stringify({
+          where: { ownerGroup: { $in: groups } },
+          order: "ownerGroup:desc",
+          skip: 0,
+          limit: 1,
+        }),
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .then((res) => {
+        res.body.should.have.length(1);
+        res.body[0].ownerGroup.should.equal("v3-order-test-c");
+      });
+  });
+
+  it("0160: order without an explicit direction defaults to ascending", async () => {
+    return request(appUrl)
+      .get("/api/v3/Policies")
+      .query({
+        filter: JSON.stringify({
+          where: { ownerGroup: { $in: groups } },
+          order: "ownerGroup",
+          skip: 0,
+          limit: 1,
+        }),
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .then((res) => {
+        res.body.should.have.length(1);
+        res.body[0].ownerGroup.should.equal("v3-order-test-a");
       });
   });
 });

--- a/test/Policy.js
+++ b/test/Policy.js
@@ -10,7 +10,7 @@ const testdataset = { ...TestData.PolicyCorrect };
 
 describe("1300: Policy: Simple Policy tests", () => {
   before(async () => {
-    db.collection("Policy").deleteMany({});
+    await db.collection("Policy").deleteMany({});
 
     accessTokenAdminIngestor = await utils.getToken(appUrl, {
       username: "adminIngestor",
@@ -77,5 +77,142 @@ describe("1300: Policy: Simple Policy tests", () => {
       .set({ Authorization: `Bearer ${accessTokenArchiveManager}` })
       .expect(TestData.SuccessfulDeleteStatusCode)
       .expect("Content-Type", /json/);
+  });
+});
+
+describe("1301: Policy: v3 jobPolicies mapping tests", () => {
+  let policyId = null;
+
+  before(async () => {
+    await db
+      .collection("Policy")
+      .deleteMany({ ownerGroup: /^v3-jobpolicies-test/ });
+
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+  });
+
+  after(async () => {
+    if (policyId) {
+      await request(appUrl)
+        .delete("/api/v3/Policies/" + policyId)
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` });
+    }
+  });
+
+  it("0100: adds a policy with legacy fields, which are stored under jobPolicies and not exposed in v3 output", async () => {
+    return request(appUrl)
+      .post("/api/v3/Policies")
+      .send({
+        ...testdataset,
+        ownerGroup: "v3-jobpolicies-test",
+        manager: [TestData.Accounts["adminIngestor"]["email"]],
+        tapeRedundancy: "high",
+        autoArchive: false,
+        autoArchiveDelay: 21,
+        archiveEmailsToBeNotified: ["a@example.com"],
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.tapeRedundancy.should.equal("high");
+        res.body.autoArchive.should.equal(false);
+        res.body.autoArchiveDelay.should.equal(21);
+        res.body.archiveEmailsToBeNotified.should.deep.equal(["a@example.com"]);
+        res.body.should.not.have.property("jobPolicies");
+        policyId = encodeURIComponent(res.body["id"]);
+      });
+  });
+
+  it("0105: response includes audit fields (createdBy, updatedBy, isPublished, createdAt, updatedAt)", async () => {
+    return request(appUrl)
+      .get("/api/v3/Policies/" + policyId)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .then((res) => {
+        res.body.should.have.property("createdBy").and.be.a("string");
+        res.body.should.have.property("updatedBy").and.be.a("string");
+        res.body.should.have.property("isPublished").and.equal(false);
+        res.body.should.have.property("createdAt");
+        res.body.should.have.property("updatedAt");
+      });
+  });
+
+  it("0110: patching one legacy field does not clobber sibling jobPolicies fields", async () => {
+    return request(appUrl)
+      .patch("/api/v3/Policies/" + policyId)
+      .send({ tapeRedundancy: "medium" })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulPatchStatusCode)
+      .then((res) => {
+        res.body.tapeRedundancy.should.equal("medium");
+        // untouched siblings within the same jobPolicies.archive entry
+        // must survive the partial update
+        res.body.autoArchive.should.equal(false);
+        res.body.autoArchiveDelay.should.equal(21);
+        res.body.archiveEmailsToBeNotified.should.deep.equal(["a@example.com"]);
+      });
+  });
+
+  it("0120: count filters using a v3 field name translated to its jobPolicies path", async () => {
+    return request(appUrl)
+      .get("/api/v3/Policies/count")
+      .query({
+        where: JSON.stringify({
+          ownerGroup: "v3-jobpolicies-test",
+          tapeRedundancy: "medium",
+        }),
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .then((res) => {
+        res.body.should.have.property("count").and.equal(1);
+      });
+  });
+
+  it("0130: findAll with a filter returns the policy matching a v3 field name", async () => {
+    return request(appUrl)
+      .get("/api/v3/Policies")
+      .query({
+        filter: JSON.stringify({
+          where: { ownerGroup: "v3-jobpolicies-test" },
+        }),
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .then((res) => {
+        res.body.should.be.an("array");
+        res.body.should.have.length(1);
+        res.body[0].tapeRedundancy.should.equal("medium");
+      });
+  });
+
+  it("0140: updateWhere updates the policy for the given ownerGroup with legacy fields mapped correctly", async () => {
+    return request(appUrl)
+      .post("/api/v3/Policies/updateWhere")
+      .send({
+        ownerGroupList: "v3-jobpolicies-test",
+        data: { tapeRedundancy: "low", embargoPeriod: 5 },
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.SuccessfulGetStatusCode)
+      .then(async () => {
+        const res = await request(appUrl)
+          .get("/api/v3/Policies/" + policyId)
+          .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` });
+        res.body.tapeRedundancy.should.equal("low");
+        res.body.embargoPeriod.should.equal(5);
+        // untouched sibling from 0110 must still survive
+        res.body.autoArchiveDelay.should.equal(21);
+      });
   });
 });

--- a/test/PolicyV4.js
+++ b/test/PolicyV4.js
@@ -1,0 +1,156 @@
+"use strict";
+const utils = require("./LoginUtils");
+const { TestData } = require("./TestData");
+
+let accessTokenAdminIngestor = null,
+  accessTokenUser1 = null;
+
+describe("1310: Policy v4 tests", () => {
+  before(async () => {
+    await db.collection("Policy").deleteMany({ ownerGroup: /^v4-policy-test/ });
+
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+  });
+
+  describe("Admin user CRUD tests (adminIngestor)", () => {
+    let policyId = null;
+
+    after(async () => {
+      if (policyId) {
+        await request(appUrl)
+          .delete("/api/v3/Policies/" + encodeURIComponent(policyId))
+          .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` });
+      }
+    });
+
+    it("0100: should create a new policy with jobPolicies", async () => {
+      return request(appUrl)
+        .post("/api/v4/policies")
+        .send({
+          ownerGroup: "v4-policy-test",
+          manager: ["adminIngestor"],
+          jobPolicies: {
+            archive: { tapeRedundancy: "high", emailTo: ["a@example.com"] },
+            retrieve: { emailTo: ["b@example.com"] },
+          },
+        })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.have.property("_id").and.be.a("string");
+          res.body.ownerGroup.should.equal("v4-policy-test");
+          res.body.jobPolicies.archive.tapeRedundancy.should.equal("high");
+          res.body.jobPolicies.archive.emailTo.should.deep.equal([
+            "a@example.com",
+          ]);
+          res.body.jobPolicies.retrieve.emailTo.should.deep.equal([
+            "b@example.com",
+          ]);
+          policyId = res.body._id;
+        });
+    });
+
+    it("0105: response includes audit fields (createdBy, updatedBy, isPublished, createdAt, updatedAt)", async () => {
+      return request(appUrl)
+        .get(`/api/v4/policies/${encodeURIComponent(policyId)}`)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .then((res) => {
+          res.body.should.have.property("createdBy").and.be.a("string");
+          res.body.should.have.property("updatedBy").and.be.a("string");
+          res.body.should.have.property("isPublished").and.equal(false);
+          res.body.should.have.property("createdAt");
+          res.body.should.have.property("updatedAt");
+        });
+    });
+
+    it("0110: should fetch the policy by id", async () => {
+      return request(appUrl)
+        .get(`/api/v4/policies/${encodeURIComponent(policyId)}`)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body._id.should.equal(policyId);
+        });
+    });
+
+    it("0115: should fetch all policies with a filter matching ownerGroup", async () => {
+      return request(appUrl)
+        .get("/api/v4/policies")
+        .query({
+          filter: JSON.stringify({ where: { ownerGroup: "v4-policy-test" } }),
+        })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.should.be.an("array");
+          res.body.should.have.length(1);
+          res.body[0]._id.should.equal(policyId);
+        });
+    });
+
+    it("0120: should return 404 for a non-existent policy id", async () => {
+      return request(appUrl)
+        .get("/api/v4/policies/does-not-exist")
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.NotFoundStatusCode);
+    });
+
+    it("0130: should partially update jobPolicies.archive without clobbering sibling fields", async () => {
+      return request(appUrl)
+        .patch(`/api/v4/policies/${encodeURIComponent(policyId)}`)
+        .send({ jobPolicies: { archive: { tapeRedundancy: "medium" } } })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulPatchStatusCode)
+        .expect("Content-Type", /json/)
+        .then((res) => {
+          res.body.jobPolicies.archive.tapeRedundancy.should.equal("medium");
+          // untouched sibling within the same archive entry must survive
+          res.body.jobPolicies.archive.emailTo.should.deep.equal([
+            "a@example.com",
+          ]);
+          // untouched retrieve entry must survive too
+          res.body.jobPolicies.retrieve.emailTo.should.deep.equal([
+            "b@example.com",
+          ]);
+        });
+    });
+
+    it("0140: should return 404 when patching a non-existent policy id", async () => {
+      return request(appUrl)
+        .patch("/api/v4/policies/does-not-exist")
+        .send({ manager: ["someone"] })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.NotFoundStatusCode);
+    });
+  });
+
+  describe("Unprivileged user access tests (user1)", () => {
+    it("0200: user1 cannot create a policy", async () => {
+      return request(appUrl)
+        .post("/api/v4/policies")
+        .send({ ownerGroup: "v4-policy-test-forbidden" })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenUser1}` })
+        .expect(TestData.CreationForbiddenStatusCode);
+    });
+  });
+});

--- a/test/PolicyV4.js
+++ b/test/PolicyV4.js
@@ -143,6 +143,92 @@ describe("1310: Policy v4 tests", () => {
     });
   });
 
+  describe("Filter tests (fields, limits, order)", () => {
+    const groups = [
+      "v4-policy-filter-test-a",
+      "v4-policy-filter-test-b",
+      "v4-policy-filter-test-c",
+    ];
+
+    before(async () => {
+      await db
+        .collection("Policy")
+        .deleteMany({ ownerGroup: /^v4-policy-filter-test/ });
+
+      for (const ownerGroup of groups) {
+        await request(appUrl)
+          .post("/api/v4/policies")
+          .send({ ownerGroup, manager: ["adminIngestor"] })
+          .set("Accept", "application/json")
+          .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+          .expect(TestData.EntryCreatedStatusCode);
+      }
+    });
+
+    after(async () => {
+      await db
+        .collection("Policy")
+        .deleteMany({ ownerGroup: /^v4-policy-filter-test/ });
+    });
+
+    it("0150: fields limits the response to only the requested fields", async () => {
+      return request(appUrl)
+        .get("/api/v4/policies")
+        .query({
+          filter: JSON.stringify({
+            where: { ownerGroup: "v4-policy-filter-test-a" },
+            fields: ["ownerGroup", "manager"],
+          }),
+        })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .then((res) => {
+          res.body.should.have.length(1);
+          res.body[0].should.have.property("ownerGroup");
+          res.body[0].should.have.property("manager");
+          res.body[0].should.not.have.property("jobPolicies");
+          res.body[0].should.not.have.property("createdBy");
+        });
+    });
+
+    it("0160: limits.order/skip/limit (nested v4 shape) apply a descending sort with a cap", async () => {
+      return request(appUrl)
+        .get("/api/v4/policies")
+        .query({
+          filter: JSON.stringify({
+            where: { ownerGroup: { $in: groups } },
+            limits: { order: "ownerGroup:desc", skip: 0, limit: 1 },
+          }),
+        })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .then((res) => {
+          res.body.should.have.length(1);
+          res.body[0].ownerGroup.should.equal("v4-policy-filter-test-c");
+        });
+    });
+
+    it("0170: limits.order without an explicit direction defaults to ascending", async () => {
+      return request(appUrl)
+        .get("/api/v4/policies")
+        .query({
+          filter: JSON.stringify({
+            where: { ownerGroup: { $in: groups } },
+            limits: { order: "ownerGroup", skip: 0, limit: 1 },
+          }),
+        })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode)
+        .then((res) => {
+          res.body.should.have.length(1);
+          res.body[0].ownerGroup.should.equal("v4-policy-filter-test-a");
+        });
+    });
+  });
+
   describe("Unprivileged user access tests (user1)", () => {
     it("0200: user1 cannot create a policy", async () => {
       return request(appUrl)


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Introduces policy V4 endpoints which accept a more generic payload that removes job types hardcoding. The v3 endpoints are fully backward compatible.

## Motivation
The v3 policy endpoints accept/return archiveEmail, retrieveEmail, but now that the jobs are configurable there is no concept of archive/retrieve anymore in the code base. To maintain backward compatibility the v3 endpoints keep these terminology.

The policy schema is migrated to a job agnostic schema with

```
manager
jobPolicies: {jobType: {emaiEnable: bool, emailList: string[], anyOtherField}
```

This allows policies to hold job specific rules, all archive specific steps are migrated to an archive policy in the migration (run with updateMany for atomicity)

The v4 endpoints now accept this schema

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Introduce job-agnostic policy storage and v4 endpoints while preserving backward compatibility for v3 consumers.

New Features:
- Add version 4 policy endpoints with generic, job-type keyed policy settings and CRUD support.
- Support field projection and nested filter limits for policy retrieval.

Bug Fixes:
- Preserve sibling nested policy settings during partial and bulk updates.
- Default unspecified policy sort directions to ascending and correctly translate legacy policy filters.

Enhancements:
- Restructure policy storage around configurable job policies while retaining the existing v3 API contract through legacy field mapping.
- Centralize policy access filtering and migrate existing notification fields into job-specific policy paths.

Tests:
- Add coverage for v3 backward compatibility, legacy-to-v4 mapping, filtering, ordering, partial updates, v4 CRUD behavior, and access control.