### PR TITLE
feat: add email group action to send to DS

### DIFF
--- a/jobConfig.example.yaml
+++ b/jobConfig.example.yaml
@@ -105,6 +105,22 @@ jobs:
               - actionType: log
                 perform: "(Job {{job.id}} Skip email notification for status {{job.statusCode}}"
 
+  - # Send one email per ownerGroup of the job's datasets. Recipients come
+    # from each ownerGroup's Policy (set via PATCH /api/v4/policies/:id):
+    # emailTo, but only when emailNotification is true for a Policy whose
+    # type matches this jobType. Groups with no matching policy, no
+    # emailTo, or the flag unset/false are skipped silently.
+    jobType: dataset_policy_email_demo
+    create:
+      auth: admin
+      actions:
+        - actionType: datasetPolicyEmail
+          ignoreErrors: true
+          subject: "Datasets updated in {{ datasets.[0].ownerGroup }}"
+          bodyTemplateFile: src/common/email-templates/job-template-simplified.html
+    update:
+      auth: "#jobOwnerUser"
+
 
   - jobType: url_demo
     create:

--- a/src/config/job-config/actions/corejobactioncreators.module.ts
+++ b/src/config/job-config/actions/corejobactioncreators.module.ts
@@ -31,6 +31,9 @@ import { actionType as switchActionType } from "./switchaction/switchaction.inte
 import { ErrorJobActionModule } from "./erroraction/erroraction.module";
 import { ErrorJobActionCreator } from "./erroraction/erroraction.service";
 import { actionType as errorActionType } from "./erroraction/erroraction.interface";
+import { DatasetPolicyEmailJobActionModule } from "./datasetpolicyemailaction/datasetpolicyemailaction.module";
+import { DatasetPolicyEmailJobActionCreator } from "./datasetpolicyemailaction/datasetpolicyemailaction.service";
+import { actionType as datasetPolicyEmailActionType } from "./datasetpolicyemailaction/datasetpolicyemailaction.interface";
 
 /**
  * Provide a list of built-in job action creators.
@@ -50,6 +53,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
     ),
     SwitchJobActionModule,
     ErrorJobActionModule,
+    DatasetPolicyEmailJobActionModule,
   ],
   providers: [
     {
@@ -62,6 +66,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
         rabbitMQJobActionCreator: RabbitMQJobActionCreator | null,
         switchCreateJobActionCreator,
         errorJobActionCreator,
+        datasetPolicyEmailJobActionCreator,
       ) => {
         return {
           [logActionType]: logJobActionCreator,
@@ -71,6 +76,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
           [rabbitmqActionType]: rabbitMQJobActionCreator,
           [switchActionType]: switchCreateJobActionCreator,
           [errorActionType]: errorJobActionCreator,
+          [datasetPolicyEmailActionType]: datasetPolicyEmailJobActionCreator,
         };
       },
       inject: [
@@ -81,6 +87,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
         { token: RabbitMQJobActionCreator, optional: true },
         SwitchCreateJobActionCreator,
         ErrorJobActionCreator,
+        DatasetPolicyEmailJobActionCreator,
       ],
     },
     {
@@ -93,6 +100,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
         rabbitMQJobActionCreator: RabbitMQJobActionCreator | null,
         switchUpdateJobActionCreator,
         errorJobActionCreator,
+        datasetPolicyEmailJobActionCreator,
       ) => {
         return {
           [logActionType]: logJobActionCreator,
@@ -102,6 +110,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
           [rabbitmqActionType]: rabbitMQJobActionCreator,
           [switchActionType]: switchUpdateJobActionCreator,
           [errorActionType]: errorJobActionCreator,
+          [datasetPolicyEmailActionType]: datasetPolicyEmailJobActionCreator,
         };
       },
       inject: [
@@ -112,6 +121,7 @@ import { actionType as errorActionType } from "./erroraction/erroraction.interfa
         { token: RabbitMQJobActionCreator, optional: true },
         SwitchUpdateJobActionCreator,
         ErrorJobActionCreator,
+        DatasetPolicyEmailJobActionCreator,
       ],
     },
   ],

--- a/src/config/job-config/actions/datasetpolicyemailaction/datasetpolicyemailaction.interface.ts
+++ b/src/config/job-config/actions/datasetpolicyemailaction/datasetpolicyemailaction.interface.ts
@@ -1,0 +1,31 @@
+import { JobActionOptions } from "../../jobconfig.interface";
+
+export const actionType = "datasetPolicyEmail";
+
+export interface DatasetPolicyEmailJobActionOptions extends JobActionOptions {
+  actionType: typeof actionType;
+  from?: string;
+  subject: string;
+  bodyTemplateFile: string;
+  ignoreErrors?: boolean;
+}
+
+/**
+ * Type guard for DatasetPolicyEmailJobActionOptions
+ */
+export function isDatasetPolicyEmailJobActionOptions(
+  options: unknown,
+): options is DatasetPolicyEmailJobActionOptions {
+  if (typeof options !== "object" || options === null) {
+    return false;
+  }
+
+  const opts = options as DatasetPolicyEmailJobActionOptions;
+  return (
+    opts.actionType === actionType &&
+    (opts.from === undefined || typeof opts.from === "string") &&
+    typeof opts.subject === "string" &&
+    typeof opts.bodyTemplateFile === "string" &&
+    (opts.ignoreErrors === undefined || typeof opts.ignoreErrors === "boolean")
+  );
+}

--- a/src/config/job-config/actions/datasetpolicyemailaction/datasetpolicyemailaction.module.ts
+++ b/src/config/job-config/actions/datasetpolicyemailaction/datasetpolicyemailaction.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { DatasetPolicyEmailJobActionCreator } from "./datasetpolicyemailaction.service";
+import { CommonModule } from "src/common/common.module";
+
+@Module({
+  imports: [CommonModule],
+  providers: [DatasetPolicyEmailJobActionCreator],
+  exports: [DatasetPolicyEmailJobActionCreator],
+})
+export class DatasetPolicyEmailJobActionModule {}

--- a/src/config/job-config/actions/datasetpolicyemailaction/datasetpolicyemailaction.service.ts
+++ b/src/config/job-config/actions/datasetpolicyemailaction/datasetpolicyemailaction.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from "@nestjs/common";
+import { ModuleRef } from "@nestjs/core";
+import {
+  JobActionCreator,
+  JobActionOptions,
+  JobDto,
+} from "../../jobconfig.interface";
+import { isDatasetPolicyEmailJobActionOptions } from "./datasetpolicyemailaction.interface";
+import { DatasetPolicyEmailJobAction } from "./datasetpolicyemailaction";
+import { MailService } from "src/common/mail.service";
+
+@Injectable()
+export class DatasetPolicyEmailJobActionCreator implements JobActionCreator<JobDto> {
+  constructor(
+    private mailService: MailService,
+    private moduleRef: ModuleRef,
+  ) {}
+
+  public create<Options extends JobActionOptions>(options: Options) {
+    if (!isDatasetPolicyEmailJobActionOptions(options)) {
+      throw new Error(
+        `Invalid options for datasetPolicyEmail action: ${JSON.stringify(options)}`,
+      );
+    }
+    return new DatasetPolicyEmailJobAction(
+      this.mailService,
+      this.moduleRef,
+      options,
+    );
+  }
+}

--- a/src/config/job-config/actions/datasetpolicyemailaction/datasetpolicyemailaction.spec.ts
+++ b/src/config/job-config/actions/datasetpolicyemailaction/datasetpolicyemailaction.spec.ts
@@ -1,0 +1,342 @@
+import { ModuleRef } from "@nestjs/core";
+import { DatasetPolicyEmailJobAction } from "./datasetpolicyemailaction";
+import { DatasetPolicyEmailJobActionOptions } from "./datasetpolicyemailaction.interface";
+import { JobClass } from "../../../../jobs/schemas/job.schema";
+import { MailService } from "src/common/mail.service";
+import { PoliciesV4Service } from "src/policies/policies.v4.service";
+import { Policy } from "src/policies/schemas/policy.schema";
+import { DatasetClass } from "src/datasets/schemas/dataset.schema";
+import { registerHelpers } from "../../handlebar-utils";
+
+jest.mock("src/common/mail.service");
+
+// initialize helpers, since app.module.ts is not loaded in this test
+registerHelpers();
+
+function makeDataset(overrides: Partial<DatasetClass>): DatasetClass {
+  return {
+    pid: "testPid/12345",
+    ownerGroup: "group1",
+    accessGroups: [],
+    createdBy: "creator",
+    updatedBy: "updater",
+    isPublished: false,
+    ...overrides,
+  } as DatasetClass;
+}
+
+function makePolicy(overrides: Partial<Policy>): Policy {
+  return {
+    _id: "policyId",
+    manager: [],
+    ownerGroup: "group1",
+    accessGroups: [],
+    isPublished: false,
+    createdBy: "creator",
+    updatedBy: "updater",
+    ...overrides,
+  } as Policy;
+}
+
+const config: DatasetPolicyEmailJobActionOptions = {
+  actionType: "datasetPolicyEmail",
+  subject: "Job {{job.id}} update for {{ datasets.[0].ownerGroup }}",
+  bodyTemplateFile:
+    "src/common/email-templates/test-minimal-template.spec.html",
+};
+
+const mockJob: JobClass = {
+  id: "jobId123",
+  _id: "jobId123",
+  type: "dataset_policy_email_demo",
+  statusCode: "jobSubmitted",
+  statusMessage: "Job submitted",
+  jobParams: { datasetList: [] },
+  jobResultObject: {},
+  ownerUser: "admin",
+  ownerGroup: "admin",
+  configVersion: "1.0",
+  createdBy: "admin",
+  updatedBy: "admin",
+  createdAt: new Date("2023-10-01T10:00:00Z"),
+  updatedAt: new Date("2023-10-01T10:00:00Z"),
+  accessGroups: [],
+  isPublished: false,
+};
+
+function mockPolicies(policies: Policy[]) {
+  (policiesService.findAll as jest.Mock).mockResolvedValue(policies);
+}
+
+let mailService: MailService;
+let policiesService: PoliciesV4Service;
+let moduleRef: ModuleRef;
+let action: DatasetPolicyEmailJobAction;
+
+describe("DatasetPolicyEmailJobAction", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mailService = { sendMail: jest.fn() } as unknown as MailService;
+    policiesService = { findAll: jest.fn() } as unknown as PoliciesV4Service;
+    moduleRef = {
+      resolve: jest.fn().mockResolvedValue(policiesService),
+    } as unknown as ModuleRef;
+    action = new DatasetPolicyEmailJobAction(mailService, moduleRef, config);
+  });
+
+  it("should be configured successfully", () => {
+    expect(action).toBeDefined();
+  });
+
+  it("does nothing when there are no datasets", async () => {
+    await action.perform({
+      request: mockJob,
+      job: mockJob,
+      env: {},
+      datasets: [],
+    });
+
+    expect(moduleRef.resolve).not.toHaveBeenCalled();
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("throws when PoliciesService cannot be resolved and ignoreErrors is not set", async () => {
+    (moduleRef.resolve as jest.Mock).mockRejectedValue(
+      new Error("Resolution failed"),
+    );
+
+    await expect(
+      action.perform({
+        request: mockJob,
+        job: mockJob,
+        env: {},
+        datasets: [makeDataset({ ownerGroup: "group1" })],
+      }),
+    ).rejects.toThrow("Resolution failed");
+
+    expect(policiesService.findAll).not.toHaveBeenCalled();
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("ignores a PoliciesService resolution failure when ignoreErrors is set", async () => {
+    (moduleRef.resolve as jest.Mock).mockRejectedValue(
+      new Error("Resolution failed"),
+    );
+    const ignoringAction = new DatasetPolicyEmailJobAction(
+      mailService,
+      moduleRef,
+      {
+        ...config,
+        ignoreErrors: true,
+      },
+    );
+
+    await expect(
+      ignoringAction.perform({
+        request: mockJob,
+        job: mockJob,
+        env: {},
+        datasets: [makeDataset({ ownerGroup: "group1" })],
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("sends one email per ownerGroup whose policy enables notifications for this job type", async () => {
+    const datasets = [
+      makeDataset({ pid: "pid1", ownerGroup: "group1" }),
+      makeDataset({ pid: "pid2", ownerGroup: "group2" }),
+    ];
+    mockPolicies([
+      makePolicy({
+        ownerGroup: "group1",
+        type: mockJob.type,
+        emailTo: ["group1@example.com"],
+        emailNotification: true,
+      }),
+      makePolicy({
+        ownerGroup: "group2",
+        type: mockJob.type,
+        emailTo: ["group2@example.com"],
+        emailNotification: true,
+      }),
+    ]);
+
+    await action.perform({
+      request: mockJob,
+      job: mockJob,
+      env: {},
+      datasets,
+    });
+
+    expect(moduleRef.resolve).toHaveBeenCalledWith(
+      PoliciesV4Service,
+      undefined,
+      {
+        strict: false,
+      },
+    );
+    expect(policiesService.findAll).toHaveBeenCalledWith({
+      where: {
+        ownerGroup: { $in: ["group1", "group2"] },
+        type: mockJob.type,
+        emailNotification: true,
+        emailTo: {
+          $exists: true,
+          $not: { $size: 0 },
+        },
+      },
+      fields: ["ownerGroup", "emailTo"],
+    });
+    expect(mailService.sendMail).toHaveBeenCalledTimes(2);
+    expect(mailService.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: ["group1@example.com"],
+        subject: "Job jobId123 update for group1",
+      }),
+    );
+    expect(mailService.sendMail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: ["group2@example.com"],
+        subject: "Job jobId123 update for group2",
+      }),
+    );
+  });
+
+  it("skips a group when its policy is missing", async () => {
+    mockPolicies([]);
+
+    await action.perform({
+      request: mockJob,
+      job: mockJob,
+      env: {},
+      datasets: [makeDataset({ ownerGroup: "group1" })],
+    });
+
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("filters out policies with emailNotification disabled at the query level", async () => {
+    // The findAll where-clause itself excludes emailNotification: false
+    // policies, so the mocked service returns none for this group.
+    mockPolicies([]);
+
+    await action.perform({
+      request: mockJob,
+      job: mockJob,
+      env: {},
+      datasets: [makeDataset({ ownerGroup: "group1" })],
+    });
+
+    expect(policiesService.findAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          emailNotification: true,
+        }),
+      }),
+    );
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("filters out policies with an empty emailTo at the query level", async () => {
+    // The findAll where-clause itself excludes empty/missing emailTo, so
+    // the mocked service returns none for this group.
+    mockPolicies([]);
+
+    await action.perform({
+      request: mockJob,
+      job: mockJob,
+      env: {},
+      datasets: [makeDataset({ ownerGroup: "group1" })],
+    });
+
+    expect(policiesService.findAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          emailTo: {
+            $exists: true,
+            $not: { $size: 0 },
+          },
+        }),
+      }),
+    );
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("filters by policy type at the query level, not the returned rows", async () => {
+    // The findAll where-clause itself scopes to this job's type, so the
+    // mocked service returns none for a different job type.
+    mockPolicies([]);
+
+    await action.perform({
+      request: mockJob,
+      job: mockJob,
+      env: {},
+      datasets: [makeDataset({ ownerGroup: "group1" })],
+    });
+
+    expect(policiesService.findAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          type: mockJob.type,
+        }),
+      }),
+    );
+    expect(mailService.sendMail).not.toHaveBeenCalled();
+  });
+
+  it("ignores send errors when ignoreErrors is set", async () => {
+    mockPolicies([
+      makePolicy({
+        ownerGroup: "group1",
+        type: mockJob.type,
+        emailTo: ["group1@example.com"],
+        emailNotification: true,
+      }),
+    ]);
+    (mailService.sendMail as jest.Mock).mockRejectedValue(
+      new Error("Email sending failed"),
+    );
+    const ignoringAction = new DatasetPolicyEmailJobAction(
+      mailService,
+      moduleRef,
+      {
+        ...config,
+        ignoreErrors: true,
+      },
+    );
+
+    await expect(
+      ignoringAction.perform({
+        request: mockJob,
+        job: mockJob,
+        env: {},
+        datasets: [makeDataset({ ownerGroup: "group1" })],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws when sending fails and ignoreErrors is not set", async () => {
+    mockPolicies([
+      makePolicy({
+        ownerGroup: "group1",
+        type: mockJob.type,
+        emailTo: ["group1@example.com"],
+        emailNotification: true,
+      }),
+    ]);
+    (mailService.sendMail as jest.Mock).mockRejectedValue(
+      new Error("Email sending failed"),
+    );
+
+    await expect(
+      action.perform({
+        request: mockJob,
+        job: mockJob,
+        env: {},
+        datasets: [makeDataset({ ownerGroup: "group1" })],
+      }),
+    ).rejects.toThrow("Email sending failed");
+  });
+});

--- a/src/config/job-config/actions/datasetpolicyemailaction/datasetpolicyemailaction.ts
+++ b/src/config/job-config/actions/datasetpolicyemailaction/datasetpolicyemailaction.ts
@@ -1,0 +1,161 @@
+/**
+ * Group the datasets attached to a job by ownerGroup, and send one email per
+ * group to the recipients configured on that ownerGroup's Policy, if enabled.
+ */
+import { readFileSync } from "fs";
+import { compileJobTemplate, TemplateJob } from "../../handlebar-utils";
+import { Logger } from "@nestjs/common";
+import {
+  JobAction,
+  JobDto,
+  JobPerformContext,
+} from "../../jobconfig.interface";
+import { ISendMailOptions } from "@nestjs-modules/mailer";
+import { ModuleRef } from "@nestjs/core";
+import {
+  actionType,
+  DatasetPolicyEmailJobActionOptions,
+} from "./datasetpolicyemailaction.interface";
+import { MailService } from "src/common/mail.service";
+import { PoliciesV4Service } from "src/policies/policies.v4.service";
+import { DatasetClass } from "src/datasets/schemas/dataset.schema";
+
+export class DatasetPolicyEmailJobAction implements JobAction<JobDto> {
+  private from?: string = undefined;
+  private subjectTemplate: TemplateJob;
+  private bodyTemplate: TemplateJob;
+  private ignoreErrors = false;
+
+  getActionType(): string {
+    return actionType;
+  }
+
+  constructor(
+    private mailService: MailService,
+    private moduleRef: ModuleRef,
+    options: DatasetPolicyEmailJobActionOptions,
+  ) {
+    Logger.log(
+      "DatasetPolicyEmailJobAction parameters are valid.",
+      "DatasetPolicyEmailJobAction",
+    );
+
+    if (options["from"]) {
+      this.from = options.from as string;
+    }
+    this.subjectTemplate = compileJobTemplate(options.subject);
+
+    const templateFile = readFileSync(
+      options["bodyTemplateFile"] as string,
+      "utf8",
+    );
+    this.bodyTemplate = compileJobTemplate(templateFile);
+
+    if (options["ignoreErrors"]) {
+      this.ignoreErrors = options.ignoreErrors;
+    }
+  }
+
+  private groupDatasetsByOwnerGroup(
+    datasets: DatasetClass[],
+  ): Map<string, DatasetClass[]> {
+    const groups = new Map<string, DatasetClass[]>();
+    for (const dataset of datasets) {
+      const group = groups.get(dataset.ownerGroup) ?? [];
+      group.push(dataset);
+      groups.set(dataset.ownerGroup, group);
+    }
+    return groups;
+  }
+
+  private async resolvePoliciesService(
+    context: JobPerformContext<JobDto>,
+  ): Promise<PoliciesV4Service> {
+    try {
+      return await this.moduleRef.resolve(PoliciesV4Service, undefined, {
+        strict: false,
+      });
+    } catch (err) {
+      Logger.error(
+        `(Job ${context.job.id}) DatasetPolicyEmailJobAction: Failed to resolve PoliciesV4Service: ${err}`,
+        "DatasetPolicyEmailJobAction",
+      );
+      throw err;
+    }
+  }
+
+  async perform(context: JobPerformContext<JobDto>) {
+    Logger.log(
+      `(Job ${context.job.id}) Performing DatasetPolicyEmailJobAction`,
+      "DatasetPolicyEmailJobAction",
+    );
+
+    const datasetsByOwnerGroup = this.groupDatasetsByOwnerGroup(
+      context.datasets,
+    );
+    if (datasetsByOwnerGroup.size === 0) return;
+
+    try {
+      const policiesService = await this.resolvePoliciesService(context);
+
+      const policies = await policiesService.findAll({
+        where: {
+          ownerGroup: { $in: [...datasetsByOwnerGroup.keys()] },
+          type: context.job.type,
+          emailNotification: true,
+          emailTo: { $exists: true, $not: { $size: 0 } },
+        },
+        fields: ["ownerGroup", "emailTo"],
+      });
+      await Promise.all(
+        policies.map(async (policy) => {
+          const groupDatasets = datasetsByOwnerGroup.get(policy.ownerGroup);
+          const emailTo = policy.emailTo;
+          if (!groupDatasets || !emailTo) return;
+
+          await this.sendGroupEmail(context, groupDatasets, emailTo);
+        }),
+      );
+    } catch (err) {
+      if (!this.ignoreErrors) {
+        throw err;
+      }
+    }
+  }
+
+  private async sendGroupEmail(
+    context: JobPerformContext<JobDto>,
+    groupDatasets: DatasetClass[],
+    emailTo: string[],
+  ) {
+    const groupContext = { ...context, datasets: groupDatasets };
+
+    let mail: ISendMailOptions;
+    try {
+      mail = {
+        to: emailTo,
+        subject: this.subjectTemplate(groupContext),
+        html: this.bodyTemplate(groupContext),
+      };
+      if (this.from) {
+        mail.from = this.from;
+      }
+    } catch (err) {
+      Logger.error(
+        `(Job ${context.job.id}) DatasetPolicyEmailJobAction: Template error: ${err}`,
+        "DatasetPolicyEmailJobAction",
+      );
+      throw err;
+    }
+
+    try {
+      await this.mailService.sendMail(mail);
+    } catch (err) {
+      Logger.error(
+        `(Job ${context.job.id}) DatasetPolicyEmailJobAction: Sending email failed: ${err}`,
+        "DatasetPolicyEmailJobAction",
+      );
+      throw err;
+    }
+  }
+}

--- a/src/config/job-config/jobconfig.spec.ts
+++ b/src/config/job-config/jobconfig.spec.ts
@@ -6,6 +6,7 @@ import { actionType as logActionType } from "./actions/logaction/logaction.inter
 import { actionType as validateActionType } from "./actions/validateaction/validateaction.interface";
 import { actionType as urlActionType } from "./actions/urlaction/urlaction.interface";
 import { actionType as rabbitmqActionType } from "./actions/rabbitmqaction/rabbitmqaction.interface";
+import { actionType as datasetPolicyEmailActionType } from "./actions/datasetpolicyemailaction/datasetpolicyemailaction.interface";
 import {
   CREATE_JOB_ACTION_CREATORS,
   UPDATE_JOB_ACTION_CREATORS,
@@ -19,6 +20,7 @@ const creatorsMock = {
   [validateActionType]: actionCreatorMock,
   [urlActionType]: actionCreatorMock,
   [rabbitmqActionType]: actionCreatorMock,
+  [datasetPolicyEmailActionType]: actionCreatorMock,
 };
 const creatorProviders = [
   {

--- a/test/JobsDatasetPolicyEmail.js
+++ b/test/JobsDatasetPolicyEmail.js
@@ -1,0 +1,181 @@
+"use strict";
+const utils = require("./LoginUtils");
+const { TestData } = require("./TestData");
+
+let accessTokenAdminIngestor = null,
+  accessTokenAdmin = null,
+  datasetPidGroup1 = null,
+  datasetPidGroup2 = null;
+
+const datasetGroup1 = {
+  ...TestData.RawCorrect,
+  isPublished: true,
+  ownerGroup: "group1",
+  accessGroups: [],
+};
+
+const datasetGroup2 = {
+  ...TestData.RawCorrect,
+  isPublished: true,
+  ownerGroup: "group2",
+  accessGroups: [],
+};
+
+const jobDatasetPolicyEmail = {
+  type: "dataset_policy_email_access",
+};
+
+describe("2950: Jobs: Test datasetPolicyEmail action for dataset_policy_email_access jobs type", () => {
+  before(async () => {
+    await db.collection("Dataset").deleteMany({});
+    await db.collection("Job").deleteMany({});
+    await db.collection("Policy").deleteMany({
+      ownerGroup: { $in: ["group1", "group2"] },
+      type: "dataset_policy_email_access",
+    });
+
+    accessTokenAdminIngestor = await utils.getToken(appUrl, {
+      username: "adminIngestor",
+      password: TestData.Accounts["adminIngestor"]["password"],
+    });
+
+    accessTokenAdmin = await utils.getToken(appUrl, {
+      username: "admin",
+      password: TestData.Accounts["admin"]["password"],
+    });
+  });
+
+  after(async () => {
+    await db.collection("Dataset").deleteMany({});
+    await db.collection("Job").deleteMany({});
+    await db.collection("Policy").deleteMany({
+      ownerGroup: { $in: ["group1", "group2"] },
+      type: "dataset_policy_email_access",
+    });
+  });
+
+  it("0010: Add dataset for group1 as Admin Ingestor", async () => {
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(datasetGroup1)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("ownerGroup").and.equal("group1");
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidGroup1 = res.body["pid"];
+      });
+  });
+
+  it("0020: Add dataset for group2 as Admin Ingestor", async () => {
+    return request(appUrl)
+      .post("/api/v3/Datasets")
+      .send(datasetGroup2)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("ownerGroup").and.equal("group2");
+        res.body.should.have.property("pid").and.be.string;
+        datasetPidGroup2 = res.body["pid"];
+      });
+  });
+
+  it("0030: Add a Policy enabling datasetPolicyEmail notifications for group1", async () => {
+    return request(appUrl)
+      .post("/api/v4/policies")
+      .send({
+        ownerGroup: "group1",
+        manager: ["adminIngestor"],
+        type: "dataset_policy_email_access",
+        emailTo: ["group1@example.com"],
+        emailNotification: true,
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.ownerGroup.should.equal("group1");
+        res.body.emailNotification.should.equal(true);
+      });
+  });
+
+  it("0040: Add a Policy for group2 with notifications disabled", async () => {
+    return request(appUrl)
+      .post("/api/v4/policies")
+      .send({
+        ownerGroup: "group2",
+        manager: ["adminIngestor"],
+        type: "dataset_policy_email_access",
+        emailTo: ["group2@example.com"],
+        emailNotification: false,
+      })
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdminIngestor}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.ownerGroup.should.equal("group2");
+        res.body.emailNotification.should.equal(false);
+      });
+  });
+
+  it("0050: Create a job spanning both ownerGroups; datasetPolicyEmail runs for the enabled group and skips the disabled one without failing the request", async () => {
+    const newJob = {
+      ...jobDatasetPolicyEmail,
+      ownerUser: "admin",
+      ownerGroup: "admin",
+      jobParams: {
+        datasetList: [
+          { pid: datasetPidGroup1, files: [] },
+          { pid: datasetPidGroup2, files: [] },
+        ],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have
+          .property("type")
+          .and.equal("dataset_policy_email_access");
+        res.body.should.have.property("statusCode").and.equal("jobSubmitted");
+      });
+  });
+
+  it("0060: Create a job for a group with no policy at all; datasetPolicyEmail skips silently and the request still succeeds", async () => {
+    await db.collection("Policy").deleteMany({
+      ownerGroup: "group1",
+      type: "dataset_policy_email_access",
+    });
+
+    const newJob = {
+      ...jobDatasetPolicyEmail,
+      ownerUser: "admin",
+      ownerGroup: "admin",
+      jobParams: {
+        datasetList: [{ pid: datasetPidGroup1, files: [] }],
+      },
+    };
+
+    return request(appUrl)
+      .post("/api/v4/Jobs")
+      .send(newJob)
+      .set("Accept", "application/json")
+      .set({ Authorization: `Bearer ${accessTokenAdmin}` })
+      .expect(TestData.EntryCreatedStatusCode)
+      .expect("Content-Type", /json/)
+      .then((res) => {
+        res.body.should.have.property("statusCode").and.equal("jobSubmitted");
+      });
+  });
+});

--- a/test/config/jobconfig.yaml
+++ b/test/config/jobconfig.yaml
@@ -42,6 +42,16 @@ jobs:
       auth: "#jobAdmin"
     update:
       auth: "#jobAdmin"
+  - jobType: dataset_policy_email_access
+    create:
+      auth: "#all"
+      actions:
+        - actionType: datasetPolicyEmail
+          ignoreErrors: true
+          subject: "Job {{ job.id }} update for {{ datasets.[0].ownerGroup }}"
+          bodyTemplateFile: src/common/email-templates/test-minimal-template.spec.html
+    update:
+      auth: "#all"
   - jobType: archive
     create:
       auth: "#all"


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Create new action to send emails based on policies distributions, grouped per ownerGroup matched on the policies. This is useful whe neededing to send emails to data stewards or PIs for each policy

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Add grouped policy-driven email notifications for dataset jobs.

New Features:
- Add a datasetPolicyEmail job action that sends one templated email per dataset owner group using recipients from matching enabled policies.

Enhancements:
- Support optional sender addresses and configurable error handling for policy lookup, template rendering, and email delivery.

Documentation:
- Add example job configuration demonstrating dataset policy email notifications.

Tests:
- Add unit and integration coverage for owner-group grouping, policy filtering, skipped notifications, and error handling.