### PR TITLE
fix: throw error when email exits non 0

### DIFF
--- a/src/common/mail.service.spec.ts
+++ b/src/common/mail.service.spec.ts
@@ -1,0 +1,30 @@
+import { MailerService } from "@nestjs-modules/mailer";
+import { MailService } from "./mail.service";
+
+describe("MailService", () => {
+  let mailerService: MailerService;
+  let mailService: MailService;
+
+  beforeEach(() => {
+    mailerService = { sendMail: jest.fn() } as unknown as MailerService;
+    mailService = new MailService(mailerService);
+  });
+
+  it("resolves when the underlying mailer succeeds", async () => {
+    (mailerService.sendMail as jest.Mock).mockResolvedValue(undefined);
+
+    await expect(
+      mailService.sendMail({ to: "a@example.com", subject: "s", html: "b" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rethrows when the underlying mailer fails", async () => {
+    (mailerService.sendMail as jest.Mock).mockRejectedValue(
+      new Error("SMTP connection refused"),
+    );
+
+    await expect(
+      mailService.sendMail({ to: "a@example.com", subject: "s", html: "b" }),
+    ).rejects.toThrow("SMTP connection refused");
+  });
+});

--- a/src/common/mail.service.spec.ts
+++ b/src/common/mail.service.spec.ts
@@ -10,12 +10,16 @@ describe("MailService", () => {
     mailService = new MailService(mailerService);
   });
 
-  it("resolves when the underlying mailer succeeds", async () => {
-    (mailerService.sendMail as jest.Mock).mockResolvedValue(undefined);
+  it("forwards the underlying mailer's result when it succeeds", async () => {
+    const sentMessageInfo = {
+      messageId: "abc123",
+      accepted: ["a@example.com"],
+    };
+    (mailerService.sendMail as jest.Mock).mockResolvedValue(sentMessageInfo);
 
     await expect(
       mailService.sendMail({ to: "a@example.com", subject: "s", html: "b" }),
-    ).resolves.toBeUndefined();
+    ).resolves.toBe(sentMessageInfo);
   });
 
   it("rethrows when the underlying mailer fails", async () => {

--- a/src/common/mail.service.ts
+++ b/src/common/mail.service.ts
@@ -15,7 +15,7 @@ export class MailService {
   async sendMail(options: ISendMailOptions): Promise<SentMessageInfo> {
     try {
       Logger.log("Sending email to: " + options.to, "Utils.sendMail");
-      await this.mailerService.sendMail(options);
+      return await this.mailerService.sendMail(options);
     } catch (error) {
       if (isAxiosError(error)) {
         if (error.response) {

--- a/src/common/mail.service.ts
+++ b/src/common/mail.service.ts
@@ -37,6 +37,7 @@ export class MailService {
         );
         Logger.error(error, "MailService.sendMail");
       }
+      throw error;
     }
   }
 }


### PR DESCRIPTION
<!--
Follow semantic-release guidelines for the PR title, which is used in the changelog.

Title should follow the format `<type>(<scope>): <subject>`, where
- Type is one of: build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|BREAKING CHANGE
- Scope (optional) describes the place of the change (eg a particular milestone) and is usually omitted
- subject should be a non-capitalized one-line description in present imperative tense and not ending with a period

See https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines for more details.
-->

## Description
Email was swamping the error, this makes it raise and either log or error depending on flag

## Tests included

- [ ] Included for each change/fix?
- [ ] Passing? <!-- Merge will not be approved unless tests pass -->

## Documentation
- [ ] swagger documentation updated (required for API changes)
- [ ] official documentation updated

### official documentation info
<!-- If you have updated the official documentation, please provide PR # and URL of the updated pages -->

## Summary by Sourcery

Propagate email send outcomes by returning successful delivery results and rethrowing failures.

Bug Fixes:
- Propagate email delivery failures so callers can handle or surface errors instead of silently swallowing them.

Enhancements:
- Return the underlying mailer's successful send result to callers.

Tests:
- Add unit coverage for successful mail delivery and rethrown mailer failures.