### PR TITLE
test(cast-where-filter): add unit test

### DIFF
--- a/src/datasets/utils/pipeline.util.spec.ts
+++ b/src/datasets/utils/pipeline.util.spec.ts
@@ -93,7 +93,7 @@ describe("castWhereFilter", () => {
       history: {
         $elemMatch: {
           property: "ownerGroup",
-          updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+          updatedAt: { $gte: new Date("2026-06-01T00:00:00.000Z") },
         },
       },
     });
@@ -102,12 +102,14 @@ describe("castWhereFilter", () => {
   it("leaves a query without markers unchanged", () => {
     const where = {
       type: "raw",
-      ownerGroup: { $in: ["scicat", "dmsc"] },
+      ownerGroup: { $in: ["ess", "dmsc"] },
       "datasetlifecycle.archivable": true,
       $nor: [{ pid: { $regex: "^test" } }],
     };
+    const original = structuredClone(where);
 
-    expect(castWhereFilter(where)).toEqual(where);
+    expect(castWhereFilter(where)).toEqual(original);
+    expect(where).toEqual(original);
   });
 
   it("leaves an already-cast Date in place", () => {

--- a/src/datasets/utils/pipeline.util.spec.ts
+++ b/src/datasets/utils/pipeline.util.spec.ts
@@ -1,5 +1,3 @@
-// cast-where-filter.spec.ts
-
 import { castWhereFilter } from "./pipeline.util";
 
 describe("castWhereFilter", () => {
@@ -21,14 +19,14 @@ describe("castWhereFilter", () => {
 
   it("casts dates mixed with plain scalar filters", () => {
     const where = {
-      ownerGroup: "ess",
+      ownerGroup: "scicat",
       isPublished: false,
       "scientificMetadata.temperature.value": { $gt: 300 },
       updatedAt: { $lte: { $date: "2026-09-10T12:00:00.000Z" } },
     };
 
     expect(castWhereFilter(where)).toEqual({
-      ownerGroup: "ess",
+      ownerGroup: "scicat",
       isPublished: false,
       "scientificMetadata.temperature.value": { $gt: 300 },
       updatedAt: { $lte: new Date("2026-09-10T12:00:00.000Z") },
@@ -38,14 +36,24 @@ describe("castWhereFilter", () => {
   it("casts dates inside $and / $or branches", () => {
     const where = {
       $and: [
-        { $or: [{ ownerGroup: "ess" }, { accessGroups: { $in: ["ess"] } }] },
+        {
+          $or: [
+            { ownerGroup: "scicat" },
+            { accscicatGroups: { $in: ["scicat"] } },
+          ],
+        },
         { creationTime: { $gte: { $date: "2026-01-01T00:00:00.000Z" } } },
       ],
     };
 
     expect(castWhereFilter(where)).toEqual({
       $and: [
-        { $or: [{ ownerGroup: "ess" }, { accessGroups: { $in: ["ess"] } }] },
+        {
+          $or: [
+            { ownerGroup: "scicat" },
+            { accscicatGroups: { $in: ["scicat"] } },
+          ],
+        },
         { creationTime: { $gte: new Date("2026-01-01T00:00:00.000Z") } },
       ],
     });
@@ -94,7 +102,7 @@ describe("castWhereFilter", () => {
   it("leaves a query without markers unchanged", () => {
     const where = {
       type: "raw",
-      ownerGroup: { $in: ["ess", "dmsc"] },
+      ownerGroup: { $in: ["scicat", "dmsc"] },
       "datasetlifecycle.archivable": true,
       $nor: [{ pid: { $regex: "^test" } }],
     };

--- a/src/datasets/utils/pipeline.util.spec.ts
+++ b/src/datasets/utils/pipeline.util.spec.ts
@@ -1,0 +1,116 @@
+// cast-where-filter.spec.ts
+
+import { castWhereFilter } from "./pipeline.util";
+
+describe("castWhereFilter", () => {
+  it("casts a date range on a single field", () => {
+    const where = {
+      createdAt: {
+        $gte: { $date: "2026-08-01T00:00:00.000Z" },
+        $lt: { $date: "2026-09-01T00:00:00.000Z" },
+      },
+    };
+
+    expect(castWhereFilter(where)).toEqual({
+      createdAt: {
+        $gte: new Date("2026-08-01T00:00:00.000Z"),
+        $lt: new Date("2026-09-01T00:00:00.000Z"),
+      },
+    });
+  });
+
+  it("casts dates mixed with plain scalar filters", () => {
+    const where = {
+      ownerGroup: "ess",
+      isPublished: false,
+      "scientificMetadata.temperature.value": { $gt: 300 },
+      updatedAt: { $lte: { $date: "2026-09-10T12:00:00.000Z" } },
+    };
+
+    expect(castWhereFilter(where)).toEqual({
+      ownerGroup: "ess",
+      isPublished: false,
+      "scientificMetadata.temperature.value": { $gt: 300 },
+      updatedAt: { $lte: new Date("2026-09-10T12:00:00.000Z") },
+    });
+  });
+
+  it("casts dates inside $and / $or branches", () => {
+    const where = {
+      $and: [
+        { $or: [{ ownerGroup: "ess" }, { accessGroups: { $in: ["ess"] } }] },
+        { creationTime: { $gte: { $date: "2026-01-01T00:00:00.000Z" } } },
+      ],
+    };
+
+    expect(castWhereFilter(where)).toEqual({
+      $and: [
+        { $or: [{ ownerGroup: "ess" }, { accessGroups: { $in: ["ess"] } }] },
+        { creationTime: { $gte: new Date("2026-01-01T00:00:00.000Z") } },
+      ],
+    });
+  });
+
+  it("casts an array of dates in $in", () => {
+    const where = {
+      creationTime: {
+        $in: [
+          { $date: "2026-08-31T00:00:00.000Z" },
+          { $date: "2026-09-01T00:00:00.000Z" },
+        ],
+      },
+    };
+
+    expect(castWhereFilter(where)).toEqual({
+      creationTime: {
+        $in: [
+          new Date("2026-08-31T00:00:00.000Z"),
+          new Date("2026-09-01T00:00:00.000Z"),
+        ],
+      },
+    });
+  });
+
+  it("casts dates nested under $elemMatch", () => {
+    const where = {
+      history: {
+        $elemMatch: {
+          property: "ownerGroup",
+          updatedAt: { $gte: { $date: "2026-06-01T00:00:00.000Z" } },
+        },
+      },
+    };
+
+    expect(castWhereFilter(where)).toEqual({
+      history: {
+        $elemMatch: {
+          property: "ownerGroup",
+          updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+        },
+      },
+    });
+  });
+
+  it("leaves a query without markers unchanged", () => {
+    const where = {
+      type: "raw",
+      ownerGroup: { $in: ["ess", "dmsc"] },
+      "datasetlifecycle.archivable": true,
+      $nor: [{ pid: { $regex: "^test" } }],
+    };
+
+    expect(castWhereFilter(where)).toEqual(where);
+  });
+
+  it("leaves an already-cast Date in place", () => {
+    const date = new Date("2026-08-31T00:00:00.000Z");
+    expect(castWhereFilter({ createdAt: { $gte: date } })).toEqual({
+      createdAt: { $gte: date },
+    });
+  });
+
+  it("passes through markers it does not know yet", () => {
+    const where = { _id: { $oid: "64f0c0de1234567890abcdef" } };
+    expect(castWhereFilter(where)).toEqual(where);
+  });
+});


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
added missing unit test for castWhereFilter function

## Motivation
<!-- Background on use case, changes needed -->

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Tests:
- Add unit coverage for date casting in simple, nested, logical, array, and element-match filters, including preservation of unchanged values and unsupported markers.