### PR TITLE
feat: add email group action to send to DS

### DIFF
--- a/jobConfig.example.yaml
+++ b/jobConfig.example.yaml
@@ -85,6 +85,15 @@ jobs:
       auth: "#datasetPolicyList"
       actions:
         - actionType: log
+        - # Notify each ownerGroup's data stewards. Groups the job's
+          # datasets by ownerGroup, and for each group sends one email to
+          # jobPolicies.markForDeletion.emailTo on that ownerGroup's Policy,
+          # but only when jobPolicies.markForDeletion.emailNotification is
+          # true. Groups with no policy, no emailTo, or the flag unset/false
+          # are skipped silently.
+          actionType: groupedEmail
+          subject: "Datasets marked for deletion in {{ datasets.[0].ownerGroup }}"
+          bodyTemplateFile: src/common/email-templates/job-template-simplified.html
     update:
       auth: admin
 

--- a/src/config/job-config/actions/corejobactioncreators.module.ts
+++ b/src/config/job-config/actions/corejobactioncreators.module.ts
@@ -31,6 +31,9 @@ import { actionType as switchActionType } from "./switchaction/switchaction.inte
 import { ErrorJobActionModule } from "./erroraction/erroraction.module";
 import { ErrorJobActionCreator } from "./erroraction/erroraction.service";
 import { actionType as errorActionType } from "./erroraction/erroraction.interface";
+import { GroupedEmailJobActionModule } from "./groupedemailaction/groupedemailaction.module";
+import { GroupedEmailJobActionCreator } from "./groupedemailaction/groupedemailaction.service";
+import { actionType as groupedEmailActionType } from "./groupedemailaction/groupedemailaction.interface";
 
 /**
  * Provide a list of built-in job action creators.
@@ -50,6 +53,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
     ),
     SwitchJobActionModule,
     ErrorJobActionModule,
+    GroupedEmailJobActionModule,
   ],
   providers: [
     {
@@ -62,6 +66,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
         rabbitMQJobActionCreator: RabbitMQJobActionCreator | null,
         switchCreateJobActionCreator,
         errorJobActionCreator,
+        groupedEmailJobActionCreator,
       ) => {
         return {
           [logActionType]: logJobActionCreator,
@@ -71,6 +76,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
           [rabbitmqActionType]: rabbitMQJobActionCreator,
           [switchActionType]: switchCreateJobActionCreator,
           [errorActionType]: errorJobActionCreator,
+          [groupedEmailActionType]: groupedEmailJobActionCreator,
         };
       },
       inject: [
@@ -81,6 +87,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
         { token: RabbitMQJobActionCreator, optional: true },
         SwitchCreateJobActionCreator,
         ErrorJobActionCreator,
+        GroupedEmailJobActionCreator,
       ],
     },
     {
@@ -93,6 +100,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
         rabbitMQJobActionCreator: RabbitMQJobActionCreator | null,
         switchUpdateJobActionCreator,
         errorJobActionCreator,
+        groupedEmailJobActionCreator,
       ) => {
         return {
           [logActionType]: logJobActionCreator,
@@ -102,6 +110,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
           [rabbitmqActionType]: rabbitMQJobActionCreator,
           [switchActionType]: switchUpdateJobActionCreator,
           [errorActionType]: errorJobActionCreator,
+          [groupedEmailActionType]: groupedEmailJobActionCreator,
         };
       },
       inject: [
@@ -112,6 +121,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
         { token: RabbitMQJobActionCreator, optional: true },
         SwitchUpdateJobActionCreator,
         ErrorJobActionCreator,
+        GroupedEmailJobActionCreator,
       ],
     },
   ],

--- a/src/config/job-config/actions/groupedemailaction/groupedemailaction.interface.ts
+++ b/src/config/job-config/actions/groupedemailaction/groupedemailaction.interface.ts
@@ -1,0 +1,31 @@
+import { JobActionOptions } from "../../jobconfig.interface";
+
+export const actionType = "groupedEmail";
+
+export interface GroupedEmailJobActionOptions extends JobActionOptions {
+  actionType: typeof actionType;
+  from?: string;
+  subject: string;
+  bodyTemplateFile: string;
+  ignoreErrors?: boolean;
+}
+
+/**
+ * Type guard for GroupedEmailJobActionOptions
+ */
+export function isGroupedEmailJobActionOptions(
+  options: unknown,
+): options is GroupedEmailJobActionOptions {
+  if (typeof options !== "object" || options === null) {
+    return false;
+  }
+
+  const opts = options as GroupedEmailJobActionOptions;
+  return (
+    opts.actionType === actionType &&
+    (opts.from === undefined || typeof opts.from === "string") &&
+    typeof opts.subject === "string" &&
+    typeof opts.bodyTemplateFile === "string" &&
+    (opts.ignoreErrors === undefined || typeof opts.ignoreErrors === "boolean")
+  );
+}

--- a/src/config/job-config/actions/groupedemailaction/groupedemailaction.module.ts
+++ b/src/config/job-config/actions/groupedemailaction/groupedemailaction.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { GroupedEmailJobActionCreator } from "./groupedemailaction.service";
+import { CommonModule } from "src/common/common.module";
+
+@Module({
+  imports: [CommonModule],
+  providers: [GroupedEmailJobActionCreator],
+  exports: [GroupedEmailJobActionCreator],
+})
+export class GroupedEmailJobActionModule {}

--- a/src/config/job-config/actions/groupedemailaction/groupedemailaction.service.ts
+++ b/src/config/job-config/actions/groupedemailaction/groupedemailaction.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from "@nestjs/common";
+import { ModuleRef } from "@nestjs/core";
+import {
+  JobActionCreator,
+  JobActionOptions,
+  JobDto,
+} from "../../jobconfig.interface";
+import { isGroupedEmailJobActionOptions } from "./groupedemailaction.interface";
+import { GroupedEmailJobAction } from "./groupedemailaction";
+import { MailService } from "src/common/mail.service";
+
+@Injectable()
+export class GroupedEmailJobActionCreator implements JobActionCreator<JobDto> {
+  constructor(
+    private mailService: MailService,
+    private moduleRef: ModuleRef,
+  ) {}
+
+  public create<Options extends JobActionOptions>(options: Options) {
+    if (!isGroupedEmailJobActionOptions(options)) {
+      throw new Error(
+        `Invalid options for groupedEmail action: ${JSON.stringify(options)}`,
+      );
+    }
+    return new GroupedEmailJobAction(this.mailService, this.moduleRef, options);
+  }
+}

--- a/src/config/job-config/actions/groupedemailaction/groupedemailaction.spec.ts
+++ b/src/config/job-config/actions/groupedemailaction/groupedemailaction.spec.ts
@@ -1,0 +1,342 @@
+import { ModuleRef } from "@nestjs/core";
+import { GroupedEmailJobAction } from "./groupedemailaction";
+import { GroupedEmailJobActionOptions } from "./groupedemailaction.interface";
+import { JobClass } from "../../../../jobs/schemas/job.schema";
+import { MailService } from "src/common/mail.service";
+import { PoliciesService } from "src/policies/policies.service";
+import { Policy } from "src/policies/schemas/policy.schema";
+import { DatasetClass } from "src/datasets/schemas/dataset.schema";
+import { registerHelpers } from "../../handlebar-utils";
+
+jest.mock("src/common/mail.service");
+
+// initialize helpers, since app.module.ts is not loaded in this test
+registerHelpers();
+
+function makeDataset(overrides: Partial<DatasetClass>): DatasetClass {
+  return {
+    pid: "testPid/12345",
+    ownerGroup: "group1",
+    accessGroups: [],
+    createdBy: "creator",
+    updatedBy: "updater",
+    isPublished: false,
+    ...overrides,
+  } as DatasetClass;
+}
+
+function makePolicy(overrides: Partial<Policy>): Policy {
+  return {
+    _id: "policyId",
+    manager: [],
+    ownerGroup: "group1",
+    accessGroups: [],
+    isPublished: false,
+    createdBy: "creator",
+    updatedBy: "updater",
+    ...overrides,
+  } as Policy;
+}
+
+const config: GroupedEmailJobActionOptions = {
+  actionType: "groupedEmail",
+  subject: "Job {{job.id}} update for {{ datasets.[0].ownerGroup }}",
+  bodyTemplateFile:
+    "src/common/email-templates/test-minimal-template.spec.html",
+};
+
+const mockJob: JobClass = {
+  id: "jobId123",
+  _id: "jobId123",
+  type: "markForDeletion",
+  statusCode: "jobSubmitted",
+  statusMessage: "Job submitted",
+  jobParams: { datasetList: [] },
+  jobResultObject: {},
+  ownerUser: "admin",
+  ownerGroup: "admin",
+  configVersion: "1.0",
+  createdBy: "admin",
+  updatedBy: "admin",
+  createdAt: new Date("2023-10-01T10:00:00Z"),
+  updatedAt: new Date("2023-10-01T10:00:00Z"),
+  accessGroups: [],
+  isPublished: false,
+};
+
+function mockPolicies(policies: Policy[]) {
+  (policiesService.findAll as jest.Mock).mockResolvedValue(policies);
+}
+
+let mailService: MailService;
+let policiesService: PoliciesService;
+let moduleRef: ModuleRef;
+let action: GroupedEmailJobAction;
+
+describe("GroupedEmailJobAction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mailService = { sendMail: jest.fn() } as unknown as MailService;
+    policiesService = { findAll: jest.fn() } as unknown as PoliciesService;
+    moduleRef = {
+      resolve: jest.fn().mockResolvedValue(policiesService),
+    } as unknown as ModuleRef;
+    action = new GroupedEmailJobAction(mailService, moduleRef, config);
+  });
+
+  it("should be configured successfully", () => {
+    expect(action).toBeDefined();
+  });
+
+  it("does nothing when there are no datasets", async () => {
+    await action.perform({
+      request: mockJob,
+      job: mockJob,
+      env: {},
+      datasets: [],
+    });
+
+    expect(moduleRef.resolve).not.toHaveBeenCalled();
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("throws when PoliciesService cannot be resolved and ignoreErrors is not set", async () => {
+    (moduleRef.resolve as jest.Mock).mockRejectedValue(
+      new Error("Resolution failed"),
+    );
+
+    await expect(
+      action.perform({
+        request: mockJob,
+        job: mockJob,
+        env: {},
+        datasets: [makeDataset({ ownerGroup: "group1" })],
+      }),
+    ).rejects.toThrow("Resolution failed");
+
+    expect(policiesService.findAll).not.toHaveBeenCalled();
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("ignores a PoliciesService resolution failure when ignoreErrors is set", async () => {
+    (moduleRef.resolve as jest.Mock).mockRejectedValue(
+      new Error("Resolution failed"),
+    );
+    const ignoringAction = new GroupedEmailJobAction(mailService, moduleRef, {
+      ...config,
+      ignoreErrors: true,
+    });
+
+    await expect(
+      ignoringAction.perform({
+        request: mockJob,
+        job: mockJob,
+        env: {},
+        datasets: [makeDataset({ ownerGroup: "group1" })],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("sends one email per ownerGroup whose policy enables notifications for this job type", async () => {
+    const datasets = [
+      makeDataset({ pid: "pid1", ownerGroup: "group1" }),
+      makeDataset({ pid: "pid2", ownerGroup: "group2" }),
+    ];
+    mockPolicies([
+      makePolicy({
+        ownerGroup: "group1",
+        jobPolicies: {
+          markForDeletion: {
+            emailTo: ["group1@example.com"],
+            emailNotification: true,
+          },
+        },
+      }),
+      makePolicy({
+        ownerGroup: "group2",
+        jobPolicies: {
+          markForDeletion: {
+            emailTo: ["group2@example.com"],
+            emailNotification: true,
+          },
+        },
+      }),
+    ]);
+
+    await action.perform({
+      request: mockJob,
+      job: mockJob,
+      env: {},
+      datasets,
+    });
+
+    expect(moduleRef.resolve).toHaveBeenCalledWith(PoliciesService, undefined, {
+      strict: false,
+    });
+    expect(policiesService.findAll).toHaveBeenCalledWith({
+      where: {
+        ownerGroup: { $in: ["group1", "group2"] },
+        "jobPolicies.markForDeletion.emailNotification": true,
+        "jobPolicies.markForDeletion.emailTo": {
+          $exists: true,
+          $not: { $size: 0 },
+        },
+      },
+      fields: ["ownerGroup", "jobPolicies.markForDeletion.emailTo"],
+    });
+    expect(mailService.sendMail).toHaveBeenCalledTimes(2);
+    expect(mailService.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: ["group1@example.com"],
+        subject: "Job jobId123 update for group1",
+      }),
+    );
+    expect(mailService.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: ["group2@example.com"],
+        subject: "Job jobId123 update for group2",
+      }),
+    );
+  });
+
+  it("skips a group when its policy is missing", async () => {
+    mockPolicies([]);
+
+    await action.perform({
+      request: mockJob,
+      job: mockJob,
+      env: {},
+      datasets: [makeDataset({ ownerGroup: "group1" })],
+    });
+
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("filters out policies with emailNotification disabled at the query level", async () => {
+    // The findAll where-clause itself excludes emailNotification: false
+    // policies, so the mocked service returns none for this group.
+    mockPolicies([]);
+
+    await action.perform({
+      request: mockJob,
+      job: mockJob,
+      env: {},
+      datasets: [makeDataset({ ownerGroup: "group1" })],
+    });
+
+    expect(policiesService.findAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          "jobPolicies.markForDeletion.emailNotification": true,
+        }),
+      }),
+    );
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("filters out policies with an empty emailTo at the query level", async () => {
+    // The findAll where-clause itself excludes empty/missing emailTo, so
+    // the mocked service returns none for this group.
+    mockPolicies([]);
+
+    await action.perform({
+      request: mockJob,
+      job: mockJob,
+      env: {},
+      datasets: [makeDataset({ ownerGroup: "group1" })],
+    });
+
+    expect(policiesService.findAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          "jobPolicies.markForDeletion.emailTo": {
+            $exists: true,
+            $not: { $size: 0 },
+          },
+        }),
+      }),
+    );
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("skips a group whose jobPolicies has no entry for this job type", async () => {
+    mockPolicies([
+      makePolicy({
+        ownerGroup: "group1",
+        jobPolicies: {
+          otherJobType: {
+            emailTo: ["group1@example.com"],
+            emailNotification: true,
+          },
+        },
+      }),
+    ]);
+
+    await action.perform({
+      request: mockJob,
+      job: mockJob,
+      env: {},
+      datasets: [makeDataset({ ownerGroup: "group1" })],
+    });
+
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("ignores send errors when ignoreErrors is set", async () => {
+    mockPolicies([
+      makePolicy({
+        ownerGroup: "group1",
+        jobPolicies: {
+          markForDeletion: {
+            emailTo: ["group1@example.com"],
+            emailNotification: true,
+          },
+        },
+      }),
+    ]);
+    (mailService.sendMail as jest.Mock).mockRejectedValue(
+      new Error("Email sending failed"),
+    );
+    const ignoringAction = new GroupedEmailJobAction(mailService, moduleRef, {
+      ...config,
+      ignoreErrors: true,
+    });
+
+    await expect(
+      ignoringAction.perform({
+        request: mockJob,
+        job: mockJob,
+        env: {},
+        datasets: [makeDataset({ ownerGroup: "group1" })],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws when sending fails and ignoreErrors is not set", async () => {
+    mockPolicies([
+      makePolicy({
+        ownerGroup: "group1",
+        jobPolicies: {
+          markForDeletion: {
+            emailTo: ["group1@example.com"],
+            emailNotification: true,
+          },
+        },
+      }),
+    ]);
+    (mailService.sendMail as jest.Mock).mockRejectedValue(
+      new Error("Email sending failed"),
+    );
+
+    await expect(
+      action.perform({
+        request: mockJob,
+        job: mockJob,
+        env: {},
+        datasets: [makeDataset({ ownerGroup: "group1" })],
+      }),
+    ).rejects.toThrow("Email sending failed");
+  });
+});

--- a/src/config/job-config/actions/groupedemailaction/groupedemailaction.ts
+++ b/src/config/job-config/actions/groupedemailaction/groupedemailaction.ts
@@ -1,0 +1,161 @@
+/**
+ * Group the datasets attached to a job by ownerGroup, and send one email per
+ * group to the recipients configured on that ownerGroup's Policy, if enabled.
+ */
+import { readFileSync } from "fs";
+import { compileJobTemplate, TemplateJob } from "../../handlebar-utils";
+import { Logger } from "@nestjs/common";
+import {
+  JobAction,
+  JobDto,
+  JobPerformContext,
+} from "../../jobconfig.interface";
+import { ISendMailOptions } from "@nestjs-modules/mailer";
+import { ModuleRef } from "@nestjs/core";
+import {
+  actionType,
+  GroupedEmailJobActionOptions,
+} from "./groupedemailaction.interface";
+import { MailService } from "src/common/mail.service";
+import { PoliciesService } from "src/policies/policies.service";
+import { DatasetClass } from "src/datasets/schemas/dataset.schema";
+
+export class GroupedEmailJobAction implements JobAction<JobDto> {
+  private from?: string = undefined;
+  private subjectTemplate: TemplateJob;
+  private bodyTemplate: TemplateJob;
+  private ignoreErrors = false;
+
+  getActionType(): string {
+    return actionType;
+  }
+
+  constructor(
+    private mailService: MailService,
+    private moduleRef: ModuleRef,
+    options: GroupedEmailJobActionOptions,
+  ) {
+    Logger.log(
+      "GroupedEmailJobAction parameters are valid.",
+      "GroupedEmailJobAction",
+    );
+
+    if (options["from"]) {
+      this.from = options.from as string;
+    }
+    this.subjectTemplate = compileJobTemplate(options.subject);
+
+    const templateFile = readFileSync(
+      options["bodyTemplateFile"] as string,
+      "utf8",
+    );
+    this.bodyTemplate = compileJobTemplate(templateFile);
+
+    if (options["ignoreErrors"]) {
+      this.ignoreErrors = options.ignoreErrors;
+    }
+  }
+
+  private groupDatasetsByOwnerGroup(
+    datasets: DatasetClass[],
+  ): Map<string, DatasetClass[]> {
+    const groups = new Map<string, DatasetClass[]>();
+    for (const dataset of datasets) {
+      const group = groups.get(dataset.ownerGroup) ?? [];
+      group.push(dataset);
+      groups.set(dataset.ownerGroup, group);
+    }
+    return groups;
+  }
+
+  private async resolvePoliciesService(
+    context: JobPerformContext<JobDto>,
+  ): Promise<PoliciesService> {
+    try {
+      return await this.moduleRef.resolve(PoliciesService, undefined, {
+        strict: false,
+      });
+    } catch (err) {
+      Logger.error(
+        `(Job ${context.job.id}) GroupedEmailJobAction: Failed to resolve PoliciesService: ${err}`,
+        "GroupedEmailJobAction",
+      );
+      throw err;
+    }
+  }
+
+  async perform(context: JobPerformContext<JobDto>) {
+    Logger.log(
+      `(Job ${context.job.id}) Performing GroupedEmailJobAction`,
+      "GroupedEmailJobAction",
+    );
+
+    const datasetsByOwnerGroup = this.groupDatasetsByOwnerGroup(
+      context.datasets,
+    );
+    if (datasetsByOwnerGroup.size === 0) return;
+
+    try {
+      const policiesService = await this.resolvePoliciesService(context);
+
+      const emailToPath = `jobPolicies.${context.job.type}.emailTo`;
+      const policies = await policiesService.findAll({
+        where: {
+          ownerGroup: { $in: [...datasetsByOwnerGroup.keys()] },
+          [`jobPolicies.${context.job.type}.emailNotification`]: true,
+          [emailToPath]: { $exists: true, $not: { $size: 0 } },
+        },
+        fields: ["ownerGroup", emailToPath],
+      });
+      await Promise.all(
+        policies.map(async (policy) => {
+          const groupDatasets = datasetsByOwnerGroup.get(policy.ownerGroup);
+          const emailTo = policy.jobPolicies?.[context.job.type]?.emailTo;
+          if (!groupDatasets || !emailTo) return;
+
+          await this.sendGroupEmail(context, groupDatasets, emailTo);
+        }),
+      );
+    } catch (err) {
+      if (!this.ignoreErrors) {
+        throw err;
+      }
+    }
+  }
+
+  private async sendGroupEmail(
+    context: JobPerformContext<JobDto>,
+    groupDatasets: DatasetClass[],
+    emailTo: string[],
+  ) {
+    const groupContext = { ...context, datasets: groupDatasets };
+
+    let mail: ISendMailOptions;
+    try {
+      mail = {
+        to: emailTo,
+        subject: this.subjectTemplate(groupContext),
+        html: this.bodyTemplate(groupContext),
+      };
+      if (this.from) {
+        mail.from = this.from;
+      }
+    } catch (err) {
+      Logger.error(
+        `(Job ${context.job.id}) GroupedEmailJobAction: Template error: ${err}`,
+        "GroupedEmailJobAction",
+      );
+      throw err;
+    }
+
+    try {
+      await this.mailService.sendMail(mail);
+    } catch (err) {
+      Logger.error(
+        `(Job ${context.job.id}) GroupedEmailJobAction: Sending email failed: ${err}`,
+        "GroupedEmailJobAction",
+      );
+      throw err;
+    }
+  }
+}


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Add email action to send emails to email lists from policies, grouped by datasets' ownergroup. This is to notify data stewards or beamline managers for jobs triggered on owned datasets. It's an opt in feature and replicates a legacy backend feature

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Enable policy-driven grouped email notifications for jobs operating on datasets.

New Features:
- Add an opt-in grouped email job action that notifies each dataset owner group using recipients configured in its policy.

Enhancements:
- Support templated email subjects and bodies with configurable error handling for policy lookup and email delivery.

Documentation:
- Document the grouped email action and its policy-based notification behavior in the example job configuration.

Tests:
- Add coverage for grouping datasets, policy filtering, templating, notification delivery, and error handling.