### PR TITLE
test: add unit tests for refactored casl abilities

### DIFF
--- a/src/casl/abilities/attachments.ability.spec.ts
+++ b/src/casl/abilities/attachments.ability.spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { AttachmentAbility } from "./attachments.ability";
+
+describe("AttachmentAbility", () => {
+  let ability: AttachmentAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [AttachmentAbility],
+    }).compile();
+
+    ability = module.get<AttachmentAbility>(AttachmentAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("ATTACHMENT_GROUPS permissions", () => {});
+
+  describe("ATTACHMENT_PRIVILEGED_GROUPS permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+
+  describe("DELETE_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/datablocks.ability.spec.ts
+++ b/src/casl/abilities/datablocks.ability.spec.ts
@@ -1,0 +1,34 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { DatablockAbility } from "./datablocks.ability";
+
+describe("DatablockAbility", () => {
+  let ability: DatablockAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [DatablockAbility],
+    }).compile();
+
+    ability = module.get<DatablockAbility>(DatablockAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("CREATE_DATASET_GROUPS permissions", () => {});
+
+  describe("CREATE_DATASET_WITH_PID_GROUPS permissions", () => {});
+
+  describe("CREATE_DATASET_PRIVILEGED_GROUPS permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+
+  describe("DELETE_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/datasets.ability.spec.ts
+++ b/src/casl/abilities/datasets.ability.spec.ts
@@ -1,0 +1,36 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { DatasetAbility } from "./datasets.ability";
+
+describe("DatasetAbility", () => {
+  let ability: DatasetAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [DatasetAbility],
+    }).compile();
+
+    ability = module.get<DatasetAbility>(DatasetAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("CREATE_DATASET_GROUPS permissions", () => {});
+
+  describe("CREATE_DATASET_WITH_PID_GROUPS permissions", () => {});
+
+  describe("CREATE_DATASET_PRIVILEGED_GROUPS permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+
+  describe("DELETE_GROUPS permissions", () => {});
+
+  describe("UPDATE_DATASET_LIFECYCLE_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/history.ability.spec.ts
+++ b/src/casl/abilities/history.ability.spec.ts
@@ -1,0 +1,42 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { HistoryAbility } from "./history.ability";
+
+describe("HistoryAbility", () => {
+  let ability: HistoryAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [HistoryAbility],
+    }).compile();
+
+    ability = module.get<HistoryAbility>(HistoryAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("HISTORY_ACCESS_ATTACHMENT_GROUPS permissions", () => {});
+
+  describe("HISTORY_ACCESS_DATABLOCK_GROUPS permissions", () => {});
+
+  describe("HISTORY_ACCESS_DATASET_GROUPS permissions", () => {});
+
+  describe("HISTORY_ACCESS_INSTRUMENT_GROUPS permissions", () => {});
+
+  describe("HISTORY_ACCESS_POLICIES_GROUPS permissions", () => {});
+
+  describe("HISTORY_ACCESS_PROPOSAL_GROUPS permissions", () => {});
+
+  describe("HISTORY_ACCESS_PUBLISHED_DATA_GROUPS permissions", () => {});
+
+  describe("HISTORY_ACCESS_SAMPLE_GROUPS permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/instruments.ability.spec.ts
+++ b/src/casl/abilities/instruments.ability.spec.ts
@@ -1,0 +1,28 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { InstrumentAbility } from "./instruments.ability";
+
+describe("InstrumentAbility", () => {
+  let ability: InstrumentAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [InstrumentAbility],
+    }).compile();
+
+    ability = module.get<InstrumentAbility>(InstrumentAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+
+  describe("DELETE_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/jobs.ability.spec.ts
+++ b/src/casl/abilities/jobs.ability.spec.ts
@@ -1,0 +1,38 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { JobConfigService } from "src/config/job-config/jobconfig.service";
+import { JobAbility } from "./jobs.ability";
+
+class JobConfigServiceMock {}
+
+describe("JobAbility", () => {
+  let ability: JobAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [
+        { provide: JobConfigService, useClass: JobConfigServiceMock },
+        JobAbility,
+      ],
+    }).compile();
+
+    ability = module.get<JobAbility>(JobAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("CREATE_JOB_PRIVILEGED_GROUPS permissions", () => {});
+
+  describe("UPDATE_JOB_PRIVILEGED_GROUPS permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+
+  describe("DELETE_JOB_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/logbooks.ability.spec.ts
+++ b/src/casl/abilities/logbooks.ability.spec.ts
@@ -1,0 +1,24 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { LogbookAbility } from "./logbooks.ability";
+
+describe("LogbookAbility", () => {
+  let ability: LogbookAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [LogbookAbility],
+    }).compile();
+
+    ability = module.get<LogbookAbility>(LogbookAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+});

--- a/src/casl/abilities/metadata-keys.ability.spec.ts
+++ b/src/casl/abilities/metadata-keys.ability.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { MetadataKeyAbility } from "./metadata-keys.ability";
+
+describe("MetadataKeyAbility", () => {
+  let ability: MetadataKeyAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [MetadataKeyAbility],
+    }).compile();
+
+    ability = module.get<MetadataKeyAbility>(MetadataKeyAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/opensearch.ability.spec.ts
+++ b/src/casl/abilities/opensearch.ability.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { OpensearchAbility } from "./opensearch.ability";
+
+describe("OpensearchAbility", () => {
+  let ability: OpensearchAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [OpensearchAbility],
+    }).compile();
+
+    ability = module.get<OpensearchAbility>(OpensearchAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/origdatablocks.ability.spec.ts
+++ b/src/casl/abilities/origdatablocks.ability.spec.ts
@@ -1,0 +1,34 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { OrigDatablockAbility } from "./origdatablocks.ability";
+
+describe("OrigDatablockAbility", () => {
+  let ability: OrigDatablockAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [OrigDatablockAbility],
+    }).compile();
+
+    ability = module.get<OrigDatablockAbility>(OrigDatablockAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("CREATE_DATASET_GROUPS permissions", () => {});
+
+  describe("CREATE_DATASET_WITH_PID_GROUPS permissions", () => {});
+
+  describe("CREATE_DATASET_PRIVILEGED_GROUPS permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+
+  describe("DELETE_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/policies.ability.spec.ts
+++ b/src/casl/abilities/policies.ability.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { PolicyAbility } from "./policies.ability";
+
+describe("PolicyAbility", () => {
+  let ability: PolicyAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [PolicyAbility],
+    }).compile();
+
+    ability = module.get<PolicyAbility>(PolicyAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("POLICY_GROUPS permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+
+  describe("DELETE_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/proposals.ability.spec.ts
+++ b/src/casl/abilities/proposals.ability.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { ProposalAbility } from "./proposals.ability";
+
+describe("ProposalAbility", () => {
+  let ability: ProposalAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [ProposalAbility],
+    }).compile();
+
+    ability = module.get<ProposalAbility>(ProposalAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("PROPOSAL_GROUPS permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+
+  describe("DELETE_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/published-data.ability.spec.ts
+++ b/src/casl/abilities/published-data.ability.spec.ts
@@ -1,0 +1,28 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { PublishedDataAbility } from "./published-data.ability";
+
+describe("PublishedDataAbility", () => {
+  let ability: PublishedDataAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [PublishedDataAbility],
+    }).compile();
+
+    ability = module.get<PublishedDataAbility>(PublishedDataAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+
+  describe("DELETE_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/runtime-config.ability.spec.ts
+++ b/src/casl/abilities/runtime-config.ability.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { RuntimeConfigAbility } from "./runtime-config.ability";
+
+describe("RuntimeConfigAbility", () => {
+  let ability: RuntimeConfigAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [RuntimeConfigAbility],
+    }).compile();
+
+    ability = module.get<RuntimeConfigAbility>(RuntimeConfigAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/samples.ability.spec.ts
+++ b/src/casl/abilities/samples.ability.spec.ts
@@ -1,0 +1,32 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { SampleAbility } from "./samples.ability";
+
+describe("SampleAbility", () => {
+  let ability: SampleAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [SampleAbility],
+    }).compile();
+
+    ability = module.get<SampleAbility>(SampleAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("SAMPLE_GROUPS permissions", () => {});
+
+  describe("SAMPLE_PRIVILEGED_GROUPS permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+
+  describe("DELETE_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/sse.ability.spec.ts
+++ b/src/casl/abilities/sse.ability.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { SseAbility } from "./sse.ability";
+
+describe("SseAbility", () => {
+  let ability: SseAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [SseAbility],
+    }).compile();
+
+    ability = module.get<SseAbility>(SseAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+});

--- a/src/casl/abilities/users.ability.spec.ts
+++ b/src/casl/abilities/users.ability.spec.ts
@@ -1,0 +1,26 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { ConfigModule } from "@nestjs/config";
+import { UserAbility } from "./users.ability";
+
+describe("UserAbility", () => {
+  let ability: UserAbility;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ConfigModule],
+      providers: [UserAbility],
+    }).compile();
+
+    ability = module.get<UserAbility>(UserAbility);
+  });
+
+  it("should be defined", () => {
+    expect(ability).toBeDefined();
+  });
+
+  describe("Unauthenticated permissions", () => {});
+
+  describe("Authenticated permissions", () => {});
+
+  describe("ADMIN_GROUPS permissions", () => {});
+});


### PR DESCRIPTION
## Description
Add unit tests for all factored out casl abilities, testing for dependency resolution and access rights for each permission class.
Depends on PR #2814 to be merged first.

## Tests included

- [x] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [x] swagger documentation updated (required for API changes)
- [x] official documentation updated

## Summary by Sourcery

Tests:
- Add NestJS unit-test scaffolding for the refactored CASL ability classes, covering dependency resolution and organizing permission scenarios by access group.