### PR TITLE
chore: add helpers to simplify duplicated v3 to v4 maps

### DIFF
--- a/migrations/20260901122200-consolidate-policy-notifications-into-jobpolicies.js
+++ b/migrations/20260901122200-consolidate-policy-notifications-into-jobpolicies.js
@@ -1,9 +1,12 @@
 const policyV3toV4FieldMap =
   require("../dist/policies/dto/policy.obsolete.dto").policyV3toV4FieldMap;
+const { toApiToDBMap } = require("../dist/common/utils/deep-mapper.util");
 
-const FIELD_MAPPINGS = Object.entries(policyV3toV4FieldMap).map(
-  ([legacy, target]) => ({ legacy, target }),
-);
+const { apiToDBMap } = toApiToDBMap(policyV3toV4FieldMap);
+const FIELD_MAPPINGS = Object.entries(apiToDBMap).map(([legacy, target]) => ({
+  legacy,
+  target,
+}));
 
 
 module.exports = {

--- a/src/common/decorators/serialize-as-v3.decorator.ts
+++ b/src/common/decorators/serialize-as-v3.decorator.ts
@@ -1,0 +1,5 @@
+import { SerializeOptions, Type } from "@nestjs/common";
+
+export function SerializeAsV3(type: Type<unknown>) {
+  return SerializeOptions({ type, excludeExtraneousValues: true });
+}

--- a/src/common/decorators/transform-from-deep-mapping.decorator.ts
+++ b/src/common/decorators/transform-from-deep-mapping.decorator.ts
@@ -1,0 +1,13 @@
+import { Transform } from "class-transformer";
+import { createDeepMapper, PathSpec } from "../utils/deep-mapper.util";
+
+export function TransformFromDeepMapping<T, U>(
+  fieldsMap: Partial<Record<keyof U & string, PathSpec>>,
+  defaultValue?: unknown,
+) {
+  const mapper = createDeepMapper<T, U>(fieldsMap);
+  return Transform(
+    ({ obj, key }: { obj: T; key: string }) => mapper(obj, key) ?? defaultValue,
+    { toClassOnly: true },
+  );
+}

--- a/src/common/dto/base-output.dto.ts
+++ b/src/common/dto/base-output.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Expose } from "class-transformer";
+import { OwnableClass } from "../schemas/ownable.schema";
+
+export class BaseOutputDto extends OwnableClass {
+  @ApiProperty()
+  @Expose()
+  _id: string;
+
+  @ApiProperty()
+  @Expose()
+  id: string;
+
+  @Expose()
+  declare createdBy: string;
+
+  @Expose()
+  declare updatedBy: string;
+
+  @Expose()
+  declare createdAt: Date;
+
+  @Expose()
+  declare updatedAt: Date;
+
+  @Expose()
+  declare ownerGroup: string;
+
+  @Expose()
+  declare accessGroups: string[];
+
+  @Expose()
+  declare instrumentGroup?: string;
+
+  @Expose()
+  declare isPublished: boolean;
+}

--- a/src/common/pipes/v3-to-v4-migration.pipe.ts
+++ b/src/common/pipes/v3-to-v4-migration.pipe.ts
@@ -1,0 +1,15 @@
+import { Injectable, PipeTransform } from "@nestjs/common";
+import { createDeepSetter, FieldsMap } from "../utils/deep-mapper.util";
+
+@Injectable()
+export class V3ToV4MigrationPipe<S, T> implements PipeTransform {
+  private readonly mapper: (source: S) => T;
+
+  constructor(fieldsMap: FieldsMap<S>) {
+    this.mapper = createDeepSetter<S, T>(fieldsMap);
+  }
+
+  transform(value: S): T {
+    return this.mapper(value);
+  }
+}

--- a/src/common/utils/deep-mapper.util.ts
+++ b/src/common/utils/deep-mapper.util.ts
@@ -1,33 +1,55 @@
-import { get, merge, set, trim } from "lodash";
+import { get, mapValues, merge, set } from "lodash";
 
 type MappingFn<S> = (source: S) => unknown;
 
-type FieldsMap<S> = Partial<Record<keyof S & string, string | MappingFn<S>>>;
+export interface PathSpec {
+  readonly path: readonly string[];
+  readonly arrayItemPath?: readonly string[];
+}
+
+class PathBuilder implements PathSpec {
+  constructor(
+    readonly path: readonly string[],
+    readonly arrayItemPath?: readonly string[],
+  ) {}
+
+  eachItem(itemDotPath: string): PathSpec {
+    return new PathBuilder(this.path, itemDotPath.split("."));
+  }
+}
+
+export function path(dotPath: string): PathBuilder {
+  return new PathBuilder(dotPath.split("."));
+}
+
+export type FieldsMap<S> = Partial<
+  Record<keyof S & string, PathSpec | MappingFn<S>>
+>;
 
 function getDeep<T, U>(
   source: T,
   key: keyof U & string,
-  fieldsMap: Partial<Record<keyof U & string, string>>,
+  fieldsMap: Partial<Record<keyof U & string, PathSpec>>,
 ): T[keyof T] | unknown | null {
   if (!source) return null;
-  const path = fieldsMap[key];
-  if (!path) return get(source, key);
-  if (!path.includes("[]")) return get(source, path);
-  const keysList = path.split("[]");
-  const initialValue = get(source, trim(keysList[0], "."));
-  if (!initialValue) return;
-  return keysList.slice(1).reduce((acc, currKey) => {
-    if (!acc) return acc;
-    return acc.map((item: object) => get(item, trim(currKey, ".")));
-  }, initialValue);
+  const spec = fieldsMap[key];
+  if (!spec) return get(source, key);
+  if (!spec.arrayItemPath) return get(source, spec.path as string[]);
+  const items = get(source, spec.path as string[]) as unknown[] | undefined;
+  if (!items) return undefined;
+  return items.map((item) => get(item, spec.arrayItemPath as string[]));
 }
 
 export function createDeepMapper<T, U>(
-  fieldsMap: Partial<Record<keyof U & string, string>>,
+  fieldsMap: Partial<Record<keyof U & string, PathSpec>>,
 ) {
   return (source: T, key: string) => {
     return getDeep<T, U>(source, key as keyof U & string, fieldsMap);
   };
+}
+
+function isPathSpec(value: unknown): value is PathSpec {
+  return !!value && typeof value === "object" && "path" in value;
 }
 
 function setDeep<S>(
@@ -38,25 +60,25 @@ function setDeep<S>(
   if (!source) return {};
   const instruction = fieldsMap[key];
   if (typeof instruction === "function") return { [key]: instruction(source) };
-  const path = (instruction as string) || key;
+  const spec: PathSpec = isPathSpec(instruction)
+    ? instruction
+    : { path: [key] };
   const value = get(source, key);
   if (value === undefined) return {};
   const fragment = {};
-  if (!path.includes("[]")) return set(fragment, path, value);
-  const [arrayRootPath, rawLeafPath] = path.split("[]");
-  const leafPath = trim(rawLeafPath, ".");
-  const arrayResult: Record<string, unknown>[] = [];
+  if (!spec.arrayItemPath) return set(fragment, spec.path as string[], value);
 
+  const arrayResult: Record<string, unknown>[] = [];
   if (Array.isArray(value))
     value.forEach((itemValue, index) => {
       arrayResult[index] = {};
-      set(arrayResult[index], leafPath, itemValue);
+      set(arrayResult[index], spec.arrayItemPath as string[], itemValue);
     });
   else {
     arrayResult[0] = {};
-    set(arrayResult[0], leafPath, value);
+    set(arrayResult[0], spec.arrayItemPath as string[], value);
   }
-  return set(fragment, trim(arrayRootPath, "."), arrayResult);
+  return set(fragment, spec.path as string[], arrayResult);
 }
 
 export function createDeepSetter<S, T>(fieldsMap: FieldsMap<S>) {
@@ -65,4 +87,14 @@ export function createDeepSetter<S, T>(fieldsMap: FieldsMap<S>) {
       const fragment = setDeep<S>(source, key as keyof S & string, fieldsMap);
       return merge(acc, fragment);
     }, {}) as T;
+}
+
+export function toApiToDBMap<K extends string>(
+  fieldsMap: Partial<Record<K, PathSpec>>,
+): { apiToDBMap: Record<K, string> } {
+  return {
+    apiToDBMap: mapValues(fieldsMap, (spec) =>
+      spec ? [...spec.path, ...(spec.arrayItemPath ?? [])].join(".") : spec,
+    ) as Record<K, string>,
+  };
 }

--- a/src/jobs/dto/output-job-v3.dto.ts
+++ b/src/jobs/dto/output-job-v3.dto.ts
@@ -1,33 +1,31 @@
-import { ApiHideProperty } from "@nestjs/swagger";
 import { DatasetListDto } from "./dataset-list.dto";
-import { Expose, Transform } from "class-transformer";
+import { Exclude, Expose, Transform } from "class-transformer";
 import _ from "lodash";
 import { jobV3toV4FieldMap } from "../types/jobs-filter-content";
-import { JobClass } from "../schemas/job.schema";
-import { createDeepMapper } from "src/common/utils/deep-mapper.util";
+import { BaseOutputDto } from "src/common/dto/base-output.dto";
+import { TransformFromDeepMapping } from "src/common/decorators/transform-from-deep-mapping.decorator";
 
-const mapJobV3toV4Field = createDeepMapper<JobClass, OutputJobV3Dto>(
-  jobV3toV4FieldMap,
-);
+export class OutputJobV3Dto extends BaseOutputDto {
+  // v3 never exposed ownership fields for jobs (unlike Policy/PublishedData) -
+  // confirmed by an existing e2e assertion that these must be absent from
+  // v3 job responses even though v4 exposes them.
+  @Exclude()
+  declare ownerGroup: string;
 
-export class OutputJobV3Dto {
-  @ApiHideProperty()
-  @Expose()
-  _id: string;
+  @Exclude()
+  declare accessGroups: string[];
 
-  /**
-   * Globally unique identifier of a job.
-   */
-  @Expose()
-  id: string;
+  @Exclude()
+  declare instrumentGroup?: string;
+
+  @Exclude()
+  declare isPublished: boolean;
 
   /**
    * The email of the person initiating the job request.
    */
   @Expose()
-  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(jobV3toV4FieldMap)
   emailJobInitiator?: string;
 
   /**
@@ -40,53 +38,47 @@ export class OutputJobV3Dto {
    * Time when job is created. Format according to chapter 5.6 internet date/time format in RFC 3339. This is handled automatically by mongoose with timestamps flag.
    */
   @Expose()
-  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(jobV3toV4FieldMap)
   creationTime: Date;
 
   /**
    * Time when job should be executed. If not specified then the Job will be executed asap. Format according to chapter 5.6 internet date/time format in RFC 3339.
    */
   @Expose()
-  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(jobV3toV4FieldMap)
   executionTime?: Date;
 
   /**
    * Object of key-value pairs defining job input parameters, e.g. 'destinationPath' for retrieve jobs or 'tapeCopies' for archive jobs.
    */
   @Expose()
-  @Transform(
-    ({ obj }) => {
-      return {
-        username: _.get(obj, jobV3toV4FieldMap["jobParams.username"]),
-        ..._.omitBy(obj?.jobParams, (_, key) =>
-          Object.values(jobV3toV4FieldMap).includes(`jobParams.${key}`),
+  @Transform(({ obj }) => {
+    const usernameSpec = jobV3toV4FieldMap["jobParams.username"];
+    return {
+      username: usernameSpec
+        ? _.get(obj, usernameSpec.path as string[])
+        : undefined,
+      ..._.omitBy(obj?.jobParams, (_, key) =>
+        Object.values(jobV3toV4FieldMap).some(
+          (spec) => spec.path.join(".") === `jobParams.${key}`,
         ),
-      };
-    },
-    { toClassOnly: true },
-  )
+      ),
+    };
+  })
   jobParams: Record<string, unknown>;
 
   /**
    * Defines current status of job lifecycle.
    */
   @Expose()
-  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(jobV3toV4FieldMap)
   jobStatusMessage?: string;
 
   /**
    * Array of objects with keys: pid, files. The value for the pid key defines the dataset ID, the value for the files key is an array of file names. This array is either an empty array, implying that all files within the dataset are selected, or an explicit list of dataset-relative file paths, which should be selected.
    */
   @Expose()
-  @Transform(({ obj, key }) => mapJobV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(jobV3toV4FieldMap)
   datasetList: DatasetListDto[];
 
   /**

--- a/src/jobs/jobs.controller.ts
+++ b/src/jobs/jobs.controller.ts
@@ -12,7 +12,6 @@ import {
   HttpStatus,
   HttpException,
   Req,
-  SerializeOptions,
   ClassSerializerInterceptor,
 } from "@nestjs/common";
 import { Request } from "express";
@@ -27,6 +26,7 @@ import { AppAbility } from "src/casl/casl-ability.factory";
 import { Action } from "src/casl/action.enum";
 import { JobClass } from "./schemas/job.schema";
 import { OutputJobV3Dto } from "./dto/output-job-v3.dto";
+import { SerializeAsV3 } from "src/common/decorators/serialize-as-v3.decorator";
 import {
   ApiBearerAuth,
   ApiBody,
@@ -93,7 +93,7 @@ export class JobsController {
     type: OutputJobV3Dto,
     description: "Created job",
   })
-  @SerializeOptions({ type: OutputJobV3Dto, excludeExtraneousValues: true })
+  @SerializeAsV3(OutputJobV3Dto)
   async create(
     @Req() request: Request,
     @Body() createJobDto: CreateJobDto,
@@ -130,7 +130,7 @@ export class JobsController {
     type: OutputJobV3Dto,
     description: "Updated job",
   })
-  @SerializeOptions({ type: OutputJobV3Dto, excludeExtraneousValues: true })
+  @SerializeAsV3(OutputJobV3Dto)
   async update(
     @Req() request: Request,
     @Param("id") id: string,
@@ -180,7 +180,7 @@ export class JobsController {
     type: [OutputJobV3Dto],
     description: "Return jobs requested.",
   })
-  @SerializeOptions({ type: OutputJobV3Dto, excludeExtraneousValues: true })
+  @SerializeAsV3(OutputJobV3Dto)
   async fullQuery(
     @Req() request: Request,
     @Query("fields", ...V3_WHERE_TO_V4_PIPE) fields?: string,
@@ -400,7 +400,7 @@ export class JobsController {
     type: OutputJobV3Dto,
     description: "Found job",
   })
-  @SerializeOptions({ type: OutputJobV3Dto, excludeExtraneousValues: true })
+  @SerializeAsV3(OutputJobV3Dto)
   async findOne(
     @Req() request: Request,
     @Param("id") id: string,
@@ -442,7 +442,7 @@ export class JobsController {
     type: [OutputJobV3Dto],
     description: "Found jobs",
   })
-  @SerializeOptions({ type: OutputJobV3Dto, excludeExtraneousValues: true })
+  @SerializeAsV3(OutputJobV3Dto)
   async findAll(
     @Req() request: Request,
 

--- a/src/jobs/pipes/v3-filter.pipe.ts
+++ b/src/jobs/pipes/v3-filter.pipe.ts
@@ -7,20 +7,23 @@ import {
 } from "src/common/pipes/filter.pipe";
 import { JobClass } from "../schemas/job.schema";
 import { JsonToStringPipe } from "src/common/pipes/json-to-string.pipe";
+import { toApiToDBMap } from "src/common/utils/deep-mapper.util";
+
+const jobV3toV4FilterMap = toApiToDBMap(jobV3toV4FieldMap);
 
 export const V3_WHERE_TO_V4_PIPE = [
-  new WherePipe<JobClass>({ apiToDBMap: jobV3toV4FieldMap }),
+  new WherePipe<JobClass>(jobV3toV4FilterMap),
   new JsonToStringPipe(),
 ];
 export const V3_ORDER_TO_V4_PIPE = [
-  new OrderPipe<JobClass>({ apiToDBMap: jobV3toV4FieldMap }),
+  new OrderPipe<JobClass>(jobV3toV4FilterMap),
   new JsonToStringPipe(),
 ];
 export const V3_FIELDS_TO_V4_PIPE = [
-  new FieldsPipe<JobClass>({ apiToDBMap: jobV3toV4FieldMap }),
+  new FieldsPipe<JobClass>(jobV3toV4FilterMap),
   new JsonToStringPipe(),
 ];
 export const V3_FILTER_TO_V4_PIPE = [
-  new FilterPipe<JobClass>({ apiToDBMap: jobV3toV4FieldMap }),
+  new FilterPipe<JobClass>(jobV3toV4FilterMap),
   new JsonToStringPipe(),
 ];

--- a/src/jobs/types/jobs-filter-content.ts
+++ b/src/jobs/types/jobs-filter-content.ts
@@ -3,6 +3,7 @@ import {
   SchemaObject,
 } from "@nestjs/swagger/dist/interfaces/open-api-spec.interface";
 import { parseBoolean } from "src/common/utils";
+import { path, PathSpec } from "src/common/utils/deep-mapper.util";
 
 const FILTERS: Record<"limits" | "fields" | "where" | "include", object> = {
   where: {
@@ -89,11 +90,11 @@ export const getSwaggerJobFilterContent = (
 // these fields must be present in a jobInstance, such that casl permissions can be assessed
 export const mandatoryFields = ["_id", "id", "type", "ownerGroup", "ownerUser"];
 
-export const jobV3toV4FieldMap: Record<string, string> = {
-  emailJobInitiator: "contactEmail",
-  creationTime: "createdAt",
-  jobStatusMessage: "statusCode",
-  executionTime: "jobParams.executionTime",
-  "jobParams.username": "ownerUser",
-  datasetList: "jobParams.datasetList",
+export const jobV3toV4FieldMap: Record<string, PathSpec> = {
+  emailJobInitiator: path("contactEmail"),
+  creationTime: path("createdAt"),
+  jobStatusMessage: path("statusCode"),
+  executionTime: path("jobParams.executionTime"),
+  "jobParams.username": path("ownerUser"),
+  datasetList: path("jobParams.datasetList"),
 };

--- a/src/policies/dto/policy.obsolete.dto.ts
+++ b/src/policies/dto/policy.obsolete.dto.ts
@@ -1,59 +1,23 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { Expose, Transform } from "class-transformer";
-import { OwnableDto } from "src/common/dto/ownable.dto";
-import { createDeepMapper } from "src/common/utils/deep-mapper.util";
-import { Policy } from "../schemas/policy.schema";
+import { Expose } from "class-transformer";
+import { BaseOutputDto } from "src/common/dto/base-output.dto";
+import { path, PathSpec } from "src/common/utils/deep-mapper.util";
+import { TransformFromDeepMapping } from "src/common/decorators/transform-from-deep-mapping.decorator";
 
 export const policyV3toV4FieldMap: Partial<
-  Record<keyof PolicyObsoleteDto & string, string>
+  Record<keyof PolicyObsoleteDto & string, PathSpec>
 > = {
-  archiveEmailNotification: "jobPolicies.archive.emailNotification",
-  archiveEmailsToBeNotified: "jobPolicies.archive.emailTo",
-  tapeRedundancy: "jobPolicies.archive.tapeRedundancy",
-  autoArchive: "jobPolicies.archive.autoArchive",
-  autoArchiveDelay: "jobPolicies.archive.autoArchiveDelay",
-  embargoPeriod: "jobPolicies.archive.embargoPeriod",
-  retrieveEmailNotification: "jobPolicies.retrieve.emailNotification",
-  retrieveEmailsToBeNotified: "jobPolicies.retrieve.emailTo",
+  archiveEmailNotification: path("jobPolicies.archive.emailNotification"),
+  archiveEmailsToBeNotified: path("jobPolicies.archive.emailTo"),
+  tapeRedundancy: path("jobPolicies.archive.tapeRedundancy"),
+  autoArchive: path("jobPolicies.archive.autoArchive"),
+  autoArchiveDelay: path("jobPolicies.archive.autoArchiveDelay"),
+  embargoPeriod: path("jobPolicies.archive.embargoPeriod"),
+  retrieveEmailNotification: path("jobPolicies.retrieve.emailNotification"),
+  retrieveEmailsToBeNotified: path("jobPolicies.retrieve.emailTo"),
 };
 
-export const mapPolicyV3toV4Field = createDeepMapper<Policy, PolicyObsoleteDto>(
-  policyV3toV4FieldMap,
-);
-
-export class PolicyObsoleteDto extends OwnableDto {
-  @ApiProperty()
-  @Expose()
-  declare readonly ownerGroup: string;
-
-  @ApiProperty({ type: [String] })
-  @Expose()
-  declare readonly accessGroups?: string[];
-
-  @ApiProperty()
-  @Expose()
-  declare readonly instrumentGroup?: string;
-
-  @ApiProperty()
-  @Expose()
-  _id: string;
-
-  @ApiProperty()
-  @Expose()
-  id: string;
-
-  @ApiProperty()
-  @Expose()
-  createdBy: string;
-
-  @ApiProperty()
-  @Expose()
-  updatedBy: string;
-
-  @ApiProperty()
-  @Expose()
-  isPublished: boolean;
-
+export class PolicyObsoleteDto extends BaseOutputDto {
   @ApiProperty({
     description:
       "Defines the emails of users that can modify the policy parameters",
@@ -66,9 +30,7 @@ export class PolicyObsoleteDto extends OwnableDto {
       "Defines the level of redundancy in storage to minimize loss of data. Allowed values are low, medium, high. Low could e.g. mean one tape copy only, medium could mean two tape copies and high two geo-redundant tape copies",
   })
   @Expose()
-  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? "low", {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(policyV3toV4FieldMap, "low")
   tapeRedundancy: string;
 
   @ApiProperty({
@@ -76,9 +38,7 @@ export class PolicyObsoleteDto extends OwnableDto {
       "Flag to indicate that a dataset should be automatically archived after ingest. If false then archive delay is ignored",
   })
   @Expose()
-  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? true, {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(policyV3toV4FieldMap, true)
   autoArchive: boolean;
 
   @ApiProperty({
@@ -86,9 +46,7 @@ export class PolicyObsoleteDto extends OwnableDto {
       "Number of days after dataset creation that (remaining) datasets are archived automatically",
   })
   @Expose()
-  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? 7, {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(policyV3toV4FieldMap, 7)
   autoArchiveDelay: number;
 
   @ApiProperty({
@@ -96,9 +54,7 @@ export class PolicyObsoleteDto extends OwnableDto {
       "Flag is true when an email notification should be sent to archiveEmailsToBeNotified upon an archive job creation",
   })
   @Expose()
-  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? false, {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(policyV3toV4FieldMap, false)
   archiveEmailNotification: boolean;
 
   @ApiProperty({
@@ -106,9 +62,7 @@ export class PolicyObsoleteDto extends OwnableDto {
       "Array of additional email addresses that should be notified up an archive job creation",
   })
   @Expose()
-  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? [], {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(policyV3toV4FieldMap, [])
   archiveEmailsToBeNotified: string[];
 
   @ApiProperty({
@@ -116,9 +70,7 @@ export class PolicyObsoleteDto extends OwnableDto {
       "Flag is true when an email notification should be sent to retrieveEmailsToBeNotified upon a retrieval job creation",
   })
   @Expose()
-  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? false, {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(policyV3toV4FieldMap, false)
   retrieveEmailNotification: boolean;
 
   @ApiProperty({
@@ -126,9 +78,7 @@ export class PolicyObsoleteDto extends OwnableDto {
       "Array of additional email addresses that should be notified up a retrieval job creation",
   })
   @Expose()
-  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? [], {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(policyV3toV4FieldMap, [])
   retrieveEmailsToBeNotified: string[];
 
   @ApiProperty({
@@ -136,16 +86,6 @@ export class PolicyObsoleteDto extends OwnableDto {
       "Number of years after dataset creation before the dataset becomes public",
   })
   @Expose()
-  @Transform(({ obj, key }) => mapPolicyV3toV4Field(obj, key) ?? 3, {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(policyV3toV4FieldMap, 3)
   embargoPeriod: number;
-
-  @ApiProperty()
-  @Expose()
-  createdAt: Date;
-
-  @ApiProperty()
-  @Expose()
-  updatedAt: Date;
 }

--- a/src/policies/pipes/filter.pipe.ts
+++ b/src/policies/pipes/filter.pipe.ts
@@ -1,5 +1,6 @@
 import { Injectable, PipeTransform } from "@nestjs/common";
 import { FilterPipe, WherePipe } from "src/common/pipes/filter.pipe";
+import { toApiToDBMap } from "src/common/utils/deep-mapper.util";
 import { Policy } from "../schemas/policy.schema";
 import { policyV3toV4FieldMap } from "../dto/policy.obsolete.dto";
 import {
@@ -20,11 +21,11 @@ export class NestPolicyLimitsPipe implements PipeTransform<
   }
 }
 
+const policyV3toV4FilterMap = toApiToDBMap(policyV3toV4FieldMap);
+
 export const V3_FILTER_PIPE = [
-  new FilterPipe<Policy>({ apiToDBMap: policyV3toV4FieldMap }),
+  new FilterPipe<Policy>(policyV3toV4FilterMap),
   new NestPolicyLimitsPipe(),
 ];
 
-export const V3_WHERE_PIPE = new WherePipe<Policy>({
-  apiToDBMap: policyV3toV4FieldMap,
-});
+export const V3_WHERE_PIPE = new WherePipe<Policy>(policyV3toV4FilterMap);

--- a/src/policies/pipes/legacy-notification.pipe.ts
+++ b/src/policies/pipes/legacy-notification.pipe.ts
@@ -1,20 +1,9 @@
-import { Injectable, PipeTransform } from "@nestjs/common";
-import { createDeepSetter } from "src/common/utils/deep-mapper.util";
+import { V3ToV4MigrationPipe } from "src/common/pipes/v3-to-v4-migration.pipe";
 import { PartialUpdatePolicyDto } from "../dto/update-policy.dto";
 import { policyV3toV4FieldMap } from "../dto/policy.obsolete.dto";
 import { Policy } from "../schemas/policy.schema";
 
-const dtoV3toV4 = createDeepSetter<PartialUpdatePolicyDto, Partial<Policy>>(
-  policyV3toV4FieldMap,
-);
-
-@Injectable()
-export class V3ToV4MigrationPipe<S, T> implements PipeTransform {
-  constructor(private readonly mapper: (source: S) => T) {}
-
-  transform(value: S): T {
-    return this.mapper(value);
-  }
-}
-
-export const LEGACY_NOTIFICATION_PIPE = new V3ToV4MigrationPipe(dtoV3toV4);
+export const LEGACY_NOTIFICATION_PIPE = new V3ToV4MigrationPipe<
+  PartialUpdatePolicyDto,
+  Partial<Policy>
+>(policyV3toV4FieldMap);

--- a/src/policies/policies.controller.ts
+++ b/src/policies/policies.controller.ts
@@ -13,13 +13,13 @@ import {
   HttpCode,
   HttpStatus,
   Req,
-  SerializeOptions,
 } from "@nestjs/common";
 import { Request } from "express";
 import { PoliciesService } from "./policies.service";
 import { CreatePolicyDto } from "./dto/create-policy.dto";
 import { PartialUpdatePolicyDto } from "./dto/update-policy.dto";
 import { PolicyObsoleteDto } from "./dto/policy.obsolete.dto";
+import { SerializeAsV3 } from "src/common/decorators/serialize-as-v3.decorator";
 import { LEGACY_NOTIFICATION_PIPE } from "./pipes/legacy-notification.pipe";
 import { V3_FILTER_PIPE, V3_WHERE_PIPE } from "./pipes/filter.pipe";
 import { ApiBearerAuth, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
@@ -49,7 +49,7 @@ export class PoliciesController {
   @CheckPolicies("policies", (ability: AppAbility) =>
     ability.can(Action.Create, Policy),
   )
-  @SerializeOptions({ type: PolicyObsoleteDto, excludeExtraneousValues: true })
+  @SerializeAsV3(PolicyObsoleteDto)
   @Post()
   async create(
     @Body(LEGACY_NOTIFICATION_PIPE)
@@ -71,7 +71,7 @@ export class PoliciesController {
     required: false,
     example: '{"order":"ownerGroup:desc","skip":0,"limit":25}',
   })
-  @SerializeOptions({ type: PolicyObsoleteDto, excludeExtraneousValues: true })
+  @SerializeAsV3(PolicyObsoleteDto)
   async findAll(
     @Req() request: Request,
     @Filter(...V3_FILTER_PIPE)
@@ -127,7 +127,7 @@ export class PoliciesController {
     ability.can(Action.Read, Policy),
   )
   @Get(":id")
-  @SerializeOptions({ type: PolicyObsoleteDto, excludeExtraneousValues: true })
+  @SerializeAsV3(PolicyObsoleteDto)
   async findOne(@Param("id") id: string): Promise<Policy | null> {
     return this.policiesService.findOne({ _id: id });
   }
@@ -136,7 +136,7 @@ export class PoliciesController {
   @CheckPolicies("policies", (ability: AppAbility) =>
     ability.can(Action.Update, Policy),
   )
-  @SerializeOptions({ type: PolicyObsoleteDto, excludeExtraneousValues: true })
+  @SerializeAsV3(PolicyObsoleteDto)
   @Patch(":id")
   async update(
     @Param("id") id: string,
@@ -153,7 +153,7 @@ export class PoliciesController {
   @CheckPolicies("policies", (ability: AppAbility) =>
     ability.can(Action.Delete, Policy),
   )
-  @SerializeOptions({ type: PolicyObsoleteDto, excludeExtraneousValues: true })
+  @SerializeAsV3(PolicyObsoleteDto)
   @Delete(":id")
   async remove(@Param("id") id: string): Promise<unknown> {
     return this.policiesService.remove({ _id: id });

--- a/src/published-data/dto/published-data.obsolete.dto.ts
+++ b/src/published-data/dto/published-data.obsolete.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { Expose, Transform } from "class-transformer";
+import { Exclude, Expose, Transform } from "class-transformer";
 import {
   IsDateString,
   IsNumber,
@@ -8,38 +8,35 @@ import {
   NotEquals,
 } from "class-validator";
 import { PublishedDataStatus } from "../interfaces/published-data.interface";
-import { PublishedData } from "../schemas/published-data.schema";
-import { createDeepMapper } from "src/common/utils/deep-mapper.util";
+import { BaseOutputDto } from "src/common/dto/base-output.dto";
+import { path, PathSpec } from "src/common/utils/deep-mapper.util";
+import { TransformFromDeepMapping } from "src/common/decorators/transform-from-deep-mapping.decorator";
 
 export const publishedDataV3toV4FieldMap: Partial<
-  Record<keyof PublishedDataObsoleteDto & string, string>
+  Record<keyof PublishedDataObsoleteDto & string, PathSpec>
 > = {
-  pidArray: "datasetPids",
-  creator: "metadata.creators.[].name",
-  authors: "metadata.contributors.[].name",
-  publisher: "metadata.publisher.name",
-  relatedPublications: "metadata.relatedIdentifiers.[].relatedIdentifier",
-  affiliation: "metadata.affiliation",
-  publicationYear: "metadata.publicationYear",
-  url: "metadata.url",
-  dataDescription: "metadata.dataDescription",
-  resourceType: "metadata.resourceType",
-  numberOfFiles: "metadata.numberOfFiles",
-  sizeOfArchive: "metadata.sizeOfArchive",
-  scicatUser: "metadata.scicatUser",
-  thumbnail: "metadata.thumbnail",
-  downloadLink: "metadata.downloadLink",
+  pidArray: path("datasetPids"),
+  creator: path("metadata.creators").eachItem("name"),
+  authors: path("metadata.contributors").eachItem("name"),
+  publisher: path("metadata.publisher.name"),
+  relatedPublications: path("metadata.relatedIdentifiers").eachItem(
+    "relatedIdentifier",
+  ),
+  affiliation: path("metadata.affiliation"),
+  publicationYear: path("metadata.publicationYear"),
+  url: path("metadata.url"),
+  dataDescription: path("metadata.dataDescription"),
+  resourceType: path("metadata.resourceType"),
+  numberOfFiles: path("metadata.numberOfFiles"),
+  sizeOfArchive: path("metadata.sizeOfArchive"),
+  scicatUser: path("metadata.scicatUser"),
+  thumbnail: path("metadata.thumbnail"),
+  downloadLink: path("metadata.downloadLink"),
 };
 
-export const mapPublishedDataV3toV4Field = createDeepMapper<
-  PublishedData,
-  PublishedDataObsoleteDto
->(publishedDataV3toV4FieldMap);
-
-export class PublishedDataObsoleteDto {
-  @IsString()
-  @Expose()
-  _id: string;
+export class PublishedDataObsoleteDto extends BaseOutputDto {
+  @Exclude()
+  declare id: string;
 
   @ApiProperty({
     type: String,
@@ -61,9 +58,7 @@ export class PublishedDataObsoleteDto {
   @IsString()
   @IsOptional()
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   affiliation?: string;
 
   @ApiProperty({
@@ -76,9 +71,7 @@ export class PublishedDataObsoleteDto {
   })
   @IsString({ each: true })
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   creator: string[];
 
   @ApiProperty({
@@ -92,9 +85,7 @@ export class PublishedDataObsoleteDto {
   @IsString()
   @NotEquals(null)
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   publisher: string;
 
   @ApiProperty({
@@ -107,9 +98,7 @@ export class PublishedDataObsoleteDto {
   })
   @IsNumber()
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   publicationYear: number;
 
   @ApiProperty({
@@ -132,9 +121,7 @@ export class PublishedDataObsoleteDto {
   @IsString()
   @IsOptional()
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   url?: string;
 
   @ApiProperty({
@@ -160,9 +147,7 @@ export class PublishedDataObsoleteDto {
   })
   @IsString()
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   dataDescription: string;
 
   @ApiProperty({
@@ -172,9 +157,7 @@ export class PublishedDataObsoleteDto {
   })
   @IsString()
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   resourceType: string;
 
   @ApiProperty({
@@ -185,9 +168,7 @@ export class PublishedDataObsoleteDto {
   @IsNumber()
   @IsOptional()
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   numberOfFiles?: number;
 
   @ApiProperty({
@@ -198,9 +179,7 @@ export class PublishedDataObsoleteDto {
   @IsNumber()
   @IsOptional()
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   sizeOfArchive?: number;
 
   @ApiProperty({
@@ -212,9 +191,7 @@ export class PublishedDataObsoleteDto {
   })
   @IsString({ each: true })
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   pidArray: string[];
 
   @ApiProperty({
@@ -225,9 +202,7 @@ export class PublishedDataObsoleteDto {
   @IsString({ each: true })
   @IsOptional()
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   authors?: string[];
 
   @ApiProperty({
@@ -265,9 +240,7 @@ export class PublishedDataObsoleteDto {
   @IsString()
   @IsOptional()
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   scicatUser?: string;
 
   @ApiProperty({
@@ -278,9 +251,7 @@ export class PublishedDataObsoleteDto {
   @IsString()
   @IsOptional()
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   thumbnail?: string;
 
   @ApiProperty({
@@ -292,9 +263,7 @@ export class PublishedDataObsoleteDto {
   @IsString({ each: true })
   @IsOptional()
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   relatedPublications?: string[];
 
   @ApiProperty({
@@ -305,26 +274,6 @@ export class PublishedDataObsoleteDto {
   @IsString()
   @IsOptional()
   @Expose()
-  @Transform(({ obj, key }) => mapPublishedDataV3toV4Field(obj, key), {
-    toClassOnly: true,
-  })
+  @TransformFromDeepMapping(publishedDataV3toV4FieldMap)
   downloadLink?: string;
-
-  @ApiProperty({
-    type: Date,
-    description:
-      "Date when the published data was created. This property is added and maintained by the system",
-  })
-  @IsDateString()
-  @Expose()
-  createdAt: Date;
-
-  @ApiProperty({
-    type: Date,
-    description:
-      "Date when the published data was last updated. This property is added and maintained by the system",
-  })
-  @IsDateString()
-  @Expose()
-  updatedAt: Date;
 }

--- a/src/published-data/pipes/body-dto.pipe.ts
+++ b/src/published-data/pipes/body-dto.pipe.ts
@@ -1,11 +1,10 @@
-import { Injectable, PipeTransform } from "@nestjs/common";
-import { createDeepSetter } from "src/common/utils/deep-mapper.util";
+import { V3ToV4MigrationPipe } from "src/common/pipes/v3-to-v4-migration.pipe";
 import { CreatePublishedDataDto } from "../dto/create-published-data.dto";
 import { CreatePublishedDataV4Dto } from "../dto/create-published-data.v4.dto";
 import { publishedDataV3toV4FieldMap } from "../dto/published-data.obsolete.dto";
 import { PublishedDataStatus } from "../interfaces/published-data.interface";
 
-const dtoV3toV4 = createDeepSetter<
+export const V3_TO_V4_DTO_BODY_PIPE = new V3ToV4MigrationPipe<
   CreatePublishedDataDto,
   CreatePublishedDataV4Dto
 >({
@@ -15,14 +14,3 @@ const dtoV3toV4 = createDeepSetter<
       ? PublishedDataStatus.REGISTERED
       : PublishedDataStatus.PRIVATE,
 });
-
-@Injectable()
-export class V3ToV4MigrationPipe<S, T> implements PipeTransform {
-  constructor(private readonly mapper: (source: S) => T) {}
-
-  transform(value: S): T {
-    return this.mapper(value);
-  }
-}
-
-export const V3_TO_V4_DTO_BODY_PIPE = new V3ToV4MigrationPipe(dtoV3toV4);

--- a/src/published-data/pipes/filter.pipe.ts
+++ b/src/published-data/pipes/filter.pipe.ts
@@ -1,11 +1,12 @@
 import { FilterPipe } from "src/common/pipes/filter.pipe";
+import { toApiToDBMap } from "src/common/utils/deep-mapper.util";
 import {
   PublishedData,
   PublishedDataDocument,
 } from "../schemas/published-data.schema";
 import { publishedDataV3toV4FieldMap } from "../dto/published-data.obsolete.dto";
 import { PipeTransform } from "@nestjs/common";
-import { isEmpty, mapValues } from "lodash";
+import { isEmpty } from "lodash";
 import { IPublishedDataFilters } from "../interfaces/published-data.interface";
 import { FilterQuery } from "mongoose";
 
@@ -31,13 +32,10 @@ class AppendFieldsToFilterPipe implements PipeTransform {
   }
 }
 
-const publishedDataV3toV4FilterMap = mapValues(
-  publishedDataV3toV4FieldMap,
-  (val) => val?.replace(/\[\]\.?/g, ""),
-);
+const publishedDataV3toV4FilterMap = toApiToDBMap(publishedDataV3toV4FieldMap);
 
 export const V3_FILTER_PIPE = [
-  new FilterPipe<PublishedData>({ apiToDBMap: publishedDataV3toV4FilterMap }),
+  new FilterPipe<PublishedData>(publishedDataV3toV4FilterMap),
 ];
 
 export const V4_FILTER_PIPE = [

--- a/src/published-data/published-data.controller.ts
+++ b/src/published-data/published-data.controller.ts
@@ -14,10 +14,10 @@ import {
   Post,
   Query,
   Req,
-  SerializeOptions,
   UseGuards,
   UseInterceptors,
 } from "@nestjs/common";
+import { SerializeAsV3 } from "src/common/decorators/serialize-as-v3.decorator";
 import { ConfigService } from "@nestjs/config";
 import {
   ApiBearerAuth,
@@ -99,10 +99,7 @@ export class PublishedDataController {
     description:
       "This endpoint is deprecated and v4 endpoints should be used in the future",
   })
-  @SerializeOptions({
-    type: PublishedDataObsoleteDto,
-    excludeExtraneousValues: true,
-  })
+  @SerializeAsV3(PublishedDataObsoleteDto)
   @Post()
   async create(
     @Body(V3_TO_V4_DTO_BODY_PIPE)
@@ -134,10 +131,7 @@ export class PublishedDataController {
     isArray: true,
     description: "Results with a published documents array",
   })
-  @SerializeOptions({
-    type: PublishedDataObsoleteDto,
-    excludeExtraneousValues: true,
-  })
+  @SerializeAsV3(PublishedDataObsoleteDto)
   async findAll(
     @Req() request: Request,
     @Filter(...V3_FILTER_PIPE, RegisteredFilterPipe)
@@ -288,10 +282,7 @@ export class PublishedDataController {
     description: "PublishedData not found",
   })
   @Get("/:id")
-  @SerializeOptions({
-    type: PublishedDataObsoleteDto,
-    excludeExtraneousValues: true,
-  })
+  @SerializeAsV3(PublishedDataObsoleteDto)
   async findOne(
     @Req() request: Request,
     @Param(new IdToDoiPipe(), RegisteredPipe)
@@ -337,10 +328,7 @@ export class PublishedDataController {
     isArray: false,
     description: "Return updated published data",
   })
-  @SerializeOptions({
-    type: PublishedDataObsoleteDto,
-    excludeExtraneousValues: true,
-  })
+  @SerializeAsV3(PublishedDataObsoleteDto)
   @Patch("/:id")
   async update(
     @Req() request: Request,
@@ -452,10 +440,7 @@ export class PublishedDataController {
     isArray: false,
     description: "Return removed published data",
   })
-  @SerializeOptions({
-    type: PublishedDataObsoleteDto,
-    excludeExtraneousValues: true,
-  })
+  @SerializeAsV3(PublishedDataObsoleteDto)
   @Delete("/:id")
   async remove(@Param("id") id: string): Promise<PublishedDataObsoleteDto> {
     const removedData = await this.publishedDataService.remove({ doi: id });


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Adds some helpers that help migrating to v4 endpoint while keeping backward compatibility. The idea is that when adding v4 endpoints there likely will be a mapping between the v3 version and the v4, so setting the mappings and using these utils allows to have filters/orders/wheres/limits sorted as well as converting v3 payloads to v4 payloads

step by step:

1. add a mapping from v3 to v4
2. create a v3 output DTO which applies the mapping with transform, just passing the mapping to `TransformFromDeepMapping`
3. decorate v3 endpoints with a serializer that maps from v4 to v3 using `SerializeAsV3` with 2
4. add pipes to dtos and filters that map from v3 payload to v4 using the inverse transform of 1 from the helpers just using `toApiToDBMap` with 1
5. write logic as if only v4 endpoints existed

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Simplify v3-to-v4 compatibility by centralizing field mappings, transformations, serialization, and request migration across legacy endpoints.

New Features:
- Add reusable helpers for mapping legacy v3 fields to v4 paths, including nested and array values.
- Provide shared decorators, DTO base fields, and migration pipes for v3 compatibility handling.

Bug Fixes:
- Preserve v3 response shapes and field mappings for jobs, policies, and published data while using v4 data models.

Enhancements:
- Centralize v3 serialization and request filtering, ordering, field selection, and body conversion across legacy endpoints.
- Update policy, job, and published-data mappings to use structured path specifications and shared deep-mapping utilities.

Chores:
- Update the policy migration to consume the normalized v3-to-v4 database mapping.