### PR TITLE
ci: speed up test suite with opensearch enabled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,7 +140,8 @@ jobs:
 
         # Start mongo container and app before running api tests
         run: |
-          cp opensearchConfig.example.json opensearchConfig.json
+          jq '.settings.index.refresh_interval = "100ms"' \
+            opensearchConfig.example.json > opensearchConfig.json
           cp CI/ESS/docker-compose.api.yaml docker-compose.yaml
           docker compose up --build -d --wait
           OPENSEARCH_ENABLED=${{ matrix.opensearch_enabled }} npm run test:api


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
Speed up the test suite when opensearch is enabled by reducing the index refresh interval.
Since the CI uses `OPENSEARCH_REFRESH="wait_for"`, most of the time was spent in the backend waiting for opensearch to refresh the index before returning to the client.
With this patch the test suite runs in ~3min compared to ~7min before. 

## Motivation
<!-- Background on use case, changes needed -->


## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

CI:
- Reduce OpenSearch-enabled API test runtime by configuring a shorter index refresh interval in CI.