### PR TITLE
feat: apply partial updates and concurrent guard

### DIFF
--- a/src/policies/policies.controller.ts
+++ b/src/policies/policies.controller.ts
@@ -23,6 +23,7 @@ import { SerializeAsV3 } from "src/common/decorators/serialize-as-v3.decorator";
 import { LEGACY_NOTIFICATION_PIPE } from "./pipes/legacy-notification.pipe";
 import { V3_FILTER_PIPE, V3_WHERE_PIPE } from "./pipes/filter.pipe";
 import { ApiBearerAuth, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { parseDate } from "src/common/utils";
 import { PoliciesGuard } from "src/casl/guards/policies.guard";
 import { CheckPolicies } from "src/casl/decorators/check-policies.decorator";
 import { AppAbility, CaslAbilityFactory } from "src/casl/casl-ability.factory";
@@ -139,13 +140,16 @@ export class PoliciesController {
   @SerializeAsV3(PolicyObsoleteDto)
   @Patch(":id")
   async update(
+    @Req() request: Request,
     @Param("id") id: string,
     @Body(LEGACY_NOTIFICATION_PIPE)
     updatePolicyDto: PartialUpdatePolicyDto,
   ): Promise<Policy | null> {
+    const unmodifiedSince = parseDate(request.headers["if-unmodified-since"]);
     return this.policiesService.update(
       { _id: id },
       updatePolicyDto as unknown as Partial<Policy>,
+      unmodifiedSince,
     );
   }
 

--- a/src/policies/policies.service.spec.ts
+++ b/src/policies/policies.service.spec.ts
@@ -1,5 +1,6 @@
 import { ConfigService } from "@nestjs/config";
 import { getModelToken } from "@nestjs/mongoose";
+import { REQUEST } from "@nestjs/core";
 import { Test, TestingModule } from "@nestjs/testing";
 import { Model } from "mongoose";
 import { DatasetsService } from "src/datasets/datasets.service";
@@ -33,7 +34,6 @@ const mockPolicy: Policy = {
 
 describe("PoliciesService", () => {
   let service: PoliciesService;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let policyModel: Model<Policy>;
 
   beforeEach(async () => {
@@ -43,6 +43,7 @@ describe("PoliciesService", () => {
         { provide: DatasetsService, useClass: DatasetsServiceMock },
         PoliciesService,
         { provide: UsersService, useClass: UsersServiceMock },
+        { provide: REQUEST, useValue: { user: { username: "tester" } } },
         {
           provide: getModelToken("Policy"),
           useValue: {
@@ -62,5 +63,60 @@ describe("PoliciesService", () => {
 
   it("should be defined", () => {
     expect(service).toBeDefined();
+  });
+
+  describe("update", () => {
+    const mockFindOneAndUpdate = (): jest.Mock => {
+      const exec = jest.fn().mockResolvedValue(mockPolicy);
+      const findOneAndUpdate = jest.fn().mockReturnValue({ exec });
+      policyModel.findOneAndUpdate =
+        findOneAndUpdate as unknown as Model<Policy>["findOneAndUpdate"];
+      return findOneAndUpdate;
+    };
+
+    it("0100: sets a field to null on a merge-patch null", async () => {
+      const findOneAndUpdate = mockFindOneAndUpdate();
+
+      await service.update(
+        { _id: "testId" },
+        { instrumentGroup: null } as unknown as Partial<Policy>,
+        undefined,
+        true,
+      );
+
+      const [, updateDoc] = findOneAndUpdate.mock.calls[0];
+      expect(updateDoc.$set.instrumentGroup).toBeNull();
+    });
+
+    it("0110: drops null fields entirely on a plain application/json patch", async () => {
+      const findOneAndUpdate = mockFindOneAndUpdate();
+
+      await service.update(
+        { _id: "testId" },
+        { instrumentGroup: null } as unknown as Partial<Policy>,
+        undefined,
+        false,
+      );
+
+      const [, updateDoc] = findOneAndUpdate.mock.calls[0];
+      expect(updateDoc.$set).not.toHaveProperty("instrumentGroup");
+    });
+
+    it("0120: flattens nested jobPolicies fields to dot paths without touching siblings", async () => {
+      const findOneAndUpdate = mockFindOneAndUpdate();
+
+      await service.update(
+        { _id: "testId" },
+        {
+          jobPolicies: { archive: { tapeRedundancy: "high" } },
+        } as unknown as Partial<Policy>,
+        undefined,
+        false,
+      );
+
+      const [, updateDoc] = findOneAndUpdate.mock.calls[0];
+      expect(updateDoc.$set["jobPolicies.archive.tapeRedundancy"]).toBe("high");
+      expect(updateDoc.$set).not.toHaveProperty("jobPolicies");
+    });
   });
 });

--- a/src/policies/policies.service.ts
+++ b/src/policies/policies.service.ts
@@ -5,6 +5,7 @@ import {
   Logger,
   NotFoundException,
   OnModuleInit,
+  PreconditionFailedException,
   UnauthorizedException,
 } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
@@ -18,6 +19,7 @@ import { UsersService } from "src/users/users.service";
 import { IPolicyFilterV4 } from "./interfaces/policy-filters.interface";
 import { addCreatedByFields, parseLimitFilters } from "src/common/utils";
 import { REQUEST } from "@nestjs/core";
+import { withOCCFilter } from "src/datasets/utils/occ-util";
 
 @Injectable()
 export class PoliciesService implements OnModuleInit {
@@ -153,21 +155,38 @@ export class PoliciesService implements OnModuleInit {
   async update(
     filter: FilterQuery<PolicyDocument>,
     updatePolicyDto: Partial<Policy>,
+    unmodifiedSince?: Date,
+    isMergePatch = false,
   ): Promise<Policy | null> {
     const username = (this.request.user as JWTUser).username;
-    const setFields = {
-      ...this.flattenToDotPaths(updatePolicyDto),
-      updatedBy: username,
-      updatedAt: new Date(),
-    };
-
-    return this.policyModel
+    const flattened = this.flattenToDotPaths(updatePolicyDto);
+    // application/json: a null value means "do not change this field".
+    // application/merge-patch+json: a null value means "reset this field to null".
+    const setFields = Object.fromEntries(
+      Object.entries(flattened).filter(
+        ([, value]) => isMergePatch || value !== null,
+      ),
+    );
+    setFields.updatedBy = username;
+    const queryFilter = withOCCFilter(filter, unmodifiedSince);
+    const updated = await this.policyModel
       .findOneAndUpdate(
-        filter,
+        queryFilter,
         { $set: setFields },
         { new: true, runValidators: true },
       )
       .exec();
+
+    if (!updated && unmodifiedSince) {
+      const stillExists = await this.policyModel.findOne(filter).exec();
+      if (stillExists) {
+        throw new PreconditionFailedException(
+          `Policy has been modified on the server since ${unmodifiedSince.toUTCString()}.`,
+        );
+      }
+    }
+
+    return updated;
   }
 
   async remove(filter: FilterQuery<PolicyDocument>): Promise<unknown> {

--- a/src/policies/policies.v4.controller.ts
+++ b/src/policies/policies.v4.controller.ts
@@ -11,12 +11,21 @@ import {
   Req,
   UseGuards,
 } from "@nestjs/common";
-import { ApiBearerAuth, ApiParam, ApiQuery, ApiTags } from "@nestjs/swagger";
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiTags,
+} from "@nestjs/swagger";
 import { Request } from "express";
 import { PoliciesGuard } from "src/casl/guards/policies.guard";
 import { CheckPolicies } from "src/casl/decorators/check-policies.decorator";
 import { AppAbility, CaslAbilityFactory } from "src/casl/casl-ability.factory";
 import { Action } from "src/casl/action.enum";
+import { parseDate } from "src/common/utils";
 import { PoliciesService } from "./policies.service";
 import { Policy } from "./schemas/policy.schema";
 import { CreatePolicyV4Dto } from "./dto/create-policy-v4.dto";
@@ -99,18 +108,40 @@ export class PoliciesV4Controller {
     ability.can(Action.Update, Policy),
   )
   @Patch(":id")
+  @ApiOperation({
+    summary: "It partially updates the policy.",
+    description: `It updates the policy through the id specified. It updates only the specified fields, merging nested objects (e.g. individual \`jobPolicies\` entries) rather than replacing them wholesale.
+
+- In \`application/json\`, setting a property to \`null\` means "do not change this value."
+- In \`application/merge-patch+json\`, setting a property to \`null\` means "reset this value to \`null\`" (or the default value, if one is defined).
+
+**Caution:** updating a specific item in an array is not supported — the result will always replace the entire array.`,
+  })
   @ApiParam({
     name: "id",
     description: "Id of the policy to update",
     type: String,
   })
+  @ApiConsumes("application/json", "application/merge-patch+json")
+  @ApiBody({
+    description:
+      "Fields that needs to be updated in the policy. Only the fields that needs to be updated have to be passed in.",
+    required: true,
+    type: UpdatePolicyV4Dto,
+  })
   async update(
+    @Req() request: Request,
     @Param("id") id: string,
     @Body() updatePolicyDto: UpdatePolicyV4Dto,
   ): Promise<Policy | null> {
+    const isMergePatch = !!request.is("application/merge-patch+json");
+    const unmodifiedSince = parseDate(request.headers["if-unmodified-since"]);
+
     const updated = await this.policiesService.update(
       { _id: id },
       updatePolicyDto as Partial<Policy>,
+      unmodifiedSince,
+      isMergePatch,
     );
     if (!updated) {
       throw new NotFoundException(`Policy not found for id: ${id}`);

--- a/test/Policy.js
+++ b/test/Policy.js
@@ -1,6 +1,7 @@
 "use strict";
 const utils = require("./LoginUtils");
 const { TestData } = require("./TestData");
+const assert = require("node:assert");
 
 let accessTokenArchiveManager = null,
   accessTokenAdminIngestor = null,
@@ -300,5 +301,76 @@ describe("1302: Policy: v3 order/skip/limit tests", () => {
         res.body[0].should.have.property("ownerGroup");
         res.body[0].should.not.have.property("manager");
       });
+  });
+});
+
+describe("1303: Policy: v3 optimistic concurrency control tests", () => {
+  before(async () => {
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+  });
+
+  it("0010: should fail one request with HTTP 412 when two requests try to update the same policy", async () => {
+    const res = await request(appUrl)
+      .post("/api/v3/Policies")
+      .send({ ...testdataset, ownerGroup: "v3-occ-test" })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode);
+    const id = encodeURIComponent(res.body.id);
+
+    const [res1, res2] = await Promise.all([
+      request(appUrl)
+        .patch("/api/v3/Policies/" + id)
+        .send({ ownerGroup: "v3-occ-test-1" })
+        .set("if-unmodified-since", res.body.updatedAt)
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` }),
+      request(appUrl)
+        .patch("/api/v3/Policies/" + id)
+        .send({ ownerGroup: "v3-occ-test-2" })
+        .set("if-unmodified-since", res.body.updatedAt)
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` }),
+    ]);
+    assert(
+      [res1.statusCode, res2.statusCode].includes(
+        TestData.SuccessfulPatchStatusCode,
+      ),
+      "Neither PATCH request succeeded",
+    );
+    if (res1.status === TestData.SuccessfulPatchStatusCode) {
+      assert(res2.statusCode == TestData.PreconditionFailedStatusCode);
+    } else {
+      assert(res1.statusCode == TestData.PreconditionFailedStatusCode);
+    }
+
+    await request(appUrl)
+      .delete("/api/v3/Policies/" + id)
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` });
+  });
+
+  it("0020: should return 412 when patching with a stale if-unmodified-since date", async () => {
+    const res = await request(appUrl)
+      .post("/api/v3/Policies")
+      .send({ ...testdataset, ownerGroup: "v3-occ-test-stale" })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode);
+    const id = encodeURIComponent(res.body.id);
+    const staleDate = new Date(
+      new Date(res.body.updatedAt).getTime() - 1000,
+    ).toISOString();
+
+    await request(appUrl)
+      .patch("/api/v3/Policies/" + id)
+      .send({ ownerGroup: "v3-occ-test-stale-updated" })
+      .set("if-unmodified-since", staleDate)
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.PreconditionFailedStatusCode);
+
+    await request(appUrl)
+      .delete("/api/v3/Policies/" + id)
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` });
   });
 });

--- a/test/PolicyV4.js
+++ b/test/PolicyV4.js
@@ -1,6 +1,7 @@
 "use strict";
 const utils = require("./LoginUtils");
 const { TestData } = require("./TestData");
+const assert = require("node:assert");
 
 let accessTokenAdminIngestor = null,
   accessTokenUser1 = null;
@@ -237,6 +238,71 @@ describe("1310: Policy v4 tests", () => {
         .set("Accept", "application/json")
         .set({ Authorization: `Bearer ${accessTokenUser1}` })
         .expect(TestData.CreationForbiddenStatusCode);
+    });
+  });
+
+  describe("Optimistic concurrency control tests", () => {
+    let policyId = null;
+
+    after(async () => {
+      if (policyId) {
+        await request(appUrl)
+          .delete("/api/v3/Policies/" + encodeURIComponent(policyId))
+          .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` });
+      }
+    });
+
+    it("0300: should fail one request with HTTP 412 when two requests try to update the same policy", async () => {
+      const res = await request(appUrl)
+        .post("/api/v4/policies")
+        .send({ ownerGroup: "v4-policy-test-occ", manager: ["adminIngestor"] })
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.EntryCreatedStatusCode);
+      policyId = res.body._id;
+      const id = encodeURIComponent(policyId);
+
+      const [res1, res2] = await Promise.all([
+        request(appUrl)
+          .patch(`/api/v4/policies/${id}`)
+          .send({ manager: ["updated1"] })
+          .set("if-unmodified-since", res.body.updatedAt)
+          .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` }),
+        request(appUrl)
+          .patch(`/api/v4/policies/${id}`)
+          .send({ manager: ["updated2"] })
+          .set("if-unmodified-since", res.body.updatedAt)
+          .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` }),
+      ]);
+      assert(
+        [res1.statusCode, res2.statusCode].includes(
+          TestData.SuccessfulPatchStatusCode,
+        ),
+        "Neither PATCH request succeeded",
+      );
+      if (res1.status === TestData.SuccessfulPatchStatusCode) {
+        assert(res2.statusCode == TestData.PreconditionFailedStatusCode);
+      } else {
+        assert(res1.statusCode == TestData.PreconditionFailedStatusCode);
+      }
+    });
+
+    it("0310: should return 412 when patching with a stale if-unmodified-since date", async () => {
+      const res = await request(appUrl)
+        .get(`/api/v4/policies/${encodeURIComponent(policyId)}`)
+        .set("Accept", "application/json")
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.SuccessfulGetStatusCode);
+      const staleDate = new Date(
+        new Date(res.body.updatedAt).getTime() - 1000,
+      ).toISOString();
+
+      return request(appUrl)
+        .patch(`/api/v4/policies/${encodeURIComponent(policyId)}`)
+        .send({ manager: ["updated3"] })
+        .set("if-unmodified-since", staleDate)
+        .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+        .expect(TestData.PreconditionFailedStatusCode);
     });
   });
 });


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Add support for merge-patch and unmodified since to policy

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Enable merge-patch policy updates and protect conditional writes with optimistic concurrency control.

New Features:
- Support partial policy updates using merge-patch semantics, including explicit null resets and nested object merging.
- Add optimistic concurrency control for policy updates through the If-Unmodified-Since header, returning HTTP 412 for stale concurrent writes.

Enhancements:
- Document the supported policy patch media types and partial-update behavior in the v4 API specification.

Tests:
- Add unit and integration coverage for merge-patch null handling, nested updates, stale timestamps, and concurrent policy updates.