### PR TITLE
feat: add allowList to policies for jobs authz

### DIFF
--- a/jobConfig.example.yaml
+++ b/jobConfig.example.yaml
@@ -12,7 +12,8 @@ jobs:
     jobType: template_job
     # actions for POST requests
     create:
-      # user, @group, #all, #authenticated, #datasetPublic, #datasetAccess, or #datasetOwner
+      # user, @group, #all, #authenticated, #datasetPublic, #datasetAccess,
+      # #datasetOwner, or #datasetPolicyList
       auth: "#authenticated"
       actions:
         - actionType: log
@@ -73,6 +74,19 @@ jobs:
               const: true
     update:
       auth: "archivemanager"
+
+  - # Request data to be marked for deletion. Only users/groups listed in
+    # jobPolicies.markForDeletion.allowedList on the Policy for a dataset's
+    # ownerGroup (set via PATCH /api/v4/policies/:id) may create this job
+    # type for that dataset. Each allowedList entry is either a user email
+    # or a group name.
+    jobType: markForDeletion
+    create:
+      auth: "#datasetPolicyList"
+      actions:
+        - actionType: log
+    update:
+      auth: admin
 
   - jobType: email_demo
     create:

--- a/src/datasets/datasets.service.ts
+++ b/src/datasets/datasets.service.ts
@@ -229,6 +229,36 @@ export class DatasetsService {
     return datasets;
   }
 
+  async countPolicyAuthorizedDatasets(
+    datasetPids: string[],
+    jobType: string,
+    userIdentities: string[],
+  ): Promise<number> {
+    const pipeline: PipelineStage[] = [
+      { $match: { pid: { $in: datasetPids } } },
+      {
+        $lookup: {
+          from: "Policy",
+          localField: "ownerGroup",
+          foreignField: "ownerGroup",
+          as: "linkedPolicy",
+        },
+      },
+      {
+        $match: {
+          [`linkedPolicy.jobPolicies.${jobType}.allowedList`]: {
+            $in: userIdentities,
+          },
+        },
+      },
+      { $count: "count" },
+    ];
+    const [result] = await this.datasetModel
+      .aggregate<{ count: number }>(pipeline)
+      .exec();
+    return result?.count ?? 0;
+  }
+
   async findAllComplete(
     filter: IDatasetFilters<DatasetDocument, IDatasetFields>,
     applyDefaults = true,

--- a/src/jobs/jobs.controller.utils.ts
+++ b/src/jobs/jobs.controller.utils.ts
@@ -422,6 +422,14 @@ export class JobsControllerUtils {
         pid: { $in: datasetList.map((x) => x.pid) },
       },
     };
+    if (jobConfiguration.create.auth === CreateJobAuth.DatasetPolicyList) {
+      await this.checkDatasetPolicyListAccess(
+        jobConfiguration.jobType,
+        datasetList,
+        user,
+      );
+      return;
+    }
     const isPrivilegedUser = this.isPrivilegedUser(user);
     const baseGroups = isPrivilegedUser
       ? (jobUser?.currentGroups ?? [])
@@ -453,6 +461,36 @@ export class JobsControllerUtils {
     const numberOfDatasetsWithAccess =
       await this.datasetsService.count(datasetsWhere);
     if (numberOfDatasetsWithAccess.count < datasetList.length)
+      throw new ForbiddenException(
+        "User does not have access to all datasets, cannot create job.",
+      );
+  }
+
+  /**
+   * Check that the user's email, or one of their groups, is listed in
+   * jobPolicies.<jobType>.allowedList on the Policy for every dataset's
+   * ownerGroup in `datasetList`. See
+   * DatasetsService.countPolicyAuthorizedDatasets.
+   */
+  private async checkDatasetPolicyListAccess(
+    jobType: string,
+    datasetList: DatasetListDto[],
+    user: JWTUser,
+  ) {
+    if (!user) throw new UnauthorizedException("User not authenticated");
+    if (!user.email)
+      throw new ForbiddenException(
+        "User has no email registered, cannot verify dataset job authorization.",
+      );
+    const userIdentities = [user.email, ...user.currentGroups];
+    const uniqueDatasetIds = [...new Set(datasetList.map((x) => x.pid))];
+    const authorizedCount =
+      await this.datasetsService.countPolicyAuthorizedDatasets(
+        uniqueDatasetIds,
+        jobType,
+        userIdentities,
+      );
+    if (authorizedCount < uniqueDatasetIds.length)
       throw new ForbiddenException(
         "User does not have access to all datasets, cannot create job.",
       );

--- a/src/jobs/types/jobs-auth.enum.ts
+++ b/src/jobs/types/jobs-auth.enum.ts
@@ -11,6 +11,10 @@ export enum CreateJobAuth {
   // User belongs to dataset's ownerGroup for all `datasetIds`.
   // Equivalent to write access to all datasets in the request
   DatasetOwner = "#datasetOwner",
+  // User's email, or one of their groups, appears in
+  // jobPolicies.<jobType>.allowedList on the Policy for the ownerGroup of
+  // every dataset in `datasetIds`.
+  DatasetPolicyList = "#datasetPolicyList",
   // User belongs to either ADMIN_GROUP or CREATE_JOB_PRIVILEGED_GROUP
   // Equivalent to jobs admin only
   JobAdmin = "#jobAdmin",

--- a/src/policies/schemas/job-policy.schema.ts
+++ b/src/policies/schemas/job-policy.schema.ts
@@ -14,5 +14,12 @@ export class JobPolicy {
   })
   emailNotification?: boolean;
 
+  @ApiProperty({
+    required: false,
+    description:
+      "Users and groups authorized to create jobs of this type for datasets owned by this ownerGroup. Each entry is either a user email or a group name. Only enforced for job types configured with the '#datasetPolicyList' create auth. Not populated automatically - must be set explicitly.",
+  })
+  allowedList?: string[];
+
   [key: string]: unknown;
 }

--- a/test/JobsDatasetPolicyList.js
+++ b/test/JobsDatasetPolicyList.js
@@ -1,0 +1,414 @@
+"use strict";
+const utils = require("./LoginUtils");
+const { TestData } = require("./TestData");
+
+let accessTokenAdminIngestor = null,
+  accessTokenUser1 = null,
+  accessTokenUser51 = null,
+  accessTokenAdmin = null,
+  datasetPidEmailMatch = null,
+  datasetPidGroupMatch = null,
+  datasetPidNoPolicy = null,
+  datasetPidEmptyAllowedList = null;
+
+const policyEmailMatch = {
+  ownerGroup: "policylisttest-email",
+  manager: ["adminIngestor"],
+  jobPolicies: {
+    policy_list_access: {
+      allowedList: ["user1@your.site"],
+    },
+  },
+};
+
+const policyGroupMatch = {
+  ownerGroup: "policylisttest-group",
+  manager: ["adminIngestor"],
+  jobPolicies: {
+    policy_list_access: {
+      allowedList: ["group5"],
+    },
+  },
+};
+
+const policyEmptyAllowedList = {
+  ownerGroup: "policylisttest-empty",
+  manager: ["adminIngestor"],
+  jobPolicies: {
+    policy_list_access: {
+      allowedList: [],
+    },
+  },
+};
+
+const jobDatasetPolicyList = {
+  type: "policy_list_access",
+};
+
+describe("3000: Jobs: Test New Job Model Authorization for policy_list_access jobs type", () => {
+  before(async () => {
+    await Promise.all([
+      db.collection("Policy").deleteMany({}),
+      db.collection("Dataset").deleteMany({}),
+      db.collection("Job").deleteMany({}),
+    ]);
+
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenUser1 = await utils.getToken(appUrl, {
+      username: "user1",
+      password: TestData.Accounts["user1"]["password"],
+    });
+
+    accessTokenUser51 = await utils.getToken(appUrl, {
+      username: "user5.1",
+      password: TestData.Accounts["user5.1"]["password"],
+    });
+
+    accessTokenAdmin = await utils.getToken(appUrl, {
+      username: "admin",
+      password: TestData.Accounts["admin"]["password"],
+    });
+  });
+
+  after(async () => {
+    await Promise.all([
+      db.collection("Policy").deleteMany({}),
+      db.collection("Dataset").deleteMany({}),
+      db.collection("Job").deleteMany({}),
+    ]);
+  });
+
+  it("0010: Add a policy for group whose allowedList matches by email", async () => {
+    return request(appUrl)
+      .post("/api/v4/policies")
+      .send(policyEmailMatch)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.jobPolicies.policy_list_access.allowedList.should.deep.equal([
+          "user1@your.site",
+        ]);
+      });
+  });
+
+  it("0020: Add a policy for group whose allowedList matches by group", async () => {
+    return request(appUrl)
+      .post("/api/v4/policies")
+      .send(policyGroupMatch)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.jobPolicies.policy_list_access.allowedList.should.deep.equal([
+          "group5",
+        ]);
+      });
+  });
+
+  it("0030: Add a policy for a group with an empty allowedList", async () => {
+    return request(appUrl)
+      .post("/api/v4/policies")
+      .send(policyEmptyAllowedList)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.jobPolicies.policy_list_access.allowedList.should.deep.equal(
+          [],
+        );
+      });
+  });
+
+  it("0040: Add dataset owned by the email-match group", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "policylisttest-email",
+      accessGroups: [],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidEmailMatch = res.body["pid"];
+      });
+  });
+
+  it("0050: Add dataset owned by the group-match group", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "policylisttest-group",
+      accessGroups: [],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidGroupMatch = res.body["pid"];
+      });
+  });
+
+  it("0060: Add dataset owned by a group with no policy at all", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "policylisttest-nopolicy",
+      accessGroups: [],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidNoPolicy = res.body["pid"];
+      });
+  });
+
+  it("0070: Add dataset owned by the group whose policy has an empty allowedList", async () => {
+    const dataset = {
+      ...TestData.RawCorrect,
+      isPublished: false,
+      ownerGroup: "policylisttest-empty",
+      accessGroups: [],
+    };
+
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(dataset)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidEmptyAllowedList = res.body["pid"];
+      });
+  });
+
+  it("0080: Add a new job as a user whose email is listed in the ownerGroup policy's allowedList", async () => {
+    const newJob = {
+      ...jobDatasetPolicyList,
+      ownerUser: "user1",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [{ pid: datasetPidEmailMatch, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("type").and.be.string;
+        res.body.should.have.property("ownerGroup").and.be.equal("group1");
+        res.body.should.have.property("ownerUser").and.be.equal("user1");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
+      });
+  });
+
+  it("0090: Add a new job as a user whose group is listed in the ownerGroup policy's allowedList", async () => {
+    const newJob = {
+      ...jobDatasetPolicyList,
+      ownerUser: "user5.1",
+      ownerGroup: "group5",
+      jobParams: {
+        datasetList: [{ pid: datasetPidGroupMatch, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser51}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("type").and.be.string;
+        res.body.should.have.property("ownerGroup").and.be.equal("group5");
+        res.body.should.have.property("ownerUser").and.be.equal("user5.1");
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
+      });
+  });
+
+  it("0100: Add a new job as a user neither listed by email nor by group, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPolicyList,
+      ownerUser: "user5.1",
+      ownerGroup: "group5",
+      jobParams: {
+        datasetList: [{ pid: datasetPidEmailMatch, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser51}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal(
+            "User does not have access to all datasets, cannot create job.",
+          );
+      });
+  });
+
+  it("0110: Add a new job spanning an authorized and an unauthorized dataset, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPolicyList,
+      ownerUser: "user1",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [
+          { pid: datasetPidEmailMatch, files: [] },
+          { pid: datasetPidGroupMatch, files: [] },
+        ],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal(
+            "User does not have access to all datasets, cannot create job.",
+          );
+      });
+  });
+
+  it("0120: Add a new job for a dataset with no linked policy, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPolicyList,
+      ownerUser: "user1",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [{ pid: datasetPidNoPolicy, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal(
+            "User does not have access to all datasets, cannot create job.",
+          );
+      });
+  });
+
+  it("0130: Add a new job for a dataset whose policy has an empty allowedList, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPolicyList,
+      ownerUser: "user1",
+      ownerGroup: "group1",
+      jobParams: {
+        datasetList: [{ pid: datasetPidEmptyAllowedList, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenUser1}` })
+      .expect(TestData.AccessForbiddenStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+        res.body.should.have
+          .property("message")
+          .and.be.equal(
+            "User does not have access to all datasets, cannot create job.",
+          );
+      });
+  });
+
+  it("0140: Add a new job as an unauthenticated user, which should be forbidden", async () => {
+    const newJob = {
+      ...jobDatasetPolicyList,
+      jobParams: {
+        datasetList: [{ pid: datasetPidEmailMatch, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .expect(TestData.UnauthorizedStatusCode)
+      .then((res) => {
+        res.body.should.not.have.property("id");
+      });
+  });
+
+  it("0150: Add a new job as a user from ADMIN_GROUPS for a dataset they are not listed in the allowedList of, which should be allowed", async () => {
+    const newJob = {
+      ...jobDatasetPolicyList,
+      ownerUser: "admin",
+      ownerGroup: "admin",
+      jobParams: {
+        datasetList: [{ pid: datasetPidEmailMatch, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("statusCode").to.be.equal("jobSubmitted");
+      });
+  });
+});

--- a/test/config/jobconfig.yaml
+++ b/test/config/jobconfig.yaml
@@ -27,6 +27,11 @@ jobs:
       auth: "#datasetOwner"
     update:
       auth: "#jobOwnerUser"
+  - jobType: policy_list_access
+    create:
+      auth: "#datasetPolicyList"
+    update:
+      auth: "admin"
   - jobType: user_access
     create:
       auth: user5.1


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Add policy based authorisation to jobs

## Motivation
Some jobs are restricted to single users per ownergroup, for example deletion ones are restricted to a very limited pool of users not contained in the dataset

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Enable allow-list policy authorization for creating jobs across datasets.

New Features:
- Add policy-based job creation authorization that matches users by email or group against per-job allow lists on dataset owner policies.

Enhancements:
- Require all datasets in a multi-dataset job request to authorize the requesting user through their linked policies, while preserving administrator access.

Documentation:
- Document the new #datasetPolicyList authorization mode and allowed-list policy configuration in the example job configuration and API schema.

Tests:
- Add end-to-end coverage for email and group authorization, denied access, missing or empty policies, mixed dataset requests, unauthenticated requests, and administrator access.