### PR TITLE
fix: correct policies ownership filters and remove obsolete casl actions

### DIFF
--- a/src/casl/abilities/policies.ability.ts
+++ b/src/casl/abilities/policies.ability.ts
@@ -43,6 +43,7 @@ export class PolicyAbility {
       /**
        * User belonging to ADMIN_GROUPS or POLICY_GROUPS
        */
+      can(Action.AccessAny, Policy);
 
       can(Action.Create, Policy);
       can(Action.Read, Policy);

--- a/src/casl/action.enum.ts
+++ b/src/casl/action.enum.ts
@@ -2,12 +2,9 @@ export enum Action {
   Manage = "manage",
   Create = "create",
   Read = "read",
-  ReadOwn = "readown",
-  ReadAll = "readall",
   Update = "update",
   Delete = "delete",
-  ListOwn = "listown",
-  ListAll = "listall",
+
   // ---------------
   // Generic access any action that can be applied to any resource
   // Currently used by addAccessBasedFilters for admin/special group users

--- a/src/policies/policies.controller.ts
+++ b/src/policies/policies.controller.ts
@@ -46,21 +46,26 @@ export class PoliciesController {
   ): IFilters<PolicyDocument, IPolicyFilter> {
     const user: JWTUser = request.user as JWTUser;
 
-    if (user) {
-      const ability = this.caslAbilityFactory.policyAccess(user);
-      // these actions are not defined in casl
-      const canViewAll = ability.can(Action.ListAll, Policy);
-      const canViewTheirOwn = ability.can(Action.ListOwn, Policy);
-      if (!canViewAll && canViewTheirOwn) {
-        if (!mergedFilters.where) {
-          mergedFilters.where = {};
-        }
-        mergedFilters.where["$or"] = [
+    const ability = this.caslAbilityFactory.policyAccess(user);
+    const canViewAny = ability.can(Action.AccessAny, Policy);
+    const canView = ability.can(Action.Read, Policy);
+
+    mergedFilters.where = mergedFilters.where ?? {};
+
+    if (!user) {
+      mergedFilters.where["$and"] = mergedFilters.where["$and"] ?? [];
+      mergedFilters.where["$and"].push({
+        isPublished: true,
+      });
+    } else if (!canViewAny && canView) {
+      mergedFilters.where["$and"] = mergedFilters.where["$and"] ?? [];
+      mergedFilters.where["$and"].push({
+        $or: [
           { ownerGroup: { $in: user.currentGroups } },
           { accessGroups: { $in: user.currentGroups } },
           { isPublished: true },
-        ];
-      }
+        ],
+      });
     }
 
     return mergedFilters;


### PR DESCRIPTION
## Description
Fixes the ownership filter generation in policyController by transferring over the logic for datasets. Additionally remove actions now obsolete due to the casl refactor.

## Fixes

* Remove undefined calls to `Action.ListAll` and `Action.ListOwn` in policy controller

## Changes:

* Remove casl actions `ListAll`, `ListOwn`, `ReadAll` and `ReadOwn`, which are unused
* Aligen ownership filter logic in policy controller to datasets
* Add `Action.AccessAny` permissions to PolicyAbility for admins and proposal privileged groups (future option to actually differentiate ownership)

## Tests included

- [x] Included for each change/fix?
- [x] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [x] swagger documentation updated (required for API changes)
- [x] official documentation updated

## Summary by Sourcery

Correct policy visibility rules and align policy authorization with the current CASL action model.

Bug Fixes:
- Correct policy ownership filtering for authenticated users and enforce published-only visibility for unauthenticated requests.
- Remove policy controller references to obsolete CASL list actions.

Enhancements:
- Grant AccessAny policy permissions to administrators and privileged policy groups.
- Remove unused ReadOwn, ReadAll, ListOwn, and ListAll CASL actions.