### PR TITLE
fix(proposal): don't overwrite `MeasurementPeriodList` on updates

### DIFF
--- a/src/common/interceptors/multi-utc-time.interceptor.spec.ts
+++ b/src/common/interceptors/multi-utc-time.interceptor.spec.ts
@@ -1,0 +1,58 @@
+import { CallHandler, ExecutionContext } from "@nestjs/common";
+import { of } from "rxjs";
+import { MeasurementPeriodClass } from "src/proposals/schemas/measurement-period.schema";
+import { ProposalClass } from "src/proposals/schemas/proposal.schema";
+import { MultiUTCTimeInterceptor } from "./multi-utc-time.interceptor";
+
+const createContext = (body: Record<string, unknown>) =>
+  ({
+    switchToHttp: () => ({
+      getRequest: () => ({ body }),
+    }),
+  }) as ExecutionContext;
+
+const callHandler: CallHandler = { handle: () => of(null) };
+
+describe("MultiUTCTimeInterceptor", () => {
+  const interceptor = new MultiUTCTimeInterceptor<
+    ProposalClass,
+    MeasurementPeriodClass
+  >("MeasurementPeriodList", ["start", "end"]);
+
+  it("should convert the dates of every measurement period to UTC", () => {
+    const body: Record<string, unknown> = {
+      MeasurementPeriodList: [
+        {
+          instrument: "ESS3-1",
+          start: "2017-07-24T13:56:30+02:00",
+          end: "2017-07-25T13:56:30+02:00",
+          comment: "Some comment",
+        },
+      ],
+    };
+    const context = createContext(body);
+
+    void interceptor.intercept(context, callHandler);
+
+    const measurementPeriodList =
+      body.MeasurementPeriodList as MeasurementPeriodClass[];
+    expect(measurementPeriodList).toHaveLength(1);
+    expect(new Date(measurementPeriodList[0].start).toISOString()).toBe(
+      "2017-07-24T11:56:30.000Z",
+    );
+    expect(new Date(measurementPeriodList[0].end).toISOString()).toBe(
+      "2017-07-25T11:56:30.000Z",
+    );
+    expect(measurementPeriodList[0].instrument).toBe("ESS3-1");
+    expect(measurementPeriodList[0].comment).toBe("Some comment");
+  });
+
+  it("should not add the measurement period list to a body that does not contain it", () => {
+    const body: Record<string, unknown> = { title: "A test proposal" };
+    const context = createContext(body);
+
+    void interceptor.intercept(context, callHandler);
+
+    expect(body).not.toHaveProperty("MeasurementPeriodList");
+  });
+});

--- a/src/common/interceptors/multi-utc-time.interceptor.ts
+++ b/src/common/interceptors/multi-utc-time.interceptor.ts
@@ -23,7 +23,12 @@ export class MultiUTCTimeInterceptor<T, U> implements NestInterceptor {
   ): Observable<unknown> | Promise<Observable<unknown>> {
     const req = context.switchToHttp().getRequest();
     const instances = req.body[this.subGroup] as U[];
-    req.body[this.subGroup] = updateAllTimesToUTC<U>(this.dateKeys, instances);
+    if (instances) {
+      req.body[this.subGroup] = updateAllTimesToUTC<U>(
+        this.dateKeys,
+        instances,
+      );
+    }
     return next.handle();
   }
 }

--- a/src/proposals/dto/update-proposal.dto.ts
+++ b/src/proposals/dto/update-proposal.dto.ts
@@ -89,7 +89,7 @@ export class UpdateProposalDto extends OwnableDto {
   @IsOptional()
   @ValidateNested({ each: true })
   @Type(() => CreateMeasurementPeriodDto)
-  readonly MeasurementPeriodList?: CreateMeasurementPeriodDto[] = [];
+  readonly MeasurementPeriodList?: CreateMeasurementPeriodDto[];
 
   /**
    * JSON object containing the proposal metadata.

--- a/test/Proposal.js
+++ b/test/Proposal.js
@@ -463,6 +463,33 @@ describe("1500: Proposal: Simple Proposal", () => {
       });
   });
 
+  it("0121: updating a proposal without the measurement period list should not remove it", async () => {
+    return request(appUrl)
+      .patch("/api/v3/Proposals/" + proposalId)
+      .send({ title: "An updated complete test proposal" })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenProposalIngestor}` })
+      .expect(TestData.SuccessfulPatchStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("title")
+          .and.equal("An updated complete test proposal");
+        res.body.should.have
+          .property("MeasurementPeriodList")
+          .and.be.an("array")
+          .and.have.lengthOf(
+            TestData.ProposalCorrectComplete.MeasurementPeriodList.length,
+          );
+        res.body.MeasurementPeriodList[0].should.have
+          .property("instrument")
+          .and.equal(
+            TestData.ProposalCorrectComplete.MeasurementPeriodList[0]
+              .instrument,
+          );
+      });
+  });
+
   it("0130: should delete this proposal attachment", async () => {
     return request(appUrl)
       .delete(


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
<!-- Short description of the pull request -->
Updating a proposal with no `MeasurementPeriodList` should not reset the existing one.

## Motivation
<!-- Background on use case, changes needed -->
see https://github.com/SciCatProject/backend/pull/2904/changes#r3977231988

## Fixes
<!-- Please provide a list of the issues fixed by this PR -->

* Bug fixed (#X)

## Changes:
<!-- Please provide a list of the changes implemented by this PR -->

* changes made

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Preserve measurement periods during partial proposal updates instead of replacing omitted lists with empty values.

Bug Fixes:
- Preserve an existing proposal's MeasurementPeriodList when updates omit that field.

Tests:
- Add interceptor and end-to-end coverage for UTC conversion and retaining measurement periods during partial proposal updates.